### PR TITLE
new keys for `modality` upgrader

### DIFF
--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -38,6 +38,11 @@ class ModalityUpgrade:
         "mesospim": Modality.SPIM,
         "single-plane-ophys": Modality.POPHYS,
         "multiplane-ophys": Modality.POPHYS,
+        "hsfp": Modality.FIB,
+        "fip": Modality.FIB,
+        "trained-behaviors": Modality.BEHAVIOR,
+        "diSPIM": Modality.SPIM,
+        "multiplane-ophys": Modality.POPHYS,
     }
 
     @classmethod

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -42,6 +42,11 @@ class ModalityUpgrade:
     }
 
     @classmethod
+    def map_modality(cls, old_modality_string) -> Optional[Modality]:
+        """Map old modality string to new modality model"""
+        return cls.legacy_name_mapping.get(old_modality_string.lower())
+
+    @classmethod
     def upgrade_modality(cls, old_modality: Union[str, dict, Modality, None]) -> Optional[Modality]:
         """
         Converts old modality models into the current model.
@@ -57,11 +62,14 @@ class ModalityUpgrade:
 
         """
         if type(old_modality) is str and cls.legacy_name_mapping.get(old_modality.lower()) is not None:
-            return cls.legacy_name_mapping[old_modality.lower()]
+            return cls.map_modality(old_modality)
         elif type(old_modality) is str:
             return Modality.from_abbreviation(old_modality)
         elif type(old_modality) is dict and old_modality.get("abbreviation") is not None:
-            return Modality.from_abbreviation(old_modality["abbreviation"])
+            if old_modality["abbreviation"].lower() in cls.legacy_name_mapping.keys():
+                return cls.map_modality(old_modality["abbreviation"])
+            else:
+                return Modality.from_abbreviation(old_modality["abbreviation"])
         elif type(old_modality) in Modality.ALL:
             return old_modality
         else:

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -38,11 +38,7 @@ class ModalityUpgrade:
         "mesospim": Modality.SPIM,
         "single-plane-ophys": Modality.POPHYS,
         "multiplane-ophys": Modality.POPHYS,
-        "hsfp": Modality.FIB,
-        "fip": Modality.FIB,
         "trained-behaviors": Modality.BEHAVIOR,
-        "diSPIM": Modality.SPIM,
-        "multiplane-ophys": Modality.POPHYS,
     }
 
     @classmethod

--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -42,11 +42,6 @@ class ModalityUpgrade:
     }
 
     @classmethod
-    def map_modality(cls, old_modality_string) -> Optional[Modality]:
-        """Map old modality string to new modality model"""
-        return cls.legacy_name_mapping.get(old_modality_string.lower())
-
-    @classmethod
     def upgrade_modality(cls, old_modality: Union[str, dict, Modality, None]) -> Optional[Modality]:
         """
         Converts old modality models into the current model.
@@ -62,14 +57,12 @@ class ModalityUpgrade:
 
         """
         if type(old_modality) is str and cls.legacy_name_mapping.get(old_modality.lower()) is not None:
-            return cls.map_modality(old_modality)
+            return cls.legacy_name_mapping[old_modality.lower()]
         elif type(old_modality) is str:
             return Modality.from_abbreviation(old_modality)
         elif type(old_modality) is dict and old_modality.get("abbreviation") is not None:
-            if old_modality["abbreviation"].lower() in cls.legacy_name_mapping.keys():
-                return cls.map_modality(old_modality["abbreviation"])
-            else:
-                return Modality.from_abbreviation(old_modality["abbreviation"])
+            legacy_mapping = cls.legacy_name_mapping.get(old_modality['abbreviation'].lower(), None)
+            return legacy_mapping or Modality.from_abbreviation(old_modality["abbreviation"])
         elif type(old_modality) in Modality.ALL:
             return old_modality
         else:

--- a/tests/resources/ephys_data_description/data_description_0_6_0_outdated_modality.json
+++ b/tests/resources/ephys_data_description/data_description_0_6_0_outdated_modality.json
@@ -1,0 +1,36 @@
+{
+  "creation_date": "2023-08-25",
+  "creation_time": "11:53:30",
+  "data_level": "raw data",
+  "data_summary": null,
+  "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/data_description.py",
+  "experiment_type": "FIP",
+  "funding_source": [
+    {
+      "fundee": null,
+      "funder": "AIND",
+      "grant_number": null
+    }
+  ],
+  "group": null,
+  "institution": {
+    "abbreviation": "AIND",
+    "name": "Allen Institute for Neural Dynamics"
+  },
+  "investigators": ["fake guy"],
+  "license": "CC-BY-4.0",
+  "modality": [
+    {
+      "abbreviation": "FIP",
+      "name": "Frame-projected independent-fiber photometry"
+    }
+  ],
+  "name": "FIP_684849_2023-08-25_11-53-30",
+  "project_id": null,
+  "project_name": null,
+  "related_data": [],
+  "restrictions": null,
+  "ror_id": null,
+  "schema_version": "0.6.0",
+  "subject_id": "684849"
+}

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -205,6 +205,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         self.assertIsNone(new_data_description.data_summary)
 
     def test_upgrades_0_6_0_outdated_modality(self):
+        """Tests data_description_0.6.0_outdated_modality.json is mapped correctly."""
         data_description_0_6_0 = self.data_descriptions["data_description_0_6_0_outdated_modality.json"]
         upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_6_0)
         new_data_description = upgrader.upgrade()

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -204,6 +204,13 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         self.assertEqual([], new_data_description.related_data)
         self.assertIsNone(new_data_description.data_summary)
 
+    def test_upgrades_0_6_0_outdated_modality(self):
+        data_description_0_6_0 = self.data_descriptions["data_description_0_6_0_outdated_modality.json"]
+        upgrader = DataDescriptionUpgrade(old_data_description_dict=data_description_0_6_0)
+        new_data_description = upgrader.upgrade()
+
+        self.assertEqual(new_data_description.modality, [Modality.FIB])
+
     def test_upgrades_0_6_2(self):
         """Tests data_description_0.6.2.json is mapped correctly."""
         data_description_0_6_2 = self.data_descriptions["data_description_0.6.2.json"]


### PR DESCRIPTION
closes #47 

Adding some new Modality maps to the `ModalityUpgrade` class.

`trained-behaviors` -> `behavior`

Fixing a bug in which values that do not exist in the `Modality.abbreviation_map` were being passed to it, causing upgrade failure. Fix runs value through `ModalityUpgrade.legacy_name_mapping` before attempting to pass it through the `abbreviation_map`. This could be changed to try passing through the `abbreviation_map` and then only attempt the `legacy_name_mapping` if that fails.