### PR TITLE
Feat 49 upgrade to `aind-data-schema` 1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["version"]
 dependencies = [
     'aind-data-schema==1.0.0',
     'pydantic>=2.7',
-    'aind-data-schema-models==0.4.0',
+    'aind-data-schema-models>=0.4.0',
     'backports-datetime-fromisoformat==2.0.1'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,9 @@ readme = "README.md"
 dynamic = ["version"]
 
 dependencies = [
-    'aind-data-schema==0.38.6',
-    'pydantic<2.7',
+    'aind-data-schema==1.0.0',
+    'pydantic>=2.7',
+    'aind-data-schema-models==0.4.0',
     'backports-datetime-fromisoformat==2.0.1'
 ]
 

--- a/src/aind_metadata_upgrader/base_upgrade.py
+++ b/src/aind_metadata_upgrader/base_upgrade.py
@@ -21,7 +21,7 @@ class BaseModelUpgrade(ABC):
         model_class : Type[AindModel]
             The class of the model
         """
-        if type(old_model) == model_class:
+        if isinstance(old_model, model_class):
             self.old_model_dict = old_model.model_dump()
         else:
             self.old_model_dict = old_model
@@ -49,8 +49,8 @@ class BaseModelUpgrade(ABC):
         """
         if kwargs.get(field_name) is not None:
             return kwargs.get(field_name)
-        
-        elif type(model) == dict and field_name in model.keys() and model.get(field_name) is not None:
+
+        elif isinstance(model, dict) and field_name in model.keys() and model.get(field_name) is not None:
             return model.get(field_name)
         else:
             try:

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -109,7 +109,7 @@ class FundingUpgrade:
         Organization.AIBS: Organization.AI,
         "NINMH": Organization.NIMH,
         "NIMH": Organization.NIMH,
-        "PGA": Organization.AI
+        "PGA": Organization.AI,
     }
 
     @classmethod

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -61,7 +61,7 @@ class ModalityUpgrade:
             return Modality.from_abbreviation(old_modality)
         elif type(old_modality) is dict and old_modality.get("abbreviation") is not None:
             return Modality.from_abbreviation(old_modality["abbreviation"])
-        elif type(old_modality) in Modality._ALL:
+        elif type(old_modality) in Modality.ALL:
             return old_modality
         else:
             return None
@@ -180,24 +180,24 @@ class InvestigatorsUpgrade:
 class DataDescriptionUpgrade(BaseModelUpgrade):
     """Handle upgrades for DataDescription class"""
 
-    def __init__(self, old_data_description_model: DataDescription, allow_validation_errors=False):
+    def __init__(self, old_data_description_dict: Union[dict, AindModel], allow_validation_errors=False):
         """
         Handle mapping of old DataDescription models into current models
         Parameters
         ----------
-        old_data_description_model : DataDescription
+        old_data_description_dict : DataDescription
         """
 
         MonkeyPatch.patch_fromisoformat()
 
         super().__init__(
-            old_data_description_model, model_class=DataDescription, allow_validation_errors=allow_validation_errors
+            old_data_description_dict, model_class=DataDescription, allow_validation_errors=allow_validation_errors
         )
 
     def get_modality(self, **kwargs):
         """Get modality from old model"""
 
-        old_modality: Any = self.old_model.modality
+        old_modality: Any = self.old_model_dict.get("modality")
         if kwargs.get("modality") is not None:
             modality = kwargs["modality"]
         elif type(old_modality) is str or type(old_modality) is dict:
@@ -212,9 +212,9 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
     def get_creation_time(self, **kwargs):
         """Get creation time from old model"""
 
-        creation_date = self._get_or_default(self.old_model, "creation_date", kwargs)
-        creation_time = self._get_or_default(self.old_model, "creation_time", kwargs)
-        old_name = self._get_or_default(self.old_model, "name", kwargs)
+        creation_date = self._get_or_default(self.old_model_dict, "creation_date", kwargs)
+        creation_time = self._get_or_default(self.old_model_dict, "creation_time", kwargs)
+        old_name = self._get_or_default(self.old_model_dict, "name", kwargs)
         if creation_time:
             if creation_date:
                 creation_time = datetime.fromisoformat(f"{creation_date}T{creation_time}")
