### PR TITLE
cleaning up paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 
 dependencies = [
     'aind-data-schema==1.0.0',
-    'pydantic>=2.7',
+    'pydantic>=2.7,<2.9',
     'aind-data-schema-models>=0.4.0',
     'backports-datetime-fromisoformat==2.0.1'
 ]

--- a/tests/test_data_description.py
+++ b/tests/test_data_description.py
@@ -108,7 +108,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         self.assertEqual(DataLevel.RAW, new_data_description2.data_level)
 
         # Should fail if inputting unknown string
-        with self.assertRaises(Exception) as e1:
+        with self.assertRaises(ValidationError) as e1:
             upgrader.upgrade(platform=Platform.ECEPHYS, data_level="asfnewnjfq")
 
         expected_error_message1 = (
@@ -121,7 +121,7 @@ class TestDataDescriptionUpgrade(unittest.TestCase):
         self.assertEqual(expected_error_message1, repr(e1.exception))
 
         # Should also fail if inputting wrong type
-        with self.assertRaises(Exception) as e2:
+        with self.assertRaises(ValidationError) as e2:
             upgrader.upgrade(platform=Platform.ECEPHYS, data_level=["raw"])
         expected_error_message2 = (
             "1 validation error for DataDescription\n"

--- a/tests/test_procedures.py
+++ b/tests/test_procedures.py
@@ -17,7 +17,7 @@ from aind_metadata_upgrader.procedures_upgrade import ProcedureUpgrade
 
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
-PROCESSING_FILES_PATH = Path(__file__).parent / "resources" / "procedures" / "class_model_examples"
+PROCEDURES_FILES_PATH = Path(__file__).parent / "resources" / "procedures" / "class_model_examples"
 PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
 
 log_file_name = "./tests/resources/procedures/log_files/log_" + datetime.now().strftime("%Y%m%d_%H%M%S") + ".log"
@@ -43,11 +43,11 @@ class TestProceduresUpgrade(unittest.TestCase):
 
         logging.info("BEGIN ERROR TESTING")
 
-        procedure_files: List[str] = os.listdir(PROCESSING_FILES_PATH)
+        procedure_files: List[str] = os.listdir(PROCEDURES_FILES_PATH)
         procedures = []
 
         for file in procedure_files:
-            with open(PROCESSING_FILES_PATH / file, "r") as f:
+            with open(PROCEDURES_FILES_PATH / file, "r") as f:
                 contents = json.load(f)
             procedures.append((file, contents))
         cls.procedures = dict(procedures)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,11 @@
 """ tests for Processing upgrades """
 
-import re
 import unittest
-from pathlib import Path
 
 from aind_data_schema.base import AindModel
-from pydantic import __version__ as pyd_version
 
 from aind_metadata_upgrader.utils import get_or_default
+
 
 class TestUtils(unittest.TestCase):
     """Class for testing utilities."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,12 +9,6 @@ from pydantic import __version__ as pyd_version
 
 from aind_metadata_upgrader.utils import get_or_default
 
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
-
-PROCESSING_FILES_PATH = Path(__file__).parent / "resources" / "ephys_processing"
-PYD_VERSION = re.match(r"(\d+.\d+).\d+", pyd_version).group(1)
-
-
 class TestUtils(unittest.TestCase):
     """Class for testing utilities."""
 


### PR DESCRIPTION
closes #53 

Changing the name of the resources path in `ProceduresUpgrader` to reflect that it is holding procedures and not processing files: `PROCESSING_FILES_PATH` -> `PROCEDURES_FILE_PATH`

Additionally, removes unused path and PYD version variables from `test_utils.py`.

EDIT: An issue arose with some test errors, updating the expected error to be a `ValidationError` rather than an `Exception`