### PR TITLE
generic data_description_updater improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-schema==0.38.0',
     'pydantic<2.7',
+    'backports-datetime-fromisoformat==2.0.1'
 ]
 
 [project.optional-dependencies]

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -208,10 +208,12 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         creation_date = self._get_or_default(self.old_model, "creation_date", kwargs)
         creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
         old_name = self._get_or_default(self.old_model, "name", kwargs)
-        if creation_date is not None and creation_time is not None:
-            creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time.replace('Z', "+00:00")}")
-        elif creation_time is not None:
-            creation_time = datetime.fromisoformat(f"{creation_time}")
+        if creation_time:
+            creation_time = creation_time.replace("Z", "+00:00")
+            if creation_date:
+                creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time}")
+            else:
+                creation_time = datetime.fromisoformat(f"{creation_time}")
         elif old_name is not None:
             creation_time = DataDescription.parse_name(old_name).get("creation_time")
         return creation_time

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -17,6 +17,7 @@ from aind_data_schema_models.pid_names import PIDName
 from aind_data_schema_models.platforms import Platform
 
 from aind_metadata_upgrader.base_upgrade import BaseModelUpgrade
+from aind_metadata_upgrader.utils import construct_new_model
 
 
 class ModalityUpgrade:
@@ -168,22 +169,21 @@ class InvestigatorsUpgrade:
                 return [PIDName(name=inv) for inv in old_investigators]
             elif type(old_investigators) is list and isinstance(old_investigators[0], dict):
                 return [PIDName(**inv) for inv in old_investigators]
-        else:
-            return [PIDName(name="Unknown")]
+
         return old_investigators
 
 
 class DataDescriptionUpgrade(BaseModelUpgrade):
     """Handle upgrades for DataDescription class"""
 
-    def __init__(self, old_data_description_model: DataDescription):
+    def __init__(self, old_data_description_model: DataDescription, allow_validation_errors=False):
         """
         Handle mapping of old DataDescription models into current models
         Parameters
         ----------
         old_data_description_model : DataDescription
         """
-        super().__init__(old_data_description_model, model_class=DataDescription)
+        super().__init__(old_data_description_model, model_class=DataDescription, allow_validation_errors=allow_validation_errors)
 
     def get_modality(self, **kwargs):
         """Get modality from old model"""
@@ -254,19 +254,21 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
 
         creation_time = self.get_creation_time(**kwargs)
 
-        return DataDescription(
-            creation_time=creation_time,
-            name=self._get_or_default(self.old_model, "name", kwargs),
-            institution=institution,
-            funding_source=funding_source,
-            data_level=data_level,
-            group=self._get_or_default(self.old_model, "group", kwargs),
-            investigators=investigators,
-            project_name=self._get_or_default(self.old_model, "project_name", kwargs),
-            restrictions=self._get_or_default(self.old_model, "restrictions", kwargs),
-            modality=modality,
-            platform=platform,
-            subject_id=self._get_or_default(self.old_model, "subject_id", kwargs),
-            related_data=self._get_or_default(self.old_model, "related_data", kwargs),
-            data_summary=self._get_or_default(self.old_model, "data_summary", kwargs),
-        )
+        data_desc_dict = {
+            "creation_time": creation_time,
+            "name": self._get_or_default(self.old_model, "name", kwargs),
+            "institution": institution,
+            "funding_source": funding_source,
+            "data_level": data_level,
+            "group": self._get_or_default(self.old_model, "group", kwargs),
+            "investigators": investigators,
+            "project_name": self._get_or_default(self.old_model, "project_name", kwargs),
+            "restrictions": self._get_or_default(self.old_model, "restrictions", kwargs),
+            "modality": modality,
+            "platform": platform,
+            "subject_id": self._get_or_default(self.old_model, "subject_id", kwargs),
+            "related_data": self._get_or_default(self.old_model, "related_data", kwargs),
+            "data_summary": self._get_or_default(self.old_model, "data_summary", kwargs),
+        }
+
+        return construct_new_model(data_desc_dict, DataDescription, self.allow_validation_errors)

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -209,7 +209,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
         old_name = self._get_or_default(self.old_model, "name", kwargs)
         if creation_date is not None and creation_time is not None:
-            creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time}")
+            creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time.replace('Z', "+00:00")}")
         elif creation_time is not None:
             creation_time = datetime.fromisoformat(f"{creation_time}")
         elif old_name is not None:

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -57,7 +57,7 @@ class ModalityUpgrade:
         if type(old_modality) is str and cls.legacy_name_mapping.get(old_modality.lower()) is not None:
             return cls.legacy_name_mapping[old_modality.lower()]
         elif type(old_modality) is str:
-            return Modality.from_abbreviation(old_modality.lower())
+            return Modality.from_abbreviation(old_modality)
         elif type(old_modality) is dict and old_modality.get("abbreviation") is not None:
             return Modality.from_abbreviation(old_modality["abbreviation"])
         elif type(old_modality) in Modality._ALL:

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -209,7 +209,6 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
         old_name = self._get_or_default(self.old_model, "name", kwargs)
         if creation_time:
-            creation_time = creation_time.replace("Z", "+00:00")
             if creation_date:
                 creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time}")
             else:

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -161,14 +161,16 @@ class InvestigatorsUpgrade:
     @staticmethod
     def upgrade_investigators(old_investigators: Any) -> List[PIDName]:
         """Map legacy investigators model to current version"""
-        if type(old_investigators) is str:
-            return [PIDName(name=old_investigators)]
-        elif type(old_investigators) is list and isinstance(old_investigators[0], str):
-            return [PIDName(name=inv) for inv in old_investigators]
-        elif type(old_investigators) is list and isinstance(old_investigators[0], dict):
-            return [PIDName(**inv) for inv in old_investigators]
+        if old_investigators:
+            if type(old_investigators) is str:
+                return [PIDName(name=old_investigators)]
+            elif type(old_investigators) is list and isinstance(old_investigators[0], str):
+                return [PIDName(name=inv) for inv in old_investigators]
+            elif type(old_investigators) is list and isinstance(old_investigators[0], dict):
+                return [PIDName(**inv) for inv in old_investigators]
         else:
-            return old_investigators
+            return [PIDName(name="Unknown")]
+        return old_investigators
 
 
 class DataDescriptionUpgrade(BaseModelUpgrade):

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -57,7 +57,7 @@ class ModalityUpgrade:
         if type(old_modality) is str and cls.legacy_name_mapping.get(old_modality.lower()) is not None:
             return cls.legacy_name_mapping[old_modality.lower()]
         elif type(old_modality) is str:
-            return Modality.from_abbreviation(old_modality)
+            return Modality.from_abbreviation(old_modality.lower())
         elif type(old_modality) is dict and old_modality.get("abbreviation") is not None:
             return Modality.from_abbreviation(old_modality["abbreviation"])
         elif type(old_modality) in Modality._ALL:

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -183,7 +183,9 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         ----------
         old_data_description_model : DataDescription
         """
-        super().__init__(old_data_description_model, model_class=DataDescription, allow_validation_errors=allow_validation_errors)
+        super().__init__(
+            old_data_description_model, model_class=DataDescription, allow_validation_errors=allow_validation_errors
+        )
 
     def get_modality(self, **kwargs):
         """Get modality from old model"""

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -72,26 +72,26 @@ class PlatformUpgrade:
     legacy_name_mapping = {
         "smartspim": Platform.SMARTSPIM,
         "single-plane-ophys": Platform.SINGLE_PLANE_OPHYS,
-        "HSFP": Platform.HSFP,
-        "exaSPIM": Platform.EXASPIM,
+        "hsfp": Platform.HSFP,
+        "exaspim": Platform.EXASPIM,
         "ophys": Platform.SINGLE_PLANE_OPHYS,
         "multiplane-ophys": Platform.MULTIPLANE_OPHYS,
         "merfish": Platform.MERFISH,
-        "mesoSPIM": Platform.MESOSPIM,
-        "SPIM": Platform.SMARTSPIM,
-        "test-FIP-opto": Platform.FIP,
-        "FIP": Platform.FIP,
+        "mesospim": Platform.MESOSPIM,
+        "spim": Platform.SMARTSPIM,
+        "test-fip-opto": Platform.FIP,
+        "fip": Platform.FIP,
         "ecephys": Platform.ECEPHYS,
         "behavior-videos": Platform.MULTIPLANE_OPHYS,
-        "SmartSPIM": Platform.SMARTSPIM,
         "ephys": Platform.ECEPHYS,
+        "trained-behavior": Platform.BEHAVIOR
     }
 
     @classmethod
     def from_modality(cls, modality: Modality) -> Optional[Platform]:
         """Get platform from modality"""
         if modality is not None:
-            return cls.legacy_name_mapping.get(modality.abbreviation)
+            return cls.legacy_name_mapping.get(str.lower(modality.abbreviation))
 
 
 class FundingUpgrade:
@@ -212,7 +212,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
             if creation_date:
                 creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time}")
             else:
-                creation_time = datetime.fromisoformat(f"{creation_time}")
+                creation_time = datetime.fromisoformat(creation_time)
         elif old_name is not None:
             creation_time = DataDescription.parse_name(old_name).get("creation_time")
         return creation_time

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -15,13 +15,10 @@ from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.organizations import Organization
 from aind_data_schema_models.pid_names import PIDName
 from aind_data_schema_models.platforms import Platform
+from backports.datetime_fromisoformat import MonkeyPatch
 
 from aind_metadata_upgrader.base_upgrade import BaseModelUpgrade
 from aind_metadata_upgrader.utils import construct_new_model
-
-from backports.datetime_fromisoformat import MonkeyPatch
-
-MonkeyPatch.patch_fromisoformat()
 
 
 class ModalityUpgrade:
@@ -88,7 +85,7 @@ class PlatformUpgrade:
         "ecephys": Platform.ECEPHYS,
         "behavior-videos": Platform.MULTIPLANE_OPHYS,
         "ephys": Platform.ECEPHYS,
-        "trained-behavior": Platform.BEHAVIOR
+        "trained-behavior": Platform.BEHAVIOR,
     }
 
     @classmethod
@@ -187,6 +184,9 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
         ----------
         old_data_description_model : DataDescription
         """