@@ -227,58 +227,58 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
     def upgrade(self, **kwargs) -> AindModel:
         """Upgrades the old model into the current version"""
 
-        version = semver.Version.parse(self._get_or_default(self.old_model, "schema_version", kwargs))
+        version = semver.Version.parse(self._get_or_default(self.old_model_dict, "schema_version", kwargs))
 
         institution = InstitutionUpgrade.upgrade_institution(
-            self._get_or_default(self.old_model, "institution", kwargs)
+            self._get_or_default(self.old_model_dict, "institution", kwargs)
         )
 
-        funding_source = self._get_or_default(self.old_model, "funding_source", kwargs)
+        funding_source = self._get_or_default(self.old_model_dict, "funding_source", kwargs)
 
         funding_source = FundingUpgrade.upgrade_funding_source(funding_source=funding_source)
 
         modality = self.get_modality(**kwargs)
 
-        data_level = self._get_or_default(self.old_model, "data_level", kwargs)
+        data_level = self._get_or_default(self.old_model_dict, "data_level", kwargs)
         if data_level in ["raw level", "raw data"]:
             data_level = DataLevel.RAW
         if data_level in ["derived level", "derived data"]:
             data_level = DataLevel.DERIVED
 
-        experiment_type = self._get_or_default(self.old_model, "experiment_type", kwargs)
+        experiment_type = self._get_or_default(self.old_model_dict, "experiment_type", kwargs)
         platform = None
         if experiment_type is not None:
-            for p in Platform._ALL:
+            for p in Platform.ALL:
                 if p().abbreviation == experiment_type:
                     platform = p()
                     break
 
         if platform is None:
-            platform = self._get_or_default(self.old_model, "platform", kwargs)
+            platform = self._get_or_default(self.old_model_dict, "platform", kwargs)
             if platform is None and version <= "0.8.0":
                 if type(modality) is list:
                     platform = PlatformUpgrade.from_modality(modality[0])
 
-        investigators = self._get_or_default(self.old_model, "investigators", kwargs)
+        investigators = self._get_or_default(self.old_model_dict, "investigators", kwargs)
         investigators = InvestigatorsUpgrade.upgrade_investigators(investigators)
 
         creation_time = self.get_creation_time(**kwargs)
 
         data_desc_dict = {
             "creation_time": creation_time,
-            "name": self._get_or_default(self.old_model, "name", kwargs),
+            "name": self._get_or_default(self.old_model_dict, "name", kwargs),
             "institution": institution,
             "funding_source": funding_source,
             "data_level": data_level,
-            "group": self._get_or_default(self.old_model, "group", kwargs),
+            "group": self._get_or_default(self.old_model_dict, "group", kwargs),
             "investigators": investigators,
-            "project_name": self._get_or_default(self.old_model, "project_name", kwargs),
-            "restrictions": self._get_or_default(self.old_model, "restrictions", kwargs),
+            "project_name": self._get_or_default(self.old_model_dict, "project_name", kwargs),
+            "restrictions": self._get_or_default(self.old_model_dict, "restrictions", kwargs),
             "modality": modality,
             "platform": platform,
-            "subject_id": self._get_or_default(self.old_model, "subject_id", kwargs),
-            "related_data": self._get_or_default(self.old_model, "related_data", kwargs),
-            "data_summary": self._get_or_default(self.old_model, "data_summary", kwargs),
+            "subject_id": self._get_or_default(self.old_model_dict, "subject_id", kwargs),
+            "related_data": self._get_or_default(self.old_model_dict, "related_data", kwargs),
+            "data_summary": self._get_or_default(self.old_model_dict, "data_summary", kwargs),
         }
 
         return construct_new_model(data_desc_dict, DataDescription, self.allow_validation_errors)

--- a/src/aind_metadata_upgrader/procedures_upgrade.py
+++ b/src/aind_metadata_upgrader/procedures_upgrade.py
@@ -337,13 +337,12 @@ class ProcedureUpgrade(BaseModelUpgrade):
     def upgrade_procedure(self) -> Optional[Procedures]:
         """Map legacy Procedure model to current version"""
 
-        if semver.Version.parse(self._get_or_default(self.old_model_dict, "schema_version", {})) <= semver.Version.parse(
-            "0.11.0"
-        ):
+        if semver.Version.parse(
+            self._get_or_default(self.old_model_dict, "schema_version", {})
+        ) <= semver.Version.parse("0.11.0"):
             subj_id = self.old_model_dict.get("subject_id")
 
             loaded_subject_procedures = {}
