### PR TITLE
Feat 17 modality to platform lookup

### DIFF
--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -68,7 +68,6 @@ class PlatformUpgrade:
     """Handle upgrades for Platform models."""
 
     legacy_name_mapping = {
-        "trained-behavior": Platform.BEHAVIOR,
         "smartspim": Platform.SMARTSPIM,
         "single-plane-ophys": Platform.SINGLE_PLANE_OPHYS,
         "HSFP": Platform.HSFP,
@@ -79,10 +78,9 @@ class PlatformUpgrade:
         "mesoSPIM": Platform.MESOSPIM,
         "SPIM": Platform.SMARTSPIM,
         "test-FIP-opto": Platform.FIP,
-        "confocal": Platform.CONFOCAL,
         "FIP": Platform.FIP,
         "ecephys": Platform.ECEPHYS,
-        "behavior-videos": Platform.BEHAVIOR,
+        "behavior-videos": Platform.MULTIPLANE_OPHYS,
         "SmartSPIM": Platform.SMARTSPIM,
         "ephys": Platform.ECEPHYS,
     }

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -67,23 +67,23 @@ class PlatformUpgrade:
     """Handle upgrades for Platform models."""
 
     legacy_name_mapping = {
-        'trained-behavior': ,
-        'smartspim': ,
-        'single-plane-ophys': ,
-        'HSFP': ,
-        'exaSPIM': ,
-        'ophys': ,
-        'multiplane-ophys': ,
-        'merfish': ,
-        'mesoSPIM': ,
-        'SPIM': ,
-        'test-FIP-opto': ,
-        'confocal': ,
-        'FIP': ,
-        'ecephys': ,
-        'behavior-videos': ,
-        'SmartSPIM': ,
-        'ephys':
+        'trained-behavior': Platform.BEHAVIOR,
+        'smartspim': Platform.SMARTSPIM,
+        'single-plane-ophys': Platform.SINGLE_PLANE_OPHYS,
+        'HSFP': Platform.HSFP,
+        'exaSPIM': Platform.EXASPIM,
+        'ophys': Platform.SINGLE_PLANE_OPHYS,
+        'multiplane-ophys': Platform.MULTIPLANE_OPHYS,
+        'merfish': Platform.MERFISH,
+        'mesoSPIM': Platform.MESOSPIM,
+        'SPIM': Platform.SMARTSPIM,
+        'test-FIP-opto': Platform.FIP,
+        'confocal': Platform.CONFOCAL,
+        'FIP': Platform.FIP,
+        'ecephys': Platform.ECEPHYS,
+        'behavior-videos': Platform.BEHAVIOR,
+        'SmartSPIM': Platform.SMARTSPIM,
+        'ephys': Platform.ECEPHYS
     }
 
     @classmethod
@@ -213,7 +213,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         if platform is None:
             platform = self._get_or_default(self.old_model, "platform", kwargs)
             if platform is None and type(modality) is list:
-                platform = [PlatformUpgrade.from_modality(mod) for mod in modality]
+                platform = PlatformUpgrade.from_modality(modality[0])
             elif platform is None and type(modality) is str:
                 platform = PlatformUpgrade.from_modality(modality)
 

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -63,6 +63,36 @@ class ModalityUpgrade:
             return None
 
 
+class PlatformUpgrade:
+    """Handle upgrades for Platform models."""
+
+    legacy_name_mapping = {
+        'trained-behavior': ,
+        'smartspim': ,
+        'single-plane-ophys': ,
+        'HSFP': ,
+        'exaSPIM': ,
+        'ophys': ,
+        'multiplane-ophys': ,
+        'merfish': ,
+        'mesoSPIM': ,
+        'SPIM': ,
+        'test-FIP-opto': ,
+        'confocal': ,
+        'FIP': ,
+        'ecephys': ,
+        'behavior-videos': ,
+        'SmartSPIM': ,
+        'ephys':
+    }
+
+    @classmethod
+    def from_modality(cls, modality: Modality) -> Optional[Platform]:
+        """Get platform from modality"""
+        if modality is not None:
+            return cls.legacy_name_mapping.get(modality.abbreviation)
+            
+
 class FundingUpgrade:
     """Handle upgrades for Funding models."""
 
@@ -182,6 +212,11 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
 
         if platform is None:
             platform = self._get_or_default(self.old_model, "platform", kwargs)
