### PR TITLE
Data description upgrader takes care of wrong funder name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema==0.31.8'
+    'aind-data-schema==0.26.5'
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema==0.26.5'
+    'aind-data-schema==0.31.8'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, get_args
 
 from aind_data_schema.base import AindModel
 from aind_data_schema.core.data_description import (
@@ -93,6 +93,11 @@ class FundingUpgrade:
         elif (
             type(old_funding) is dict and old_funding.get("funder") is not None and type(old_funding["funder"]) is dict
         ):
+            # check that the funder is valid. If not, set it to Allen Institute
+            possible_funders = [f() for f in get_args(get_args(Organization.FUNDERS)[0])]
+            if Organization.from_name(old_funding["funder"]["name"]) not in possible_funders:
+                print(f"Invalid funder: {old_funding['funder']['name']}")
+                old_funding["funder"] = Organization.from_name("Allen Institute")
             return Funding.model_validate(old_funding)
         else:
             return Funding(funder=Organization.AI)

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -93,11 +93,16 @@ class FundingUpgrade:
         elif (
             type(old_funding) is dict and old_funding.get("funder") is not None and type(old_funding["funder"]) is dict
         ):
-            # check that the funder is valid. If not, set it to Allen Institute
-            possible_funders = [f() for f in get_args(get_args(Organization.FUNDERS)[0])]
-            if Organization.from_name(old_funding["funder"]["name"]) not in possible_funders:
-                old_funding["funder"] = Organization.AI
-            return Funding.model_validate(old_funding)
+            old_funder = old_funding.get("funder")
+            if Organization().name_map.get(old_funder["name"]) is not None:
+                new_funder = Organization.from_name(old_funder["name"])
+            else:
+                new_funder = Organization.from_abbreviation(old_funder["name"])
+            new_funding = deepcopy(old_funding)
+            if type(new_funder) in Organization._ALL and new_funder.name in cls.funders_map.keys():
+                new_funder = cls.funders_map[new_funder.name]
+            new_funding["funder"] = new_funder
+            return Funding.model_validate(new_funding)
         else:
             return Funding(funder=Organization.AI)
 

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -96,8 +96,7 @@ class FundingUpgrade:
             # check that the funder is valid. If not, set it to Allen Institute
             possible_funders = [f() for f in get_args(get_args(Organization.FUNDERS)[0])]
             if Organization.from_name(old_funding["funder"]["name"]) not in possible_funders:
-                print(f"Invalid funder: {old_funding['funder']['name']}")
-                old_funding["funder"] = Organization.from_name("Allen Institute")
+                old_funding["funder"] = Organization.AI
             return Funding.model_validate(old_funding)
         else:
             return Funding(funder=Organization.AI)

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -70,6 +70,9 @@ class FundingUpgrade:
         "Allen Institute for Brain Science": Organization.AI,
         "Allen Institute for Neural Dynamics": Organization.AI,
         "AIND": Organization.AI,
+        "AIBS": Organization.AI,
+        "AI": Organization.AI,
+        "Allen Institute": Organization.AI,
         Organization.AIND: Organization.AI,
         Organization.AIBS: Organization.AI,
     }
@@ -80,28 +83,18 @@ class FundingUpgrade:
         if type(old_funding) is Funding:
             return old_funding
         elif type(old_funding) is dict and old_funding.get("funder") is not None and type(old_funding["funder"]) is str:
-            old_funder = old_funding.get("funder")
-            if Organization().name_map.get(old_funder) is not None:
-                new_funder = Organization.from_name(old_funder)
-            else:
-                new_funder = Organization.from_abbreviation(old_funder)
+            old_funder_name = old_funding.get("funder")
             new_funding = deepcopy(old_funding)
-            if type(new_funder) in Organization._ALL and new_funder.name in cls.funders_map.keys():
-                new_funder = cls.funders_map[new_funder.name]
-            new_funding["funder"] = new_funder
+            if old_funder_name in cls.funders_map.keys():
+                new_funding["funder"] = cls.funders_map[old_funder_name]
             return Funding.model_validate(new_funding)
         elif (
             type(old_funding) is dict and old_funding.get("funder") is not None and type(old_funding["funder"]) is dict
         ):
-            old_funder = old_funding.get("funder")
-            if Organization().name_map.get(old_funder["name"]) is not None:
-                new_funder = Organization.from_name(old_funder["name"])
-            else:
-                new_funder = Organization.from_abbreviation(old_funder["name"])
+            old_funder_name = old_funding.get("funder")["name"]
             new_funding = deepcopy(old_funding)