-            logging.info(f"Upgrading procedures {type(self.old_model_dict.get("subject_procedures"))}")
 
             for subj_procedure in self.old_model_dict.get("subject_procedures"):  # type: dict
 

--- a/src/aind_metadata_upgrader/processing_upgrade.py
+++ b/src/aind_metadata_upgrader/processing_upgrade.py
@@ -1,15 +1,17 @@
 """Module to contain code to upgrade old processing models"""
 
+from typing import Union
+
 from aind_data_schema.base import AindModel
 from aind_data_schema.core.processing import (
     DataProcess,
     PipelineProcess,
     Processing,
 )
-from typing import Union
-from aind_metadata_upgrader.utils import construct_new_model
 
 from aind_metadata_upgrader.base_upgrade import BaseModelUpgrade
+from aind_metadata_upgrader.utils import construct_new_model
+
 
 class DataProcessUpgrade(BaseModelUpgrade):
     """Handle upgrades for DataProcess class"""
@@ -69,10 +71,7 @@ class ProcessingUpgrade(BaseModelUpgrade):
 
             if data_processes is not None:
                 # upgrade data processes
-                data_processes_new = [
-                    DataProcessUpgrade(data_process).upgrade()
-                    for data_process in data_processes
-                ]
+                data_processes_new = [DataProcessUpgrade(data_process).upgrade() for data_process in data_processes]
                 processor_full_name = kwargs.get("processor_full_name")
                 processing_pipeline = PipelineProcess(
                     pipeline_version=pipeline_version,

--- a/src/aind_metadata_upgrader/processing_upgrade.py
+++ b/src/aind_metadata_upgrader/processing_upgrade.py
@@ -6,40 +6,42 @@ from aind_data_schema.core.processing import (
     PipelineProcess,
     Processing,
 )
+from typing import Union
+from aind_metadata_upgrader.utils import construct_new_model
 
 from aind_metadata_upgrader.base_upgrade import BaseModelUpgrade
-
 
 class DataProcessUpgrade(BaseModelUpgrade):
     """Handle upgrades for DataProcess class"""
 
-    def __init__(self, old_data_process_model: DataProcess):
+    def __init__(self, old_data_process_dict: Union[dict, DataProcess]):
         """
         Handle mapping of old DataProcess models into current models
 
         Parameters
         ----------
-        old_data_process_model : DataProcess
+        old_data_process_dict : dict
         """
-        super().__init__(old_model=old_data_process_model, model_class=DataProcess)
+        super().__init__(old_model=old_data_process_dict, model_class=DataProcess)
 
     def upgrade(self, **kwargs) -> AindModel:
         """Upgrades the old model into the current version"""
-        version = self._get_or_default(self.old_model, "version", kwargs)
-        software_version = self._get_or_default(self.old_model, "software_version", kwargs)
+        version = self._get_or_default(self.old_model_dict, "version", kwargs)
+        software_version = self._get_or_default(self.old_model_dict, "software_version", kwargs)
         if version is not None and software_version is None:
-            self.old_model.software_version = version
+            self.old_model_dict["software_version"] = version
+            del self.old_model_dict["version"]
         # Empty notes with 'Other' name is not allowed in the new schema
-        name = self._get_or_default(self.old_model, "name", kwargs)
-        notes = self._get_or_default(self.old_model, "notes", kwargs)
-        outputs = self._get_or_default(self.old_model, "outputs", kwargs)
+        name = self._get_or_default(self.old_model_dict, "name", kwargs)
+        notes = self._get_or_default(self.old_model_dict, "notes", kwargs)
+        outputs = self._get_or_default(self.old_model_dict, "outputs", kwargs)
 
         if name == "Other" and notes is None:
-            self.old_model.notes = "missing notes"
+            self.old_model_dict["notes"] = "missing notes"
         # this takes care of setting the outputs to an empty dict (default) if it is None
-        self.old_model.outputs = outputs
+        self.old_model_dict["outputs"] = outputs
 
-        return self.old_model
+        return construct_new_model(self.old_model_dict, DataProcess, self.allow_validation_errors)
 
 
 class ProcessingUpgrade(BaseModelUpgrade):
@@ -59,11 +61,11 @@ class ProcessingUpgrade(BaseModelUpgrade):
     def upgrade(self, **kwargs) -> AindModel:
         """Upgrades the old model into the current version"""
         # old versions of the schema (<0.3.0) had data_processes directly
-        schema_version = self.old_model.schema_version
+        schema_version = self.old_model_dict.get("schema_version")
         if schema_version is None or schema_version < "0.3.0":
-            data_processes = self._get_or_default(self.old_model, "data_processes", kwargs)
-            pipeline_version = self._get_or_default(self.old_model, "pipeline_version", kwargs)
-            pipeline_url = self._get_or_default(self.old_model, "pipeline_version", kwargs)
+            data_processes = self._get_or_default(self.old_model_dict, "data_processes", kwargs)
+            pipeline_version = self._get_or_default(self.old_model_dict, "pipeline_version", kwargs)
+            pipeline_url = self._get_or_default(self.old_model_dict, "pipeline_version", kwargs)
 
             if data_processes is not None:
                 # upgrade data processes
@@ -79,7 +81,7 @@ class ProcessingUpgrade(BaseModelUpgrade):
                     processor_full_name=processor_full_name,
                 )
         else:
-            processing_pipeline = self._get_or_default(self.old_model, "processing_pipeline", kwargs)
+            processing_pipeline = self._get_or_default(self.old_model_dict, "processing_pipeline", kwargs)
             # upgrade data processes
             data_processes_new = []
             if isinstance(processing_pipeline, PipelineProcess):
@@ -95,6 +97,6 @@ class ProcessingUpgrade(BaseModelUpgrade):
 
         return Processing(
             processing_pipeline=processing_pipeline,
-            analyses=self._get_or_default(self.old_model, "analyses", kwargs),
-            notes=self._get_or_default(self.old_model, "notes", kwargs),
+            analyses=self._get_or_default(self.old_model_dict, "analyses", kwargs),
+            notes=self._get_or_default(self.old_model_dict, "notes", kwargs),
         )

--- a/src/aind_metadata_upgrader/processing_upgrade.py
+++ b/src/aind_metadata_upgrader/processing_upgrade.py
@@ -70,7 +70,7 @@ class ProcessingUpgrade(BaseModelUpgrade):
             if data_processes is not None:
                 # upgrade data processes
                 data_processes_new = [
-                    DataProcessUpgrade(DataProcess.model_construct(**data_process)).upgrade()
+                    DataProcessUpgrade(data_process).upgrade()
                     for data_process in data_processes
                 ]
                 processor_full_name = kwargs.get("processor_full_name")
@@ -84,12 +84,8 @@ class ProcessingUpgrade(BaseModelUpgrade):
             processing_pipeline = self._get_or_default(self.old_model_dict, "processing_pipeline", kwargs)
             # upgrade data processes
             data_processes_new = []
-            if isinstance(processing_pipeline, PipelineProcess):
-                data_processes_old = processing_pipeline.data_processes
-                processing_pipeline_dict = processing_pipeline.model_dump()
-            else:
-                data_processes_old = processing_pipeline["data_processes"]
-                processing_pipeline_dict = processing_pipeline
+            data_processes_old = processing_pipeline["data_processes"]
+            processing_pipeline_dict = processing_pipeline
             for data_process in data_processes_old:
                 data_processes_new.append(DataProcessUpgrade(data_process).upgrade())
             processing_pipeline_dict.pop("data_processes")

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -130,9 +130,6 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/enum"
         )
 
-        print("error: ", repr(e2.exception))
-        print("expec: ", expected_error_message2)
-
         self.assertEqual(expected_error_message2, repr(e2.exception))
 
         # Should work if data_level is missing in original json doc and
@@ -444,8 +441,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             expected_error_message,
             repr(e.exception),
         )
-        print("error2: ", repr(e.exception))
-        print("expec2: ", expected_error_message)
+
         # this no longer throws the expected exception
         self.assertEqual(DataLevel.RAW, d1.data_level)
         self.assertEqual(DataLevel.RAW, d2.data_level)

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -7,6 +7,7 @@ import re
 import unittest
 from pathlib import Path
 from typing import List