+
+        MonkeyPatch.patch_fromisoformat()
+
         super().__init__(
             old_data_description_model, model_class=DataDescription, allow_validation_errors=allow_validation_errors
         )

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -19,6 +19,10 @@ from aind_data_schema_models.platforms import Platform
 from aind_metadata_upgrader.base_upgrade import BaseModelUpgrade
 from aind_metadata_upgrader.utils import construct_new_model
 
+from backports.datetime_fromisoformat import MonkeyPatch
+
+MonkeyPatch.patch_fromisoformat()
+
 
 class ModalityUpgrade:
     """Handle upgrades for Modality models."""

--- a/tests/resources/ephys_data_description/data_description_0.13.8_parse_time.json
+++ b/tests/resources/ephys_data_description/data_description_0.13.8_parse_time.json
@@ -1,0 +1,67 @@
+{
+  "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+  "schema_version": "0.13.8",
+  "license": "CC-BY-4.0",
+  "platform": {
+    "name": "Electrophysiology platform",
+    "abbreviation": "ecephys"
+  },
+  "subject_id": "708020",
+  "creation_time": "2024-06-11T18:37:31.983373Z",
+  "label": null,
+  "name": "ecephys_708020_2024-05-17_10-01-28_sorted_2024-06-11_18-37-31",
+  "institution": {
+    "name": "Allen Institute for Neural Dynamics",
+    "abbreviation": "AIND",
+    "registry": {
+      "name": "Research Organization Registry",
+      "abbreviation": "ROR"
+    },
+    "registry_identifier": "04szwah67"
+  },
+  "funding_source": [
+    {
+      "funder": {
+        "name": "Allen Institute",
+        "abbreviation": "AI",
+        "registry": {
+          "name": "Research Organization Registry",
+          "abbreviation": "ROR"
+        },
+        "registry_identifier": "03cpe7c52"
+      },
+      "grant_number": null,
+      "fundee": "Shawn Olsen"
+    }
+  ],
+  "data_level": "derived",
+  "group": null,
+  "investigators": [
+    {
+      "name": "Shawn Olsen",
+      "abbreviation": null,
+      "registry": null,
+      "registry_identifier": null
+    }
+  ],
+  "project_name": null,
+  "restrictions": null,
+  "modality": [
+    {
+      "name": "Extracellular electrophysiology",
+      "abbreviation": "ecephys"
+    },
+    {
+      "name": "Behavior",
+      "abbreviation": "behavior"
+    },
+    {
+      "name": "Behavior videos",
+      "abbreviation": "behavior-videos"
+    }
+  ],
+  "related_data": [],
+  "data_summary": null,
+  "input_data_name": "ecephys_708020_2024-05-17_10-01-28",
+  "process_name": "sorted"
+}

