### PR TITLE
`allow_validation_errors` flag

### DIFF
--- a/src/aind_metadata_upgrader/base_upgrade.py
+++ b/src/aind_metadata_upgrader/base_upgrade.py
@@ -10,7 +10,7 @@ from pydantic.fields import PydanticUndefined
 class BaseModelUpgrade(ABC):
     """Base class for handling upgrades for models"""
 
-    def __init__(self, old_model: Union[AindModel, dict], model_class: Type[AindModel]):
+    def __init__(self, old_model: Union[AindModel, dict], model_class: Type[AindModel], allow_validation_errors = False):
         """
         Handle mapping of old AindModel model versions into current models
 
@@ -25,6 +25,7 @@ class BaseModelUpgrade(ABC):
             old_model = model_class.model_construct(**old_model)
         self.old_model = old_model
         self.model_class = model_class
+        self.allow_validation_errors = allow_validation_errors
 
     def _get_or_default(self, model: AindModel, field_name: str, kwargs: dict) -> Any:
         """

--- a/src/aind_metadata_upgrader/base_upgrade.py
+++ b/src/aind_metadata_upgrader/base_upgrade.py
@@ -10,7 +10,7 @@ from pydantic.fields import PydanticUndefined
 class BaseModelUpgrade(ABC):
     """Base class for handling upgrades for models"""
 
-    def __init__(self, old_model: Union[AindModel, dict], model_class: Type[AindModel], allow_validation_errors = False):
+    def __init__(self, old_model: Union[AindModel, dict], model_class: Type[AindModel], allow_validation_errors=False):
         """
         Handle mapping of old AindModel model versions into current models
 

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -502,19 +502,21 @@ class TestFundingUpgrade(unittest.TestCase):
             "name": "SmartSPIM_623711_2022-10-27_16-48-54_stitched_2022-11-01_16-01-12",
             "institution": "AIND",
             "investigators": ["John Doe"],
-            "funding_source": [{
-                "funder": {
-                    "name": "Allen Institute",
-                    "abbreviation": "AI",
-                    "registry": {
-                        "name": "Research Organization Registry",
-                        "abbreviation": "ROR",
+            "funding_source": [
+                {
+                    "funder": {
+                        "name": "Allen Institute",
+                        "abbreviation": "AI",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR",
+                        },
+                        "registry_identifier": "03cpe7c52",
                     },
-                    "registry_identifier": "03cpe7c52",
-                },
-                "grant_number": None,
-                "fundee": None,
-            }],
+                    "grant_number": None,
+                    "fundee": None,
+                }
+            ],
             "data_level": "derived data",
             "group": None,
             "project_name": None,


### PR DESCRIPTION
closes #20 

Adding field `BaseModelUpgrade.allow_validation_errors`, which will allow models to be upgrade without passing validation when the flag is set to true.  