+import copy
 
 from aind_data_schema.core.data_description import (
     DataDescription,
@@ -47,13 +48,13 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         for file_path in data_description_files:
             with open(DATA_DESCRIPTION_FILES_PATH / file_path) as f:
                 contents = json.load(f)
-            data_descriptions.append((file_path, DataDescription.model_construct(**contents)))
+            data_descriptions.append((file_path,contents))
         cls.data_descriptions = dict(data_descriptions)
 
     def test_upgrades_0_3_0(self):
         """Tests data_description_0.3.0.json is mapped correctly."""
         data_description_0_3_0 = self.data_descriptions["data_description_0.3.0.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_3_0)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_3_0)
 
         new_data_description = upgrader.upgrade()
         self.assertEqual(
@@ -79,7 +80,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     def test_upgrades_0_3_0_wrong_field(self):
         """Tests data_description_0.3.0_wrong_field.json is mapped correctly."""
         data_description_0_3_0 = self.data_descriptions["data_description_0.3.0_wrong_field.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_3_0)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_3_0)
 
         new_data_description = upgrader.upgrade()
         self.assertEqual(
@@ -113,7 +114,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         expected_error_message1 = (
             "1 validation error for DataDescription\n"
             "data_level\n"
-            "  Input should be 'derived', 'raw' or 'simulated' [type=enum, input_value='asfnewnjfq', input_type=str]"
+            "  Input should be 'derived', 'raw' or 'simulated' [type=enum, input_value='asfnewnjfq', input_type=str]\n"
+            "    For further information visit https://errors.pydantic.dev/2.8/v/enum"
         )
 
         self.assertEqual(expected_error_message1, repr(e1.exception))
@@ -124,17 +126,20 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         expected_error_message2 = (
             "1 validation error for DataDescription\n"
             "data_level\n"
-            "  Input should be a valid string [type=string_type, input_value=['raw'], input_type=list]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_type"
+            "  Input should be 'derived', 'raw' or 'simulated' [type=enum, input_value=['raw'], input_type=list]\n"
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/enum"
         )
+
+        print("error: ", repr(e2.exception))
+        print("expec: ", expected_error_message2)
 
         self.assertEqual(expected_error_message2, repr(e2.exception))
 
         # Should work if data_level is missing in original json doc and
         # user sets it explicitly
-        data_description_copy = data_description_0_3_0.model_copy(deep=True)
-        del data_description_copy.data_level
-        upgrader3 = DataDescriptionUpgrade(old_data_description_model=data_description_copy)
+        data_description_copy = copy.deepcopy(data_description_0_3_0)
+        del data_description_copy["data_level"]
+        upgrader3 = DataDescriptionUpgrade(old_data_description_dict=data_description_copy)
         new_data_description3 = upgrader3.upgrade(platform=Platform.ECEPHYS, data_level=DataLevel.DERIVED)
         self.assertEqual(DataLevel.DERIVED, new_data_description3.data_level)
 
@@ -142,7 +147,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         """Tests upgrade with missing creation time"""
 
         data_description_0_3_0_missing_creation_time = self.data_descriptions["data_description_0.3.0_no_creation.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_3_0_missing_creation_time)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_3_0_missing_creation_time)
 
         new_data_description = upgrader.upgrade(platform=Platform.ECEPHYS, data_level=DataLevel.RAW)
 
@@ -151,7 +156,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     def test_upgrades_0_4_0(self):
         """Tests data_description_0.4.0.json is mapped correctly."""
         data_description_0_4_0 = self.data_descriptions["data_description_0.4.0.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_4_0)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_4_0)
 
         # Should work by setting platform explicitly
         new_data_description = upgrader.upgrade()
@@ -178,7 +183,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     def test_upgrades_0_6_0(self):
         """Tests data_description_0.6.0.json is mapped correctly."""
         data_description_0_6_0 = self.data_descriptions["data_description_0.6.0.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_0)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_6_0)
 
         # Should work by setting experiment type explicitly
         new_data_description = upgrader.upgrade()
@@ -205,7 +210,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     def test_upgrades_0_6_2(self):
         """Tests data_description_0.6.2.json is mapped correctly."""
         data_description_0_6_2 = self.data_descriptions["data_description_0.6.2.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_2)
+        data_description_0_6_2_copy = copy.deepcopy(data_description_0_6_2)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_6_2)
 
         # Should work by setting experiment type explicitly
         new_data_description = upgrader.upgrade()
@@ -250,9 +256,8 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         new_dd_0_6_2 = upgrader.upgrade(modality=[Modality.ECEPHYS])
         self.assertEqual([Modality.ECEPHYS], new_dd_0_6_2.modality)
         # Blank Modality
-        data_description_0_6_2_copy = data_description_0_6_2.model_copy(deep=True)
-        data_description_0_6_2_copy.modality = None
-        upgrader2 = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_2_copy)
+        data_description_0_6_2_copy["modality"] = None
+        upgrader2 = DataDescriptionUpgrade(old_data_description_dict=data_description_0_6_2_copy)
         with self.assertRaises(Exception) as e:
             upgrader2.upgrade()
 
@@ -262,7 +267,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     def test_upgrades_0_6_2_wrong_field(self):
         """Tests data_description_0.6.2_wrong_field.json is mapped correctly."""
         data_description_0_6_2_wrong_field = self.data_descriptions["data_description_0.6.2_wrong_field.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_2_wrong_field)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_6_2_wrong_field)
 
         # Should complain about funder not being correct
         with self.assertRaises(Exception) as e:
@@ -318,7 +323,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             "data_description_0.6.2_empty_investigators.json"
         ]
         upgrader = DataDescriptionUpgrade(
-            old_data_description_model=data_description_0_6_2_missing_investigators, allow_validation_errors=True
+            old_data_description_dict=data_description_0_6_2_missing_investigators, allow_validation_errors=True
         )
 
         new_data_description = upgrader.upgrade()
@@ -328,7 +333,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     def test_upgrades_0_10_0(self):
         """Tests data_description_0.10.0.json is mapped correctly."""
         data_description_0_10_0 = self.data_descriptions["data_description_0.10.0.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_10_0)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_10_0)
 
         # Should work by setting experiment type explicitly
         new_data_description = upgrader.upgrade()
@@ -356,7 +361,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     def test_upgrades_0_11_0_wrong_funding(self):
         """Tests data_description_0.11.0.json is mapped correctly."""
         data_description_0_11_0 = self.data_descriptions["data_description_0.11.0_wrong_funder.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_11_0)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_11_0)
 
         new_data_description = upgrader.upgrade()
         # AIND should be set to AI by upgrader
@@ -385,7 +390,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         """Tests that strings which include a Z timezone are upgraded correctly"""
 
         data_description_0_13_8 = self.data_descriptions["data_description_0.13.8_parse_time.json"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_13_8)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_13_8)
 
         new_data_description = upgrader.upgrade()
 
@@ -431,13 +436,16 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
                 funding_source=[Funding(funder=Organization.NINDS, grant_number="grant001")],
                 investigators=[PIDName(name="Jane Smith")],
             )
-        self.assertEqual(
-            "1 validation error for DataDescription\n"
+        expected_error_message = ("1 validation error for DataDescription\n"
             "data_level\n"
-            "  Input should be a valid string [type=string_type, input_value=[2, 3], input_type=list]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/string_type",
+            "  Input should be 'derived', 'raw' or 'simulated' [type=enum, input_value=[2, 3], input_type=list]\n"
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/enum")
+        self.assertEqual(
+            expected_error_message,
             repr(e.exception),
         )
+        print("error2: ", repr(e.exception))
+        print("expec2: ", expected_error_message)
         # this no longer throws the expected exception
         self.assertEqual(DataLevel.RAW, d1.data_level)
         self.assertEqual(DataLevel.RAW, d2.data_level)
@@ -445,7 +453,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
     # def test_edge_cases(self):
     #     """Tests a few edge cases"""
     #     data_description_0_6_2 = deepcopy(self.data_descriptions["data_description_0.6.2.json"])
-    #     upgrader = DataDescriptionUpgrade(old_data_description_model=data_description_0_6_2)
+    #     upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_6_2)
     #     new_dd_0_6_2 = upgrader.upgrade(modality=[Modality.ECEPHYS])
     #     self.assertEqual([Modality.ECEPHYS], new_dd_0_6_2.modality)
 
@@ -486,8 +494,7 @@ class TestModalityUpgrade(unittest.TestCase):
             "subject_id": "623711",
             "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
         }
-        dd = DataDescription.model_construct(**dd_dict)
-        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=dd_dict)
         upgrader.upgrade()
 
 
@@ -519,8 +526,7 @@ class TestPlatformUpgrade(unittest.TestCase):
             "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
         }
 
-        dd = DataDescription.model_construct(**dd_dict)
-        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=dd_dict)
         upgrader.upgrade()
 
     def test_platform_lookup(self):
@@ -546,8 +552,7 @@ class TestPlatformUpgrade(unittest.TestCase):
             "subject_id": "623711",
             "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
         }
-        dd = DataDescription.model_construct(**dd_dict)
-        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=dd_dict)
         upgrader.upgrade()
 
 
@@ -622,20 +627,19 @@ class TestFundingUpgrade(unittest.TestCase):
             "subject_id": "623711",
             "input_data_name": "SmartSPIM_623711_2022-10-27_16-48-54",
         }
-        dd = DataDescription.model_construct(**dd_dict)
-        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=dd_dict)
         upgrader.upgrade()
 
-        self.assertEqual(dd.funding_source, [Funding(funder=Organization.AI).model_dump()])
+        self.assertEqual(dd_dict["funding_source"], [Funding(funder=Organization.AI).model_dump()])
 
-        dd.funding_source = [{"funder": Organization.AIND, "grant_number": None, "fundee": None}]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        dd_dict["funding_source"] = [{"funder": Organization.AIND, "grant_number": None, "fundee": None}]
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=dd_dict)
         dd2 = upgrader.upgrade()
 
         self.assertEqual(dd2.funding_source, [Funding(funder=Organization.AI)])
 
