### PR TITLE
fix: bug where original dataframe recods were getting dropped

### DIFF
--- a/src/aind_metadata_upgrader/sync.py
+++ b/src/aind_metadata_upgrader/sync.py
@@ -145,7 +145,7 @@ def check_skip_conditions(data_dict: dict, original_df: Optional[pd.DataFrame]) 
 
 
 def upload_to_rds(original_df: Optional[pd.DataFrame], upgrade_results: list[dict]):
-
+    """Upload upgrade results to RDS"""
     # Upload any remaining tracking data
     if upgrade_results:
         print(f"Uploading final batch of {len(upgrade_results)} tracking records to RDS")


### PR DESCRIPTION
This PR fixes an issue where if original records existed in redshift they would get dropped entirely when they didn't get upgraded. The fix merges the original records with any new ones that got caught by the upgrader and re-uploads that. This prevents a cycle where every other night the upgrader ends up getting unnecessarily re-run.