--- a/tests/resources/ephys_data_description/data_description_0.6.2_empty_investigators.json
+++ b/tests/resources/ephys_data_description/data_description_0.6.2_empty_investigators.json
@@ -1,0 +1,37 @@
+{
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
+    "schema_version": "0.6.2",
+    "license": "CC-BY-4.0",
+    "funding_source": [
+        {
+            "funder": "Allen Institute"
+        }
+    ],
+    "investigators": [],
+    "modality": [
+        {
+            "name": "Extracellular electrophysiology",
+            "abbreviation": "ecephys"
+        }
+    ],
+    "related_data": [
+        {
+            "related_data_path": "\\\\allen\\aind\\scratch\\ephys\\persist\\data\\MRI\\processed\\661279",
+            "relation": "Contains MRI and processing used to choose insertion locations."
+        }
+    ],
+    "creation_time": "22:31:18",
+    "creation_date": "2023-03-23",
+    "name": "661279_2023-03-23_15-31-18",
+    "institution": {
+        "name": "Allen Institute for Neural Dynamics",
+        "abbreviation": "AIND"
+    },
+    "ror_id": "04szwah67",
+    "data_level": "raw",
+    "group": "ephys",
+    "project_name": "mri-guided-electrophysiology",
+    "experiment_type": "ecephys",
+    "subject_id": "661279",
+    "data_summary": "This dataset was collected to evaluate the accuracy and feasibility of the AIND MRI-guided insertion pipeline. One probe targets the retinotopic center of LGN, with drifting grating for receptive field mapping to evaluate targeting. Other targets can be evaluated in histology."
+}

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -381,6 +381,19 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         self.assertEqual(Platform.ECEPHYS, new_data_description.platform)
         self.assertIsNone(new_data_description.data_summary)
 
+    def test_upgrades_creation_time(self):
+        """Tests that strings which include a Z timezone are upgraded correctly"""
+
+        data_description_0_13_8 = self.data_descriptions["data_description_0.13.8_parse_time.json"]
+        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_13_8)
+
+        new_data_description = upgrader.upgrade()
+
+        self.assertEqual(
+            datetime.datetime(2024, 6, 11, 18, 37, 31, microsecond=983373, tzinfo=datetime.timezone.utc),
+            new_data_description.creation_time,
+        )
+
     def test_data_level_upgrade(self):
         """Tests data level can be set from legacy versions"""
 

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -317,7 +317,9 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         data_description_0_6_2_missing_investigators = self.data_descriptions[
             "data_description_0.6.2_empty_investigators.json"
         ]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_2_missing_investigators, allow_validation_errors=True)
+        upgrader = DataDescriptionUpgrade(
+            old_data_description_model=data_description_0_6_2_missing_investigators, allow_validation_errors=True
+        )
 
         new_data_description = upgrader.upgrade()
 

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -8,8 +8,6 @@ import unittest
 from pathlib import Path
 from typing import List
 
-
-
 from aind_data_schema.core.data_description import (
     DataDescription,
     DataLevel,

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -317,11 +317,11 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         data_description_0_6_2_missing_investigators = self.data_descriptions[
             "data_description_0.6.2_empty_investigators.json"
         ]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_2_missing_investigators)
+        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_2_missing_investigators, allow_validation_errors=True)
 
         new_data_description = upgrader.upgrade()
 
-        self.assertEqual(new_data_description.investigators, [PIDName(name="Unknown")])
+        self.assertEqual(new_data_description.investigators, [])
 
     def test_upgrades_0_10_0(self):
         """Tests data_description_0.10.0.json is mapped correctly."""

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -311,6 +311,18 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             new_data_description.data_summary,
         )
 
+    def test_upgrades_0_6_2_missing_investigators(self):
+        """Tests upgrade with missing investigators"""
+
+        data_description_0_6_2_missing_investigators = self.data_descriptions[
+            "data_description_0.6.2_empty_investigators.json"
+        ]
+        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_2_missing_investigators)
+
+        new_data_description = upgrader.upgrade()
+
+        self.assertEqual(new_data_description.investigators, [PIDName(name="Unknown")])
+
     def test_upgrades_0_10_0(self):
         """Tests data_description_0.10.0.json is mapped correctly."""
         data_description_0_10_0 = self.data_descriptions["data_description_0.10.0.json"]

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -8,6 +8,8 @@ import unittest
 from pathlib import Path
 from typing import List
 
+
+
 from aind_data_schema.core.data_description import (
     DataDescription,
     DataLevel,


### PR DESCRIPTION
closes #28 
closes #30 
closes #31 

Covers multiple small QoL and bugfix improvements to the `DataDescriptionUpgrader` module.

Adds a check to the `InvestigatorsUpgrade.upgrade_investigator()` which handles an empty list of investigators without accessing an empty list.
Adds the flag `allow_validation_errors` (first used in `ProceduresUpgrade`) to `DataDescriptionUpgrade`
Implements usage of `utils.construct_new_model` for construction of the final DataDescription.
Ensures that modality lookup in `ModalityUpgrade.upgrade_modality()` uses lower cased strings.