-        dd.funding_source = ["Allen Institute for Neural Dynamics"]
-        upgrader = DataDescriptionUpgrade(old_data_description_model=dd)
+        dd_dict["funding_source"] = ["Allen Institute for Neural Dynamics"]
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=dd_dict)
         dd3 = upgrader.upgrade()
 
         self.assertEqual(dd3.funding_source, [Funding(funder=Organization.AI)])

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -115,7 +115,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
             "1 validation error for DataDescription\n"
             "data_level\n"
             "  Input should be 'derived', 'raw' or 'simulated' [type=enum, input_value='asfnewnjfq', input_type=str]\n"
-            "    For further information visit https://errors.pydantic.dev/2.8/v/enum"
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/enum"
         )
 
         self.assertEqual(expected_error_message1, repr(e1.exception))

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -1,5 +1,6 @@
 """Tests methods for upgrading DataDescriptions"""
 
+import copy
 import datetime
 import json
 import os
@@ -7,7 +8,6 @@ import re
 import unittest
 from pathlib import Path
 from typing import List
-import copy
 
 from aind_data_schema.core.data_description import (
     DataDescription,
@@ -48,7 +48,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         for file_path in data_description_files:
             with open(DATA_DESCRIPTION_FILES_PATH / file_path) as f:
                 contents = json.load(f)
-            data_descriptions.append((file_path,contents))
+            data_descriptions.append((file_path, contents))
         cls.data_descriptions = dict(data_descriptions)
 
     def test_upgrades_0_3_0(self):
@@ -433,10 +433,12 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
                 funding_source=[Funding(funder=Organization.NINDS, grant_number="grant001")],
                 investigators=[PIDName(name="Jane Smith")],
             )
