### PR TITLE
add PGA to funders_map

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema==0.38.0',
+    'aind-data-schema==0.38.6',
     'pydantic<2.7',
     'backports-datetime-fromisoformat==2.0.1'
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema==0.38.6',
+    'aind-data-schema==0.38.0',
     'pydantic<2.7',
     'backports-datetime-fromisoformat==2.0.1'
 ]

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -109,6 +109,7 @@ class FundingUpgrade:
         Organization.AIBS: Organization.AI,
         "NINMH": Organization.NIMH,
         "NIMH": Organization.NIMH,
+        "PGA": Organization.AI
     }
 
     @classmethod


### PR DESCRIPTION
closes #43 

One line change to add a new mapping to the `FundingUpgrade.funders_map` to handle a missing funder.