### PR TITLE
funding upgrade lookup table

### DIFF
--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -89,8 +89,6 @@ class FundingUpgrade:
             if type(new_funder) in Organization._ALL and new_funder.name in cls.funders_map.keys():
                 new_funder = cls.funders_map[new_funder.name]
             new_funding["funder"] = new_funder
-            print("old: ", old_funding)
-            print("new: ", new_funding)
             return Funding.model_validate(new_funding)
         elif (
             type(old_funding) is dict and old_funding.get("funder") is not None and type(old_funding["funder"]) is dict
@@ -175,9 +173,6 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         funding_source = self._get_or_default(self.old_model, "funding_source", kwargs)
 
         funding_source = FundingUpgrade.upgrade_funding_source(funding_source=funding_source)
-
-        if type(funding_source) is not list:
-            funding_source = [funding_source]
 
         modality = self.get_modality(**kwargs)
 

--- a/tests/resources/ephys_data_description/data_description_0.6.2_funding_map.json
+++ b/tests/resources/ephys_data_description/data_description_0.6.2_funding_map.json
@@ -1,0 +1,40 @@
+{
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
+    "schema_version": "0.6.2",
+    "license": "CC-BY-4.0",
+    "funding_source": [
+        {
+            "funder": "Allen Institute for Neural Dynamics"
+        }
+    ],
+    "investigators": [
+        "John Doe",
+        "Mary Smith"
+    ],
+    "modality": [
+        {
+            "name": "Extracellular electrophysiology",
+            "abbreviation": "ecephys"
+        }
+    ],
+    "related_data": [
+        {
+            "related_data_path": "\\\\allen\\aind\\scratch\\ephys\\persist\\data\\MRI\\processed\\661279",
+            "relation": "Contains MRI and processing used to choose insertion locations."
+        }
+    ],
+    "creation_time": "22:31:18",
+    "creation_date": "2023-03-23",
+    "name": "661279_2023-03-23_15-31-18",
+    "institution": {
+        "name": "Allen Institute for Neural Dynamics",
+        "abbreviation": "AIND"
+    },
+    "ror_id": "04szwah67",
+    "data_level": "raw",
+    "group": "ephys",
+    "project_name": "mri-guided-electrophysiology",
+    "experiment_type": "ecephys",
+    "subject_id": "661279",
+    "data_summary": "This dataset was collected to evaluate the accuracy and feasibility of the AIND MRI-guided insertion pipeline. One probe targets the retinotopic center of LGN, with drifting grating for receptive field mapping to evaluate targeting. Other targets can be evaluated in histology."
+}

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -502,7 +502,7 @@ class TestFundingUpgrade(unittest.TestCase):
             "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
             "institution": "AIND",
             "investigators": ["John Doe"],
-            "funding_source": {
+            "funding_source": [{
                 "funder": {
                     "name": "Allen Institute",
                     "abbreviation": "AI",
@@ -514,7 +514,7 @@ class TestFundingUpgrade(unittest.TestCase):
                 },
                 "grant_number": None,
                 "fundee": None,
-            },
+            }],
             "data_level": "derived data",
             "group": None,
             "project_name": None,
@@ -529,13 +529,19 @@ class TestFundingUpgrade(unittest.TestCase):
         upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
         upgrader.upgrade()
 
-        dd.funding_source = [{"funder": "Allen Institute for Neural Dynamics", "grant_number": None, "fundee": None}]
+        self.assertEqual(dd.funding_source, [Funding(funder=Organization.AI).model_dump()])
+
+        dd.funding_source = [{"funder": Organization.AIND, "grant_number": None, "fundee": None}]
         upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
-        upgrader.upgrade()
+        dd2 = upgrader.upgrade()
+
+        self.assertEqual(dd2.funding_source, [Funding(funder=Organization.AI)])
 
         dd.funding_source = ["Allen Institute for Neural Dynamics"]
         upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
-        upgrader.upgrade()
+        dd3 = upgrader.upgrade()
+
+        self.assertEqual(dd3.funding_source, [Funding(funder=Organization.AI)])
 
 
 class TestInstitutionUpgrade(unittest.TestCase):

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -440,7 +440,7 @@ class TestModalityUpgrade(unittest.TestCase):
             "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
             "institution": "AIND",
             "investigators": ["John Doe"],
-            "funding_source": [{"funder": "AI", "grant_number": None, "fundee": None}],
+            "funding_source": [{"funder": "AIND", "grant_number": None, "fundee": None}],
             "data_level": "derived data",
             "group": None,
             "project_name": None,
@@ -489,6 +489,53 @@ class TestFundingUpgrade(unittest.TestCase):
                 }
             ),
         )
+
+    def test_funding_lookup(self):
+        """Tests old funding lookup case"""
+        dd_dict = {
+            "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema"
+            "/main/src/aind_data_schema/data_description.py",
+            "schema_version": "0.3.0",
+            "license": "CC-BY-4.0",
+            "creation_time": "16:01:12.123456",
+            "creation_date": "2022-11-01",
+            "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
+            "institution": "AIND",
+            "investigators": ["John Doe"],
+            "funding_source": {
+                "funder": {
+                    "name": "Allen Institute",
+                    "abbreviation": "AI",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR",
+                    },
+                    "registry_identifier": "03cpe7c52",
+                },
+                "grant_number": None,
+                "fundee": None,
+            },
+            "data_level": "derived data",
+            "group": None,
+            "project_name": None,
+            "project_id": None,
+            "restrictions": None,
+            "modality": "SmartSPIM",
+            "platform": Platform.SMARTSPIM,
+            "subject_id": "623711",
+            "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
+        }
+        dd = DataDescription.model_construct(**dd_dict)
+        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader.upgrade()
+
+        dd.funding_source = [{"funder": "Allen Institute for Neural Dynamics", "grant_number": None, "fundee": None}]
+        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader.upgrade()
+
+        dd.funding_source = ["Allen Institute for Neural Dynamics"]
+        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader.upgrade()
 
 
 class TestInstitutionUpgrade(unittest.TestCase):


### PR DESCRIPTION
closes #14 

Adds a lookup table for outdated funders. Current functionality only involves validating `Organization` models, but could be updated to handle less valid input methods if they exist in schema. At this moment, it does not seem like they do.