-            if type(new_funder) in Organization._ALL and new_funder.name in cls.funders_map.keys():
-                new_funder = cls.funders_map[new_funder.name]
-            new_funding["funder"] = new_funder
+            if old_funder_name in cls.funders_map.keys():
+                new_funding["funder"] = cls.funders_map[old_funder_name]
             return Funding.model_validate(new_funding)
         else:
             return Funding(funder=Organization.AI)

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Optional, Union, get_args
+from typing import Any, Optional, Union
 
 from aind_data_schema.base import AindModel
 from aind_data_schema.core.data_description import (

--- a/tests/resources/ephys_data_description/data_description_0.11.0_wrong_funder.json
+++ b/tests/resources/ephys_data_description/data_description_0.11.0_wrong_funder.json
@@ -1,0 +1,50 @@
+{
+   "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
+   "schema_version": "0.11.0",
+   "license": "CC-BY-4.0",
+   "creation_time": "2023-03-06T15:08:24",
+   "name": "ecephys_649038_2023-03-06_15-08-24",
+   "label": null,
+   "institution": {
+      "name": "Allen Institute for Neural Dynamics",
+      "abbreviation": "AIND",
+      "registry": {
+         "name": "Research Organization Registry",
+         "abbreviation": "ROR"
+      },
+      "registry_identifier": "04szwah67"
+   },
+   "funding_source": [
+      {
+         "funder": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": {
+               "name": "Research Organization Registry",
+               "abbreviation": "ROR"
+            },
+            "registry_identifier": "04szwah67"
+         },
+         "grant_number": null,
+         "fundee": null
+      }
+   ],
+   "data_level": "raw",
+   "group": null,
+   "investigators": ["John Doe"],
+   "platform": {
+      "name": "Electrophysiology platform",
+      "abbreviation": "ecephys"
+   },
+   "project_name": null,
+   "restrictions": null,
+   "modality": [
+      {
+         "name": "Extracellular electrophysiology",
+         "abbreviation": "ecephys"
+      }
+   ],
+   "subject_id": "649038",
+   "related_data": [],
+   "data_summary": null
+}

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -360,6 +360,34 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         self.assertEqual(Platform.ECEPHYS, new_data_description.platform)
         self.assertIsNone(new_data_description.data_summary)
 
+    def test_upgrades_0_11_0_wrong_funding(self):
+        """Tests data_description_0.11.0.json is mapped correctly."""
+        data_description_0_11_0 = self.data_descriptions["data_description_0.11.0_wrong_funder.json"]
+        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_11_0)
+
+        new_data_description = upgrader.upgrade()
+        # AIND should be set to AI by upgrader
+        self.assertEqual(
+            [Funding(funder=Organization.AI)],
+            new_data_description.funding_source,
+        )
+        self.assertEqual(
+            datetime.datetime(2023, 3, 6, 15, 8, 24),
+            new_data_description.creation_time,
+        )
+        self.assertEqual("ecephys_649038_2023-03-06_15-08-24", new_data_description.name)
+        self.assertEqual(Organization.AIND, new_data_description.institution)
+        self.assertEqual(DataLevel.RAW, new_data_description.data_level)
+        self.assertIsNone(new_data_description.group)
+        self.assertEqual(["John Doe"], new_data_description.investigators)
+        self.assertIsNone(new_data_description.project_name)
+        self.assertIsNone(new_data_description.restrictions)
+        self.assertEqual([Modality.ECEPHYS], new_data_description.modality)
+        self.assertEqual("649038", new_data_description.subject_id)
+        self.assertEqual([], new_data_description.related_data)
+        self.assertEqual(Platform.ECEPHYS, new_data_description.platform)
+        self.assertIsNone(new_data_description.data_summary)
+
     def test_data_level_upgrade(self):
         """Tests data level can be set from legacy versions"""
 

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -290,8 +290,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         with self.assertRaises(Exception) as e:
             upgrader.upgrade()
 
-        expected_error_message = "KeyError('Not a real funder')"
-        self.assertEqual(expected_error_message, repr(e.exception))
+        expected_error_message = "1 validation error for Funding"
+        self.assertIn(expected_error_message, repr(e.exception))
 
         # Should work by setting funding_source explicitly
         new_data_description = upgrader.upgrade(funding_source=[Funding(funder=Organization.AI)])


### PR DESCRIPTION
Fixes #23

The `Organization.FUNDERS` only includes AI, NINDS, and SIMONS. We have several assets with AIND as funder. In case the specified funder is not among the possible ones, it is set to `Organization.AI`.

**Note:** I tried to avoid hard-coding supported funders, with [this](https://github.com/AllenNeuralDynamics/aind-metadata-upgrader/blob/fix-23/src/aind_metadata_upgrader/data_description_upgrade.py#L96-L100)

@jtyoung84 @dyf @Sun-flow  I have a feeling there is probably a better way to do that (basically get the inner types of an `Annotated Union`). Thoughts?