### PR TITLE
pinning to latest minor version, adding miliseconds support

### DIFF
--- a/doc_template/source/conf.py
+++ b/doc_template/source/conf.py
@@ -1,4 +1,5 @@
 """Configuration file for the Sphinx documentation builder."""
+
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html

--- a/doc_template/source/conf.py
+++ b/doc_template/source/conf.py
@@ -3,10 +3,12 @@
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# -- Path Setup --------------------------------------------------------------
-from os.path import dirname, abspath
-from pathlib import Path
 from datetime import date
+
+# -- Path Setup --------------------------------------------------------------
+from os.path import abspath, dirname
+from pathlib import Path
+
 from aind_metadata_upgrader import __version__ as package_version
 
 INSTITUTE_NAME = "Allen Institute for Neural Dynamics"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema==0.24.0'
+    'aind-data-schema==0.26.5'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_metadata_upgrader/__init__.py
+++ b/src/aind_metadata_upgrader/__init__.py
@@ -1,2 +1,3 @@
 """Init package"""
+
 __version__ = "0.0.0"

--- a/src/aind_metadata_upgrader/base_upgrade.py
+++ b/src/aind_metadata_upgrader/base_upgrade.py
@@ -3,9 +3,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Type, Union
 
-from pydantic.fields import PydanticUndefined
-
 from aind_data_schema.base import AindModel
+from pydantic.fields import PydanticUndefined
 
 
 class BaseModelUpgrade(ABC):

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -4,8 +4,12 @@ from datetime import datetime
 from typing import Any, Optional, Union
 
 from aind_data_schema.base import AindModel
-from aind_data_schema.core.data_description import DataDescription, DataLevel, Funding
-from aind_data_schema.models.institutions import Institution
+from aind_data_schema.core.data_description import (
+    DataDescription,
+    DataLevel,
+    Funding,
+)
+from aind_data_schema.models.organizations import Organization
 from aind_data_schema.models.modalities import Modality
 from aind_data_schema.models.platforms import Platform
 
@@ -68,10 +72,10 @@ class FundingUpgrade:
             return old_funding
         elif type(old_funding) is dict and old_funding.get("funder") is not None and type(old_funding["funder"]) is str:
             old_funder = old_funding.get("funder")
-            if Institution().name_map.get(old_funder) is not None:
-                new_funder = Institution.from_name(old_funder)
+            if Organization().name_map.get(old_funder) is not None:
+                new_funder = Organization.from_name(old_funder)
             else:
-                new_funder = Institution.from_abbreviation(old_funder)
+                new_funder = Organization.from_abbreviation(old_funder)
             new_funding = deepcopy(old_funding)
             new_funding["funder"] = new_funder
             return Funding.model_validate(new_funding)
@@ -80,7 +84,7 @@ class FundingUpgrade:
         ):
             return Funding.model_validate(old_funding)
         else:
-            return Funding(funder=Institution.AI)
+            return Funding(funder=Organization.AI)
 
     @staticmethod
     def upgrade_funding_source(funding_source):
@@ -98,12 +102,12 @@ class InstitutionUpgrade:
     """Handle upgrades for Institution class"""
 
     @staticmethod
-    def upgrade_institution(old_institution: Any) -> Optional[Institution]:
+    def upgrade_institution(old_institution: Any) -> Optional[Organization]:
         """Map legacy Institution model to current version"""
         if type(old_institution) is str:
-            return Institution.from_abbreviation(old_institution)
+            return Organization.from_abbreviation(old_institution)
         elif type(old_institution) is dict and old_institution.get("abbreviation") is not None:
-            return Institution.from_abbreviation(old_institution.get("abbreviation"))
+            return Organization.from_abbreviation(old_institution.get("abbreviation"))
         else:
             return None
 

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -141,7 +141,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         creation_date = self._get_or_default(self.old_model, "creation_date", kwargs)
         creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
         old_name = self._get_or_default(self.old_model, "name", kwargs)