+            if platform is None and type(modality) is list:
+                platform = [PlatformUpgrade.from_modality(mod) for mod in modality]
+            elif platform is None and type(modality) is str:
+                platform = PlatformUpgrade.from_modality(modality)
+
 
         creation_time = self.get_creation_time(**kwargs)
 

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from typing import Any, Optional, Union
 
 import semver
-
 from aind_data_schema.base import AindModel
 from aind_data_schema.core.data_description import (
     DataDescription,
@@ -69,23 +68,23 @@ class PlatformUpgrade:
     """Handle upgrades for Platform models."""
 
     legacy_name_mapping = {
-        'trained-behavior': Platform.BEHAVIOR,
-        'smartspim': Platform.SMARTSPIM,
-        'single-plane-ophys': Platform.SINGLE_PLANE_OPHYS,
-        'HSFP': Platform.HSFP,
-        'exaSPIM': Platform.EXASPIM,
-        'ophys': Platform.SINGLE_PLANE_OPHYS,
-        'multiplane-ophys': Platform.MULTIPLANE_OPHYS,
-        'merfish': Platform.MERFISH,
-        'mesoSPIM': Platform.MESOSPIM,
-        'SPIM': Platform.SMARTSPIM,
-        'test-FIP-opto': Platform.FIP,
-        'confocal': Platform.CONFOCAL,
-        'FIP': Platform.FIP,
-        'ecephys': Platform.ECEPHYS,
-        'behavior-videos': Platform.BEHAVIOR,
-        'SmartSPIM': Platform.SMARTSPIM,
-        'ephys': Platform.ECEPHYS
+        "trained-behavior": Platform.BEHAVIOR,
+        "smartspim": Platform.SMARTSPIM,
+        "single-plane-ophys": Platform.SINGLE_PLANE_OPHYS,
+        "HSFP": Platform.HSFP,
+        "exaSPIM": Platform.EXASPIM,
+        "ophys": Platform.SINGLE_PLANE_OPHYS,
+        "multiplane-ophys": Platform.MULTIPLANE_OPHYS,
+        "merfish": Platform.MERFISH,
+        "mesoSPIM": Platform.MESOSPIM,
+        "SPIM": Platform.SMARTSPIM,
+        "test-FIP-opto": Platform.FIP,
+        "confocal": Platform.CONFOCAL,
+        "FIP": Platform.FIP,
+        "ecephys": Platform.ECEPHYS,
+        "behavior-videos": Platform.BEHAVIOR,
+        "SmartSPIM": Platform.SMARTSPIM,
+        "ephys": Platform.ECEPHYS,
     }
 
     @classmethod
@@ -93,7 +92,7 @@ class PlatformUpgrade:
         """Get platform from modality"""
         if modality is not None:
             return cls.legacy_name_mapping.get(modality.abbreviation)
-            
+
 
 class FundingUpgrade:
     """Handle upgrades for Funding models."""
@@ -220,9 +219,6 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
             if platform is None and version <= "0.8.0":
                 if type(modality) is list:
                     platform = PlatformUpgrade.from_modality(modality[0])
-                elif type(modality) is str:
-                    platform = PlatformUpgrade.from_modality(modality)
-
 
         creation_time = self.get_creation_time(**kwargs)
 

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -76,23 +76,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         """Tests data_description_0.3.0_wrong_field.json is mapped correctly."""
         data_description_0_3_0 = self.data_descriptions["data_description_0.3.0_wrong_field.json"]
         upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_3_0)
-        # Should complain about platform being None and missing data level
-        with self.assertRaises(Exception) as e:
-            upgrader.upgrade()
 
-        expected_error_message = (
-            "1 validation error for DataDescription\n"
-            "platform\n"
-            "  Input should be a valid dictionary or object to extract fields"
-            " from [type=model_attributes_type, input_value=None, input_type=NoneType]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/model_attributes_type"
-        )
-        print("repr: ", repr(e.exception))
-        print("error:", expected_error_message)
-        self.assertEqual(expected_error_message, repr(e.exception))
-
-        # Should work by setting platform explicitly and DataLevel
-        new_data_description = upgrader.upgrade(platform=Platform.ECEPHYS, data_level=DataLevel.RAW)
+        new_data_description = upgrader.upgrade()
         self.assertEqual(
             datetime.datetime(2022, 7, 26, 10, 52, 15),
             new_data_description.creation_time,

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -430,6 +430,7 @@ class TestModalityUpgrade(unittest.TestCase):
         upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
         upgrader.upgrade()
 
+
 class TestPlatformUpgrade(unittest.TestCase):
     """Tests PlatformUpgrade methods"""
 
@@ -461,7 +462,6 @@ class TestPlatformUpgrade(unittest.TestCase):
         dd = DataDescription.model_construct(**dd_dict)
         upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
         upgrader.upgrade()
-        
 
     def test_platform_lookup(self):
         """Tests old platform lookup case"""

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -50,21 +50,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         """Tests data_description_0.3.0.json is mapped correctly."""
         data_description_0_3_0 = self.data_descriptions["data_description_0.3.0.json"]
         upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_3_0)
