### PR TITLE
forcing lower casing on ModalityUpgrade

### DIFF
--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -58,9 +58,9 @@ class ModalityUpgrade:
         if type(old_modality) is str and cls.legacy_name_mapping.get(old_modality.lower()) is not None:
             return cls.legacy_name_mapping[old_modality.lower()]
         elif type(old_modality) is str:
-            return Modality.from_abbreviation(old_modality)
+            return Modality.from_abbreviation(old_modality.lower())
         elif type(old_modality) is dict and old_modality.get("abbreviation") is not None:
-            return Modality.from_abbreviation(old_modality["abbreviation"])
+            return Modality.from_abbreviation(old_modality["abbreviation"].lower())
         elif type(old_modality) in Modality._ALL:
             return old_modality
         else:


### PR DESCRIPTION
closes #41 

some Modality abbreviations in schema do not naturally use lower-casing, which is causing errors when upgrading.

Adding a forced `.lower()` cast to all checks that lacked it in `ModalityUpgrade`