-        if creation_date is not None and creation_time is None:
+        if creation_date is not None and creation_time is not None:
             creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time}")
         elif creation_time is not None:
             creation_time = datetime.fromisoformat(f"{creation_time}")

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -143,7 +143,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         old_name = self._get_or_default(self.old_model, "name", kwargs)
         if creation_date is not None:
             creation_date = datetime.strptime(creation_date, "%Y-%m-%d").date()
-            creation_time = datetime.strptime(creation_time, "%H:%M:%S").time()
+            creation_time = datetime.strptime(creation_time, "%H:%M:%S.%f").time()
             creation_time = datetime.combine(creation_date, creation_time)
         elif old_name is not None:
             creation_time = DataDescription.parse_name(old_name).get("creation_time")

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -141,8 +141,10 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         creation_date = self._get_or_default(self.old_model, "creation_date", kwargs)
         creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
         old_name = self._get_or_default(self.old_model, "name", kwargs)
-        if creation_time is not None:
+        if creation_date is not None and creation_time is None:
             creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time}")
+        elif creation_time is not None:
+            creation_time = datetime.fromisoformat(f"{creation_time}")
         elif old_name is not None:
             creation_time = DataDescription.parse_name(old_name).get("creation_time")
         return creation_time

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -141,8 +141,8 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         creation_date = self._get_or_default(self.old_model, "creation_date", kwargs)
         creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
         old_name = self._get_or_default(self.old_model, "name", kwargs)
-        if creation_date is not None and creation_time is not None:
-            creation_date = datetime.fromisoformat(f"{creation_date}T{creation_time}")
+        if creation_time is not None:
+            creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time}")
         elif old_name is not None:
             creation_time = DataDescription.parse_name(old_name).get("creation_time")
         return creation_time

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -1,4 +1,5 @@
 """Module to contain code to upgrade old data description models"""
+
 from copy import deepcopy
 from datetime import datetime
 from typing import Any, Optional, Union

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -143,7 +143,10 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         old_name = self._get_or_default(self.old_model, "name", kwargs)
         if creation_date is not None:
             creation_date = datetime.strptime(creation_date, "%Y-%m-%d").date()
-            creation_time = datetime.strptime(creation_time, "%H:%M:%S.%f").time()
+            if '.' in creation_time:
+                creation_time = datetime.strptime(creation_time, "%H:%M:%S.%f").time()
+            else:
+                creation_time = datetime.strptime(creation_time, "%H:%M:%S").time()
             creation_time = datetime.combine(creation_date, creation_time)
         elif old_name is not None:
             creation_time = DataDescription.parse_name(old_name).get("creation_time")

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -141,13 +141,8 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         creation_date = self._get_or_default(self.old_model, "creation_date", kwargs)
         creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
         old_name = self._get_or_default(self.old_model, "name", kwargs)
-        if creation_date is not None:
-            creation_date = datetime.strptime(creation_date, "%Y-%m-%d").date()
-            if '.' in creation_time:
-                creation_time = datetime.strptime(creation_time, "%H:%M:%S.%f").time()
-            else:
-                creation_time = datetime.strptime(creation_time, "%H:%M:%S").time()
-            creation_time = datetime.combine(creation_date, creation_time)
+        if creation_date is not None and creation_time is not None:
+            creation_date = datetime.fromisoformat(f"{creation_date}T{creation_time}")
         elif old_name is not None:
             creation_time = DataDescription.parse_name(old_name).get("creation_time")
         return creation_time

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -9,8 +9,8 @@ from aind_data_schema.core.data_description import (
     DataLevel,
     Funding,
 )
-from aind_data_schema.models.organizations import Organization
 from aind_data_schema.models.modalities import Modality
+from aind_data_schema.models.organizations import Organization
 from aind_data_schema.models.platforms import Platform
 
 from aind_metadata_upgrader.base_upgrade import BaseModelUpgrade

--- a/src/aind_metadata_upgrader/processing_upgrade.py
+++ b/src/aind_metadata_upgrader/processing_upgrade.py
@@ -1,12 +1,11 @@
 """Module to contain code to upgrade old processing models"""
 