-        # Should complain about platform being None
-        with self.assertRaises(Exception) as e:
-            upgrader.upgrade()
 
-        expected_error_message = (
-            "1 validation error for DataDescription\n"
-            "platform\n"
-            "  Input should be a valid dictionary or object to extract fields"
-            " from [type=model_attributes_type, input_value=None, input_type=NoneType]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/model_attributes_type"
-        )
-        self.assertEqual(expected_error_message, repr(e.exception))
-
-        # Should work by setting platform explicitly
-        new_data_description = upgrader.upgrade(platform=Platform.ECEPHYS)
+        new_data_description = upgrader.upgrade()
         self.assertEqual(
             datetime.datetime(2022, 6, 28, 10, 31, 30),
             new_data_description.creation_time,
@@ -100,6 +87,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             " from [type=model_attributes_type, input_value=None, input_type=NoneType]\n"
             f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/model_attributes_type"
         )
+        print("repr: ", repr(e.exception))
+        print("error:", expected_error_message)
         self.assertEqual(expected_error_message, repr(e.exception))
 
         # Should work by setting platform explicitly and DataLevel
@@ -430,6 +419,7 @@ class TestModalityUpgrade(unittest.TestCase):
 
     def test_modality_lookup(self):
         """Tests old modality lookup case"""
+
         dd_dict = {
             "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema"
             "/main/src/aind_data_schema/data_description.py",
@@ -448,6 +438,66 @@ class TestModalityUpgrade(unittest.TestCase):
             "restrictions": None,
             "modality": "SmartSPIM",
             "platform": Platform.SMARTSPIM,
+            "subject_id": "623711",
+            "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
+        }
+        dd = DataDescription.model_construct(**dd_dict)
+        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader.upgrade()
+
+class TestPlatformUpgrade(unittest.TestCase):
+    """Tests PlatformUpgrade methods"""
+
+    def test_platform_upgrade(self):
+        """Tests edge case"""
+
+        dd_dict = {
+            "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema"
+            "/main/src/aind_data_schema/data_description.py",
+            "schema_version": "0.3.0",
+            "license": "CC-BY-4.0",
+            "creation_time": "16:01:12.123456",
+            "creation_date": "2022-11-01",
+            "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
+            "institution": "AIND",
+            "investigators": ["John Doe"],
+            "funding_source": [{"funder": "AI", "grant_number": None, "fundee": None}],
+            "data_level": "derived data",
+            "group": None,
+            "project_name": None,
+            "project_id": None,
+            "restrictions": None,
+            "modality": "SmartSPIM",
+            "platform": None,
+            "subject_id": "623711",
+            "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
+        }
+
+        dd = DataDescription.model_construct(**dd_dict)
+        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader.upgrade()
+        
+
+    def test_platform_lookup(self):
+        """Tests old platform lookup case"""
+        dd_dict = {
+            "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema"
+            "/main/src/aind_data_schema/data_description.py",
+            "schema_version": "0.3.0",
+            "license": "CC-BY-4.0",
+            "creation_time": "16:01:12.123456",
+            "creation_date": "2022-11-01",
+            "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
+            "institution": "AIND",
+            "investigators": ["John Doe"],
+            "funding_source": [{"funder": "AI", "grant_number": None, "fundee": None}],
+            "data_level": "derived data",
+            "group": None,
+            "project_name": None,
+            "project_id": None,
+            "restrictions": None,
+            "modality": "ecephys",
+            "platform": None,
             "subject_id": "623711",
             "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
         }


### PR DESCRIPTION
closes #17 

Introduces a lookup table for `platform` if the original model is before the introduction of `platform`. Translates `modality` -> `platform`.