### PR TITLE
Update data_description_upgrade.py

### DIFF
--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -107,6 +107,7 @@ class FundingUpgrade:
         "Allen Institute": Organization.AI,
         Organization.AIND: Organization.AI,
         Organization.AIBS: Organization.AI,
+        "NINMH": Organization.NIMH,
     }
 
     @classmethod


### PR DESCRIPTION
closes #34 

Quick fix, adds mapping from `NINMH` -> `NIMH` model to `FundingUpgrade` map.