+from aind_data_schema.base import AindModel
 from aind_data_schema.core.processing import (
     DataProcess,
     PipelineProcess,
     Processing,
 )
-
-from aind_data_schema.base import AindModel
 
 from aind_metadata_upgrader.base_upgrade import BaseModelUpgrade
 

--- a/tests/resources/ephys_data_description/data_description_0.10.0.json
+++ b/tests/resources/ephys_data_description/data_description_0.10.0.json
@@ -2,7 +2,7 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
    "schema_version": "0.10.0",
    "license": "CC-BY-4.0",
-   "creation_time": "2023-10-18T16:00:06.74276",
+   "creation_time": "2023-10-18T16:00:06",
    "name": "ecephys_691897_2023-10-18_16-00-06",
    "institution": {
       "name": "Allen Institute for Neural Dynamics",

--- a/tests/resources/ephys_data_description/data_description_0.10.0.json
+++ b/tests/resources/ephys_data_description/data_description_0.10.0.json
@@ -2,7 +2,7 @@
    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
    "schema_version": "0.10.0",
    "license": "CC-BY-4.0",
-   "creation_time": "2023-10-18T16:00:06",
+   "creation_time": "2023-10-18T16:00:06.74276",
    "name": "ecephys_691897_2023-10-18_16-00-06",
    "institution": {
       "name": "Allen Institute for Neural Dynamics",

--- a/tests/resources/ephys_data_description/data_description_0.10.0.json
+++ b/tests/resources/ephys_data_description/data_description_0.10.0.json
@@ -16,13 +16,13 @@
    "funding_source": [
       {
          "funder": {
-            "name": "Allen Institute for Neural Dynamics",
-            "abbreviation": "AIND",
+            "name": "Allen Institute",
+            "abbreviation": "AI",
             "registry": {
                "name": "Research Organization Registry",
                "abbreviation": "ROR"
             },
-            "registry_identifier": "04szwah67"
+            "registry_identifier": "03cpe7c52"
          },
          "grant_number": null,
          "fundee": null

--- a/tests/resources/ephys_data_description/data_description_0.3.0_no_creation.json
+++ b/tests/resources/ephys_data_description/data_description_0.3.0_no_creation.json
@@ -1,0 +1,24 @@
+{
+   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
+   "schema_version": "0.3.0",
+   "license": "CC-BY-4.0",
+   "creation_time": null,
+   "creation_date": null,
+   "name": "ecephys_623705_2022-06-28_10-31-30",
+   "institution": "AIND",
+   "investigators": ["John Doe"],
+   "funding_source": [
+      {
+         "funder": "AI",
+         "grant_number": null,
+         "fundee": null
+      }
+   ],
+   "data_level": "raw",
+   "group": null,
+   "project_name": null,
+   "project_id": null,
+   "restrictions": null,
+   "modality": "ecephys",
+   "subject_id": "623705"
+}

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -418,7 +418,7 @@ class TestModalityUpgrade(unittest.TestCase):
             "/main/src/aind_data_schema/data_description.py",
             "schema_version": "0.3.0",
             "license": "CC-BY-4.0",
-            "creation_time": "16:01:12",
+            "creation_time": "16:01:12.1245",
             "creation_date": "2022-11-01",
             "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
             "institution": "AIND",

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -418,7 +418,7 @@ class TestModalityUpgrade(unittest.TestCase):
             "/main/src/aind_data_schema/data_description.py",
             "schema_version": "0.3.0",
             "license": "CC-BY-4.0",
-            "creation_time": "16:01:12.1245",
+            "creation_time": "16:01:12.123456",
             "creation_date": "2022-11-01",
             "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
             "institution": "AIND",

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -3,8 +3,8 @@
 import datetime
 import json
 import os
-import unittest
 import re
+import unittest
 from pathlib import Path
 from typing import List
 
@@ -15,12 +15,11 @@ from aind_data_schema.core.data_description import (
     Group,
     RelatedData,
 )
-from aind_data_schema.models.organizations import Organization
 from aind_data_schema.models.modalities import Modality
+from aind_data_schema.models.organizations import Organization
 from aind_data_schema.models.platforms import Platform
 from pydantic import ValidationError
 from pydantic import __version__ as pyd_version
-
 
 from aind_metadata_upgrader.data_description_upgrade import (
     DataDescriptionUpgrade,
@@ -140,11 +139,10 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             " [type=value_error, input_value='asfnewnjfq', input_type=str]\n"
             f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/value_error"
         )
-        
+
         print("repr: ", repr(e1.exception))
         print("errr: ", expected_error_message1)
         self.assertEqual(expected_error_message1, repr(e1.exception))
-        
 
         # Should also fail if inputting wrong type
         with self.assertRaises(Exception) as e2:

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -5,7 +5,6 @@ import json
 import os
 import re
 import unittest
-import re
 from pathlib import Path
 from typing import List
 
@@ -28,8 +27,6 @@ from aind_metadata_upgrader.data_description_upgrade import (
     InstitutionUpgrade,
     ModalityUpgrade,
 )
-
-from pydantic import __version__ as pyd_version
 
 DATA_DESCRIPTION_FILES_PATH = Path(__file__).parent / "resources" / "ephys_data_description"
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
@@ -403,6 +400,13 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
                 funding_source=[Funding(funder=Organization.NINDS, grant_number="grant001")],
                 investigators=["Jane Smith"],
             )
+        self.assertEqual(
+            "1 validation error for DataDescription\n"
+            "data_level\n"
+            "  Input should be a valid string [type=string_type, input_value=[2, 3], input_type=list]\n"
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_type",
+            repr(e.exception)
+        )
         # this no longer throws the expected exception
         self.assertEqual(DataLevel.RAW, d1.data_level)
         self.assertEqual(DataLevel.RAW, d2.data_level)

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -135,13 +135,9 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         expected_error_message1 = (
             "1 validation error for DataDescription\n"
             "data_level\n"
-            "  Value error, 'asfnewnjfq' is not a valid DataLevel"
-            " [type=value_error, input_value='asfnewnjfq', input_type=str]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/value_error"
+            "  Input should be 'derived' or 'raw' [type=enum, input_value='asfnewnjfq', input_type=str]"
         )
 
-        print("repr: ", repr(e1.exception))
-        print("errr: ", expected_error_message1)
         self.assertEqual(expected_error_message1, repr(e1.exception))
 
         # Should also fail if inputting wrong type
@@ -150,9 +146,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         expected_error_message2 = (
             "1 validation error for DataDescription\n"
             "data_level\n"
-            "  Value error, Data Level needs to be string or enum"
-            " [type=value_error, input_value=['raw'], input_type=list]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/value_error"
+            "  Input should be a valid string [type=string_type, input_value=['raw'], input_type=list]\n"
+            "    For further information visit https://errors.pydantic.dev/2.6/v/string_type"
         )
 
         self.assertEqual(expected_error_message2, repr(e2.exception))
@@ -164,6 +159,19 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         upgrader3 = DataDescriptionUpgrade(old_data_description_model=data_description_copy)
         new_data_description3 = upgrader3.upgrade(platform=Platform.ECEPHYS, data_level=DataLevel.DERIVED)
         self.assertEqual(DataLevel.DERIVED, new_data_description3.data_level)
+
+    def test_upgrades_0_3_0_missing_creation_time(self):
+        """Tests upgrade with missing creation time"""
+
+        data_description_0_3_0_missing_creation_time = self.data_descriptions["data_description_0.3.0_no_creation.json"]
+        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_3_0_missing_creation_time)
+
+        new_data_description = upgrader.upgrade(platform=Platform.ECEPHYS, data_level=DataLevel.RAW)
+
+        self.assertEqual(
+            new_data_description.creation_time,
+            datetime.datetime(2022, 6, 28, 10, 31, 30)
+        )
 
     def test_upgrades_0_4_0(self):
         """Tests data_description_0.4.0.json is mapped correctly."""

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -168,10 +168,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
 
         new_data_description = upgrader.upgrade(platform=Platform.ECEPHYS, data_level=DataLevel.RAW)
 
-        self.assertEqual(
-            new_data_description.creation_time,
-            datetime.datetime(2022, 6, 28, 10, 31, 30)
-        )
+        self.assertEqual(new_data_description.creation_time, datetime.datetime(2022, 6, 28, 10, 31, 30))
 
     def test_upgrades_0_4_0(self):
         """Tests data_description_0.4.0.json is mapped correctly."""
@@ -405,7 +402,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             "data_level\n"
             "  Input should be a valid string [type=string_type, input_value=[2, 3], input_type=list]\n"
             f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_type",
-            repr(e.exception)
+            repr(e.exception),
         )
         # this no longer throws the expected exception
         self.assertEqual(DataLevel.RAW, d1.data_level)

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -6,7 +6,6 @@ import os
 import unittest
 from pathlib import Path
 from typing import List
-from pydantic import ValidationError
 
 from aind_data_schema.core.data_description import (
     DataDescription,
@@ -15,9 +14,10 @@ from aind_data_schema.core.data_description import (
     Group,
     RelatedData,
 )
-from aind_data_schema.models.institutions import Institution
+from aind_data_schema.models.organizations import Organization
 from aind_data_schema.models.modalities import Modality
 from aind_data_schema.models.platforms import Platform
+from pydantic import ValidationError
 
 from aind_metadata_upgrader.data_description_upgrade import (
     DataDescriptionUpgrade,
@@ -67,9 +67,9 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             new_data_description.creation_time,
         )
         self.assertEqual("ecephys_623705_2022-06-28_10-31-30", new_data_description.name)
-        self.assertEqual(Institution.AIND, new_data_description.institution)
+        self.assertEqual(Organization.AIND, new_data_description.institution)
         self.assertEqual(
-            [Funding(funder=Institution.AI)],
+            [Funding(funder=Organization.AI)],
             new_data_description.funding_source,
         )
         self.assertEqual(DataLevel.RAW, new_data_description.data_level)
@@ -106,9 +106,9 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             new_data_description.creation_time,
         )
         self.assertEqual("ecephys_624643_2022-07-26_10-52-15", new_data_description.name)
-        self.assertEqual(Institution.AIND, new_data_description.institution)
+        self.assertEqual(Organization.AIND, new_data_description.institution)
         self.assertEqual(
-            [Funding(funder=Institution.AI)],
+            [Funding(funder=Organization.AI)],
             new_data_description.funding_source,
         )
         self.assertEqual(DataLevel.RAW, new_data_description.data_level)
@@ -172,9 +172,9 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             new_data_description.creation_time,
         )
         self.assertEqual("ecephys_664438_2023-04-13_14-35-51", new_data_description.name)
