### PR TITLE
remove noqa from DD upgrader

### DIFF
--- a/src/aind_metadata_upgrader/data_description_upgrade.py
+++ b/src/aind_metadata_upgrader/data_description_upgrade.py
@@ -247,7 +247,7 @@ class DataDescriptionUpgrade(BaseModelUpgrade):
             return DataLevel.DERIVED
         return data_level
 
-    def upgrade(self, **kwargs) -> AindModel:  # noqa: C901
+    def upgrade(self, **kwargs) -> AindModel:
         """Upgrades the old model into the current version"""
 
         version = semver.Version.parse(self._get_or_default(self.old_model_dict, "schema_version", kwargs))


### PR DESCRIPTION
closes #64 

Removed the `noqa` heading from a function. Adjusted function to no longer throw error.