-        expected_error_message = ("1 validation error for DataDescription\n"
+        expected_error_message = (
+            "1 validation error for DataDescription\n"
             "data_level\n"
             "  Input should be 'derived', 'raw' or 'simulated' [type=enum, input_value=[2, 3], input_type=list]\n"
-            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/enum")
+            f"    For further information visit https://errors.pydantic.dev/{PYD_VERSION}/v/enum"
+        )
         self.assertEqual(
             expected_error_message,
             repr(e.exception),

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -7,6 +7,8 @@ import re
 import unittest
 from pathlib import Path
 from typing import List
+import traceback
+import sys
 
 from aind_data_schema.base import AindGeneric
 from aind_data_schema.core.processing import (
@@ -38,7 +40,7 @@ class TestProcessingUpgrade(unittest.TestCase):
         for file_path in processing_files:
             with open(PROCESSING_FILES_PATH / file_path) as f:
                 contents = json.load(f)
-            processings.append((file_path, Processing.model_construct(**contents)))
+            processings.append((file_path, contents))
         cls.processings = dict(processings)
 
     def test_upgrades_0_0_1(self):
@@ -135,6 +137,7 @@ class TestProcessingUpgrade(unittest.TestCase):
         with self.assertRaises(Exception) as e:
             upgrader.upgrade()
 
+
         expected_error_message = (
             "1 validation error for PipelineProcess\n"
             "processor_full_name\n"
@@ -224,9 +227,7 @@ class TestDataProcessUpgrade(unittest.TestCase):
             output_location="my-output-location",
             parameters={"param1": "value1"},
         )
-        old_data_process = DataProcess.model_construct(**old_data_process_dict)
-
-        upgrader = DataProcessUpgrade(old_data_process_model=old_data_process)
+        upgrader = DataProcessUpgrade(old_data_process_dict=old_data_process_dict)
         new_data_process = upgrader.upgrade()
 
         # the upgrader updates version to software_version
@@ -243,9 +244,9 @@ class TestDataProcessUpgrade(unittest.TestCase):
         processing_path = PROCESSING_FILES_PATH / "processing_other_no_notes.json"
         with open(processing_path, "r") as f:
             processing_dict = json.load(f)
-        data_process_no_notes = DataProcess.model_construct(**processing_dict["data_processes"][1])
+        data_process_no_notes_dict = processing_dict["data_processes"][1]
 
-        upgrader = DataProcessUpgrade(data_process_no_notes)
+        upgrader = DataProcessUpgrade(data_process_no_notes_dict)
         new_data_process = upgrader.upgrade()
 
         # the upgrader updates version to software_version
@@ -270,9 +271,8 @@ class TestDataProcessUpgrade(unittest.TestCase):
             output_location="my-output-location",
             parameters={"param1": "value1"},
         )
-        data_process = DataProcess(**data_process_dict)
 
-        upgrader = DataProcessUpgrade(old_data_process_model=data_process)
+        upgrader = DataProcessUpgrade(old_data_process_dict=data_process_dict)
         new_data_process = upgrader.upgrade()
 
         # the upgrader updates version to software_version

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4,13 +4,11 @@ import datetime
 import json
 import os
 import re
-import sys
-import traceback
 import unittest
 from pathlib import Path
 from typing import List
 
-from aind_data_schema.base import AindGeneric, AwareDatetimeWithDefault
+from aind_data_schema.base import AindGeneric
 from aind_data_schema.core.processing import (
     DataProcess,
     PipelineProcess,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -4,13 +4,13 @@ import datetime
 import json
 import os
 import re
+import sys
+import traceback
 import unittest
 from pathlib import Path
 from typing import List
-import traceback
-import sys
 
-from aind_data_schema.base import AindGeneric
+from aind_data_schema.base import AindGeneric, AwareDatetimeWithDefault
 from aind_data_schema.core.processing import (
     DataProcess,
     PipelineProcess,
@@ -22,8 +22,6 @@ from aind_metadata_upgrader.processing_upgrade import (
     DataProcessUpgrade,
     ProcessingUpgrade,
 )
-
-from aind_data_schema.base import AwareDatetimeWithDefault
 
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
@@ -140,7 +138,6 @@ class TestProcessingUpgrade(unittest.TestCase):
         with self.assertRaises(Exception) as e:
             upgrader.upgrade()
 
-
         expected_error_message = (
             "1 validation error for PipelineProcess\n"
             "processor_full_name\n"
@@ -221,7 +218,7 @@ class TestDataProcessUpgrade(unittest.TestCase):
         """Tests data process from old model is upgraded correctly."""
         start_date_time = datetime.datetime.fromisoformat("2023-02-22T18:16:35.919299+00:00")
         end_date_time = datetime.datetime.fromisoformat("2023-02-22T18:41:06.929027+00:00")
-    
+
         old_data_process_dict = dict(
             name="Ephys preprocessing",
             version="0.1.5",


### PR DESCRIPTION
close #49 

Upgrades the pins on this repo to support `aind-data-schema` version `1.0.0`. 

Also upgrades `Pydantic` pin to `>= 2.7`, which caused some issues with the usage of `construct_model`. This led to converting all Upgraders to intake a dict, rather than a model. Functionality has not otherwise changed.