-        self.assertEqual(Institution.AIND, new_data_description.institution)
+        self.assertEqual(Organization.AIND, new_data_description.institution)
         self.assertEqual(
-            [Funding(funder=Institution.AI)],
+            [Funding(funder=Organization.AI)],
             new_data_description.funding_source,
         )
         self.assertEqual(DataLevel.RAW, new_data_description.data_level)
@@ -199,9 +199,9 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             new_data_description.creation_time,
         )
         self.assertEqual("ecephys_661278_2023-04-10_17-09-26", new_data_description.name)
-        self.assertEqual(Institution.AIND, new_data_description.institution)
+        self.assertEqual(Organization.AIND, new_data_description.institution)
         self.assertEqual(
-            [Funding(funder=Institution.AI)],
+            [Funding(funder=Organization.AI)],
             new_data_description.funding_source,
         )
         self.assertEqual(DataLevel.RAW, new_data_description.data_level)
@@ -226,9 +226,9 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             new_data_description.creation_time,
         )
         self.assertEqual("661279_2023-03-23_15-31-18", new_data_description.name)
-        self.assertEqual(Institution.AIND, new_data_description.institution)
+        self.assertEqual(Organization.AIND, new_data_description.institution)
         self.assertEqual(
-            [Funding(funder=Institution.AI)],
+            [Funding(funder=Organization.AI)],
             new_data_description.funding_source,
         )
         self.assertEqual(DataLevel.RAW, new_data_description.data_level)
@@ -284,15 +284,15 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         self.assertEqual(expected_error_message, repr(e.exception))
 
         # Should work by setting funding_source explicitly
-        new_data_description = upgrader.upgrade(funding_source=[Funding(funder=Institution.AIND)])
+        new_data_description = upgrader.upgrade(funding_source=[Funding(funder=Organization.AIND)])
         self.assertEqual(
             datetime.datetime(2023, 3, 23, 22, 31, 18),
             new_data_description.creation_time,
         )
         self.assertEqual("661279_2023-03-23_15-31-18", new_data_description.name)
-        self.assertEqual(Institution.AIND, new_data_description.institution)
+        self.assertEqual(Organization.AIND, new_data_description.institution)
         self.assertEqual(
-            [Funding(funder=Institution.AIND)],
+            [Funding(funder=Organization.AIND)],
             new_data_description.funding_source,
         )
         self.assertEqual(DataLevel.RAW, new_data_description.data_level)
@@ -334,9 +334,9 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             new_data_description.creation_time,
         )
         self.assertEqual("ecephys_691897_2023-10-18_16-00-06", new_data_description.name)
-        self.assertEqual(Institution.AIND, new_data_description.institution)
+        self.assertEqual(Organization.AIND, new_data_description.institution)
         self.assertEqual(
-            [Funding(funder=Institution.AIND)],
+            [Funding(funder=Organization.AIND)],
             new_data_description.funding_source,
         )
         self.assertEqual(DataLevel.RAW, new_data_description.data_level)
@@ -360,8 +360,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             subject_id="1234",
             data_level="raw data",
             creation_time=datetime.datetime(2020, 10, 10, 10, 10, 10),
-            institution=Institution.AIND,
-            funding_source=[Funding(funder=Institution.NINDS, grant_number="grant001")],
+            institution=Organization.AIND,
+            funding_source=[Funding(funder=Organization.NINDS, grant_number="grant001")],
             investigators=["Jane Smith"],
         )
         d2 = DataDescription(
@@ -371,8 +371,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             subject_id="1234",
             data_level=DataLevel.RAW,
             creation_time=datetime.datetime(2020, 10, 10, 10, 10, 10),
-            institution=Institution.AIND,
-            funding_source=[Funding(funder=Institution.NINDS, grant_number="grant001")],
+            institution=Organization.AIND,
+            funding_source=[Funding(funder=Organization.NINDS, grant_number="grant001")],
             investigators=["Jane Smith"],
         )
         with self.assertRaises(ValidationError) as e:
@@ -383,8 +383,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
                 subject_id="1234",
                 data_level=2,
                 creation_time=datetime.datetime(2020, 10, 10, 10, 10, 10),
-                institution=Institution.AIND,
-                funding_source=[Funding(funder=Institution.NINDS, grant_number="grant001")],
+                institution=Organization.AIND,
+                funding_source=[Funding(funder=Organization.NINDS, grant_number="grant001")],
                 investigators=["Jane Smith"],
             )
         self.assertTrue("Data Level needs to be string or enum" in repr(e.exception))
@@ -447,7 +447,7 @@ class TestFundingUpgrade(unittest.TestCase):
 
         # Default gets set to AI
         self.assertEqual(
-            Funding(funder=Institution.AI, grant_number=None, fundee=None),
+            Funding(funder=Organization.AI, grant_number=None, fundee=None),
             FundingUpgrade.upgrade_funding(None),
         )
 
@@ -455,7 +455,7 @@ class TestFundingUpgrade(unittest.TestCase):
         self.assertEqual([], FundingUpgrade.upgrade_funding_source(None))
 
         self.assertEqual(
-            Funding(funder=Institution.AIND),
+            Funding(funder=Organization.AIND),
             FundingUpgrade.upgrade_funding(
                 {
                     "funder": {

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -6,6 +6,7 @@ import os
 import unittest
 from pathlib import Path
 from typing import List
+import re
 
 from aind_data_schema.core.processing import (
     DataProcess,
@@ -18,7 +19,11 @@ from aind_metadata_upgrader.processing_upgrade import (
     ProcessingUpgrade,
 )
 
+from pydantic import __version__ as pyd_version
+
+
 PROCESSING_FILES_PATH = Path(__file__).parent / "resources" / "ephys_processing"
+PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 
 class TestProcessingUpgrade(unittest.TestCase):
@@ -47,7 +52,7 @@ class TestProcessingUpgrade(unittest.TestCase):
             "1 validation error for PipelineProcess\n"
             "processor_full_name\n"
             "  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]\n"
-            "    For further information visit https://errors.pydantic.dev/2.5/v/string_type"
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_type"
         )
         self.assertEqual(expected_error_message, repr(e.exception))
 
@@ -77,7 +82,7 @@ class TestProcessingUpgrade(unittest.TestCase):
             "1 validation error for PipelineProcess\n"
             "processor_full_name\n"
             "  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]\n"
-            "    For further information visit https://errors.pydantic.dev/2.5/v/string_type"
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_type"
         )
         self.assertEqual(expected_error_message, repr(e.exception))
 
@@ -105,7 +110,7 @@ class TestProcessingUpgrade(unittest.TestCase):
             "1 validation error for PipelineProcess\n"
             "processor_full_name\n"
             "  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]\n"
-            "    For further information visit https://errors.pydantic.dev/2.5/v/string_type"
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_type"
         )
         self.assertEqual(expected_error_message, repr(e.exception))
 
@@ -133,7 +138,7 @@ class TestProcessingUpgrade(unittest.TestCase):
             "1 validation error for PipelineProcess\n"
             "processor_full_name\n"
             "  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]\n"
-            "    For further information visit https://errors.pydantic.dev/2.5/v/string_type"
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_type"
         )
         self.assertEqual(expected_error_message, repr(e.exception))
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -20,8 +20,6 @@ from aind_metadata_upgrader.processing_upgrade import (
     ProcessingUpgrade,
 )
 
-from pydantic import __version__ as pyd_version
-
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 PROCESSING_FILES_PATH = Path(__file__).parent / "resources" / "ephys_processing"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -3,24 +3,22 @@
 import datetime
 import json
 import os
+import re
 import unittest
 from pathlib import Path
 from typing import List
-import re
 
 from aind_data_schema.core.processing import (
     DataProcess,
     PipelineProcess,
     Processing,
 )
+from pydantic import __version__ as pyd_version
 
 from aind_metadata_upgrader.processing_upgrade import (
     DataProcessUpgrade,
     ProcessingUpgrade,
 )
-
-from pydantic import __version__ as pyd_version
-
 
 PROCESSING_FILES_PATH = Path(__file__).parent / "resources" / "ephys_processing"
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,20 +1,21 @@
 """ tests for Processing upgrades """
 
-import unittest
-import os
-from pathlib import Path
-import json
 import datetime
+import json
+import os
+import unittest
+from pathlib import Path
 from typing import List
 
 from aind_data_schema.core.processing import (
-    Processing,
-    PipelineProcess,
     DataProcess,
+    PipelineProcess,
+    Processing,
 )
+
 from aind_metadata_upgrader.processing_upgrade import (
-    ProcessingUpgrade,
     DataProcessUpgrade,
+    ProcessingUpgrade,
 )
 
 PROCESSING_FILES_PATH = Path(__file__).parent / "resources" / "ephys_processing"


### PR DESCRIPTION
closes #7 

Simple change to allow upgrader to handle times which include miliseconds.

EDIT:
scope expanded to include integration of some changes to aind-data-schema, specifically regarding the `Institution` -> `Organization` change.

Additionally, some tests seem to have broken with these changes / with the upgrade to pydantic V2, so those were also fixed.

EDIT2:
aind-data-schema pin was relatively out of date (ver 0.24.0 vs live schema ver 0.26.7). Schema has been pinned to 0.26.5, and tests have been updated to reflect changes to pydantic error messages.