### PR TITLE
fix: ensure that upgraded_data contains a copy of the original data

### DIFF
--- a/src/aind_metadata_upgrader/upgrade.py
+++ b/src/aind_metadata_upgrader/upgrade.py
@@ -187,6 +187,7 @@ class Upgrade:
 
         print(f"Upgrading {core_file}:{original_schema_version} -> {upgraded_schema_version}")
 
+        upgraded_data = core_data.copy()
         if original_schema_version == upgraded_schema_version:
             print(f"No upgrade needed for {core_file} (version {original_schema_version})")
         else:

--- a/tests/records/v1/7f919e1b-3ba8-4ddf-9a3b-6767d86f686e.json
+++ b/tests/records/v1/7f919e1b-3ba8-4ddf-9a3b-6767d86f686e.json
@@ -1,0 +1,11412 @@
+{
+    "_id": "7f919e1b-3ba8-4ddf-9a3b-6767d86f686e",
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "schema_version": "1.1.1",
+    "name": "ecephys_800779_2025-09-26_12-57-44_sorted_2025-10-07_17-18-32",
+    "created": "2025-10-07T17:18:33Z",
+    "last_modified": "2025-10-13T17:12:29.841Z",
+    "location": "s3://codeocean-s3datasetsbucket-1u41qdg42ur9/895375ae-cd6f-4959-923e-d00afb1bdd70",
+    "metadata_status": "Invalid",
+    "external_links": {
+        "Code Ocean": [
+            "895375ae-cd6f-4959-923e-d00afb1bdd70"
+        ]
+    },
+    "subject": {
+        "alleles": [
+            {
+                "abbreviation": null,
+                "name": "Drd1<tm1(cre)Rpa>",
+                "registry": {
+                    "abbreviation": "MGI",
+                    "name": "Mouse Genome Informatics"
+                },
+                "registry_identifier": "3527153"
+            }
+        ],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Exp-ND-01-014-2414",
+            "maternal_genotype": "Ai233(TICL-ChRmine-TS-GFP-WPRE-ICF-CoChR-oScarlet-WPRE)-hyg/wt",
+            "maternal_id": "785833",
+            "paternal_genotype": "Drd1a-Cre/wt;Adora2a-T2A-FlpO/wt",
+            "paternal_id": "778221"
+        },
+        "date_of_birth": "2025-04-06",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "Drd1a-Cre/wt;Adora2a-T2A-FlpO/wt;Ai233(TICL-ChRmine-TS-GFP-WPRE-ICF-CoChR-oScarlet-WPRE)-hyg/wt",
+        "housing": {
+            "cage_id": "8300198",
+            "cohoused_subjects": [],
+            "home_cage_enrichment": [],
+            "light_cycle": null,
+            "room_id": "217"
+        },
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.3",
+        "sex": "Male",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "800779",
+        "wellness_reports": []
+    },
+    "data_description": {
+        "object_type": "Data description",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "2.1.0",
+        "license": "CC-BY-4.0",
+        "subject_id": "800779",
+        "creation_time": "2025-10-07T14:19:09.055676Z",
+        "tags": null,
+        "name": "ecephys_800779_2025-09-26_12-57-44_sorted_2025-10-07_14-19-09",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": "Research Organization Registry (ROR)",
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "object_type": "Funding",
+                "funder": {
+                    "name": "National Institute of Neurological Disorders and Stroke",
+                    "abbreviation": "NINDS",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "01s5ya894"
+                },
+                "grant_number": "U01NS133760",
+                "fundee": [
+                    {
+                        "object_type": "Person",
+                        "name": "Josh Siegle",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": null
+                    }
+                ]
+            }
+        ],
+        "data_level": "derived",
+        "group": "ephys",
+        "investigators": [
+            {
+                "object_type": "Person",
+                "name": "Josh Siegle",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": null
+            },
+            {
+                "object_type": "Person",
+                "name": "Anna Lakunina",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": null
+            }
+        ],
+        "project_name": "Cell Type Lookup Table",
+        "restrictions": null,
+        "modalities": [
+            {
+                "name": "Extracellular electrophysiology",
+                "abbreviation": "ecephys"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            },
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            }
+        ],
+        "source_data": [
+            "ecephys_800779_2025-09-26_12-57-44"
+        ],
+        "data_summary": "optotagging cell types for creation of ground truth data"
+    },
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.2.1",
+        "specimen_procedures": [],
+        "subject_id": "800779",
+        "subject_procedures": [
+            {
+                "anaesthesia": {
+                    "duration": "180.0",
+                    "duration_unit": "minute",
+                    "level": "1.5",
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": "32.1",
+                "animal_weight_prior": "28.8",
+                "experimenter_full_name": "NSB-2864",
+                "iacuc_protocol": "2414",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "bregma_to_lambda_distance": "4.187",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "craniotomy_hemisphere": null,
+                        "craniotomy_type": "Dual hemisphere craniotomy",
+                        "dura_removed": null,
+                        "implant_part_number": "3006",
+                        "procedure_type": "Craniotomy",
+                        "protective_material": null,
+                        "recovery_time": "30.0",
+                        "recovery_time_unit": "minute"
+                    },
+                    {
+                        "headframe_material": "Titanium",
+                        "headframe_part_number": "0160-100-57",
+                        "headframe_type": "DHC",
+                        "procedure_type": "Headframe",
+                        "well_part_number": "0160-075-01",
+                        "well_type": "DHC well"
+                    }
+                ],
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2",
+                "start_date": "2025-06-30",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 9"
+            },
+            {
+                "baseline_weight": "29.3",
+                "end_date": null,
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "procedure_type": "Water restriction",
+                "start_date": "2025-07-31",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "weight_unit": "gram"
+            }
+        ]
+    },
+    "session": {
+        "active_mouse_platform": false,
+        "anaesthesia": null,
+        "animal_weight_post": "23.94",
+        "animal_weight_prior": null,
+        "calibrations": [],
+        "data_streams": [
+            {
+                "camera_names": [
+                    "Face Camera Assembly",
+                    "Body Camera Assembly"
+                ],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "10.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiI",
+                        "implant_hole_number": 7,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "6444.0",
+                            "y": "7644.0",
+                            "z": "9374.0"
+                        },
+                        "module_angle": "35.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "0",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "10.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiI",
+                        "implant_hole_number": 3,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "8583.0",
+                            "y": "11084.0",
+                            "z": "5694.0"
+                        },
+                        "module_angle": "-35.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "PL",
+                            "atlas": "CCFv3",
+                            "id": "972",
+                            "name": "Prelimbic area"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2025-09-26T14:25:31-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    },
+                    {
+                        "abbreviation": "behavior-videos",
+                        "name": "Behavior videos"
+                    },
+                    {
+                        "abbreviation": "behavior",
+                        "name": "Behavior"
+                    }
+                ],
+                "stream_start_time": "2025-09-26T12:57:44-07:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "10.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiI",
+                        "implant_hole_number": 7,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "6444.0",
+                            "y": "7644.0",
+                            "z": "9374.0"
+                        },
+                        "module_angle": "35.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "0",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "10.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiI",
+                        "implant_hole_number": 3,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "8583.0",
+                            "y": "11084.0",
+                            "z": "5694.0"
+                        },
+                        "module_angle": "-35.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "PL",
+                            "atlas": "CCFv3",
+                            "id": "972",
+                            "name": "Prelimbic area"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2025-09-26T14:27:18-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2025-09-26T14:25:49-07:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "10.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiI",
+                        "implant_hole_number": 7,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "6444.0",
+                            "y": "7644.0",
+                            "z": "9374.0"
+                        },
+                        "module_angle": "35.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "0",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "10.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiI",
+                        "implant_hole_number": 3,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "8583.0",
+                            "y": "11084.0",
+                            "z": "5694.0"
+                        },
+                        "module_angle": "-35.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "PL",
+                            "atlas": "CCFv3",
+                            "id": "972",
+                            "name": "Prelimbic area"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2025-09-26T14:28:50-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2025-09-26T14:27:34-07:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "10.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiI",
+                        "implant_hole_number": 7,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "6444.0",
+                            "y": "7644.0",
+                            "z": "9374.0"
+                        },
+                        "module_angle": "35.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "0",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "10.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiI",
+                        "implant_hole_number": 3,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "8583.0",
+                            "y": "11084.0",
+                            "z": "5694.0"
+                        },
+                        "module_angle": "-35.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "PL",
+                            "atlas": "CCFv3",
+                            "id": "972",
+                            "name": "Prelimbic area"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2025-09-26T14:31:17-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2025-09-26T14:29:05-07:00"
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "experimenter_full_name": [
+            "Anna Lakunina",
+            "Meghan Olsen",
+            "Josh Siegle"
+        ],
+        "headframe_registration": null,
+        "iacuc_protocol": "2414",
+        "maintenance": [],
+        "mouse_platform_name": "Running Wheel",
+        "notes": "nan",
+        "protocol_id": [],
+        "reward_consumed_total": "470.0",
+        "reward_consumed_unit": "milliliter",
+        "reward_delivery": null,
+        "rig_id": "323_EPHYS1_20250922",
+        "schema_version": "1.1.1",
+        "session_end_time": "2025-09-26T14:31:17-07:00",
+        "session_start_time": "2025-09-26T12:57:44-07:00",
+        "session_type": "Optotagging and dynamic foraging",
+        "stimulus_epochs": [
+            {
+                "light_source_config": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "Oxxius Red Laser 1",
+                        "wavelength": 638,
+                        "wavelength_unit": "nanometer"
+                    },
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "Oxxius Blue Laser 1",
+                        "wavelength": 473,
+                        "wavelength_unit": "nanometer"
+                    },
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "Oxxius Red Laser 2",
+                        "wavelength": 638,
+                        "wavelength_unit": "nanometer"
+                    },
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "Oxxius Blue Laser 2",
+                        "wavelength": 473,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "notes": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "np-opto-stim",
+                    "parameters": {},
+                    "url": "https://github.com/AllenNeuralDynamics/np-opto-stim",
+                    "version": "commit: 2d45704cfc82608fa34f667a9f3f0ab29fc9f408"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "Python",
+                        "parameters": {},
+                        "url": null,
+                        "version": "3.7"
+                    }
+                ],
+                "speaker_config": null,
+                "stimulus_device_names": [
+                    "Oxxius Red Laser 1",
+                    "Oxxius Blue Laser 1",
+                    "Oxxius Red Laser 2",
+                    "Oxxius Blue Laser 2"
+                ],
+                "stimulus_end_time": "2025-09-26T14:25:18-07:00",
+                "stimulus_modalities": [
+                    "Optogenetics"
+                ],
+                "stimulus_name": "Laser pulses for optotagging",
+                "stimulus_parameters": [
+                    {
+                        "baseline_duration": "600",
+                        "baseline_duration_unit": "second",
+                        "fixed_pulse_train_interval": false,
+                        "notes": null,
+                        "number_pulse_trains": [
+                            5
+                        ],
+                        "other_parameters": {},
+                        "pulse_frequency": [
+                            "20.0"
+                        ],
+                        "pulse_frequency_unit": "hertz",
+                        "pulse_shape": "Ramp",
+                        "pulse_train_duration": [
+                            "0.25"
+                        ],
+                        "pulse_train_duration_unit": "second",
+                        "pulse_train_interval": null,
+                        "pulse_train_interval_unit": "second",
+                        "pulse_width": [
+                            10
+                        ],
+                        "pulse_width_unit": "millisecond",
+                        "stimulus_name": "Laser pulses",
+                        "stimulus_type": "Opto Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-09-26T14:17:23-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": "The duration of go cue is 100 ms. The frequency is 7500 Hz. Amplitude is 60dB. The total reward consumed in the session is 470.0 microliters. The total reward including consumed in the session and supplementary water is 1.435 milliliters.",
+                "output_parameters": {
+                    "meta": {
+                        "box": "323_EPHYS1",
+                        "session_run_time_in_min": 69
+                    },
+                    "performance": {
+                        "foraging_efficiency": 0.49738496571948254,
+                        "foraging_efficiency_with_actual_random_seed": 0.5830258302583026
+                    }
+                },
+                "reward_consumed_during_epoch": "470.0",
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "dynamic-foraging-task",
+                    "parameters": {
+                        "BlockBeta": "20",
+                        "BlockMax": "35",
+                        "BlockMin": "20",
+                        "DelayBeta": "0.0",
+                        "DelayMax": "1.0",
+                        "DelayMin": "1.0",
+                        "ITIBeta": "3.0",
+                        "ITIMax": "30.0",
+                        "ITIMin": "1.0",
+                        "LeftValue_volume": "3.00",
+                        "RightValue_volume": "3.00",
+                        "Task": "Uncoupled Baiting",
+                        "curriculum_in_use": "off curriculum",
+                        "reward_probability": "0.1, 0.4, 0.7",
+                        "stage_in_use": "unknown training stage"
+                    },
+                    "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                    "version": "behavior branch:main   commit ID:3ffdd641a2b8b1468a0addb67a74b1bf6600558f    version:1.6.55; metadata branch: main   commit ID:3ffdd641a2b8b1468a0addb67a74b1bf6600558f   version:1.6.55"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "Bonsai",
+                        "parameters": {},
+                        "url": null,
+                        "version": "2.8.0"
+                    }
+                ],
+                "speaker_config": {
+                    "name": "Go cue speaker",
+                    "volume": "60",
+                    "volume_unit": "decibels"
+                },
+                "stimulus_device_names": [
+                    "Go cue speaker"
+                ],
+                "stimulus_end_time": "2025-09-26T14:25:24.424083-07:00",
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_name": "Auditory go cue for foraging task",
+                "stimulus_parameters": [
+                    {
+                        "amplitude_modulation_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_low_frequency": null,
+                        "bandpass_order": null,
+                        "frequency_unit": "hertz",
+                        "notes": null,
+                        "sample_frequency": "7500",
+                        "stimulus_name": "Auditory go cue",
+                        "stimulus_type": "Auditory Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-09-26T12:57:51.312535-07:00",
+                "trials_finished": 345,
+                "trials_rewarded": 158,
+                "trials_total": 450
+            }
+        ],
+        "subject_id": "800779",
+        "weight_unit": "gram"
+    },
+    "rig": {
+        "additional_devices": [],
+        "calibrations": [
+            {
+                "calibration_date": "2025-09-15T00:00:00-07:00",
+                "description": "Laser power calibration collimator",
+                "device_name": "Oxxius Red Laser 1",
+                "input": {
+                    "voltage (V)": [
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.5,
+                        0.7,
+                        0.9,
+                        1.2,
+                        1.5,
+                        1.7,
+                        2,
+                        2.5,
+                        3
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.83,
+                        2.08,
+                        3.32,
+                        5.8,
+                        8.25,
+                        10.69,
+                        14.25,
+                        17.73,
+                        20.09,
+                        23.72,
+                        30.68,
+                        34.61
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-09-15T00:00:00-07:00",
+                "description": "Laser power calibration collimator",
+                "device_name": "Oxxius Blue Laser 1",
+                "input": {
+                    "voltage (V)": [
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.5,
+                        0.7,
+                        0.9,
+                        1.2,
+                        1.5,
+                        1.7,
+                        2,
+                        2.5,
+                        3,
+                        3.5,
+                        4
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.37,
+                        0.94,
+                        1.53,
+                        2.71,
+                        3.97,
+                        5.3,
+                        7.04,
+                        8.96,
+                        10.07,
+                        11.49,
+                        14.31,
+                        17,
+                        19.6,
+                        22.2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-09-15T00:00:00-07:00",
+                "description": "Laser power calibration collimator",
+                "device_name": "Oxxius Red Laser 2",
+                "input": {
+                    "voltage (V)": [
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.5,
+                        0.7,
+                        0.9,
+                        1.2,
+                        1.5,
+                        1.7,
+                        2,
+                        2.5,
+                        3
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        1.36,
+                        3.13,
+                        4.91,
+                        8.52,
+                        12.21,
+                        15.98,
+                        21.69,
+                        27.19,
+                        30.65,
+                        35.79,
+                        44.18,
+                        51.31
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-09-15T00:00:00-07:00",
+                "description": "Laser power calibration collimator",
+                "device_name": "Oxxius Blue Laser 2",
+                "input": {
+                    "voltage (V)": [
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.5,
+                        0.7,
+                        0.9,
+                        1.2,
+                        1.5,
+                        1.7,
+                        2,
+                        2.5,
+                        3,
+                        3.5,
+                        4
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.57,
+                        1.39,
+                        2.22,
+                        3.92,
+                        5.62,
+                        7.34,
+                        9.93,
+                        12.64,
+                        14.48,
+                        17.1,
+                        21.7,
+                        26.3,
+                        31.1,
+                        35.6
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-09-15T00:00:00-07:00",
+                "description": "Laser power calibration fiber",
+                "device_name": "Oxxius Red Laser 1",
+                "input": {
+                    "voltage (V)": [
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.5,
+                        0.7,
+                        0.9,
+                        1.2,
+                        1.5,
+                        1.7,
+                        2,
+                        2.5,
+                        3
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.19,
+                        0.49,
+                        0.79,
+                        1.37,
+                        1.95,
+                        2.51,
+                        3.36,
+                        4.22,
+                        4.79,
+                        5.64,
+                        7.29,
+                        8.24
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-09-15T00:00:00-07:00",
+                "description": "Laser power calibration fiber",
+                "device_name": "Oxxius Blue Laser 1",
+                "input": {
+                    "voltage (V)": [
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.5,
+                        0.7,
+                        0.9,
+                        1.2,
+                        1.5,
+                        1.7,
+                        2,
+                        2.5,
+                        3,
+                        3.5,
+                        4
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.1,
+                        0.27,
+                        0.42,
+                        0.76,
+                        1.12,
+                        1.47,
+                        1.91,
+                        2.41,
+                        2.71,
+                        3.11,
+                        3.9,
+                        4.56,
+                        5.26,
+                        5.93
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-09-15T00:00:00-07:00",
+                "description": "Laser power calibration fiber",
+                "device_name": "Oxxius Red Laser 2",
+                "input": {
+                    "voltage (V)": [
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.5,
+                        0.7,
+                        0.9,
+                        1.2,
+                        1.5,
+                        1.7,
+                        2,
+                        2.5,
+                        3
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.28,
+                        0.66,
+                        1.04,
+                        1.81,
+                        2.6,
+                        3.41,
+                        4.63,
+                        5.81,
+                        6.55,
+                        7.71,
+                        9.49,
+                        10.89
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-09-15T00:00:00-07:00",
+                "description": "Laser power calibration fiber",
+                "device_name": "Oxxius Blue Laser 2",
+                "input": {
+                    "voltage (V)": [
+                        0.1,
+                        0.2,
+                        0.3,
+                        0.5,
+                        0.7,
+                        0.9,
+                        1.2,
+                        1.5,
+                        1.7,
+                        2,
+                        2.5,
+                        3,
+                        3.5,
+                        4
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.12,
+                        0.3,
+                        0.48,
+                        0.84,
+                        1.22,
+                        1.58,
+                        2.14,
+                        2.7,
+                        3.11,
+                        3.68,
+                        4.67,
+                        5.68,
+                        6.66,
+                        7.61
+                    ]
+                }
+            }
+        ],
+        "cameras": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT713669",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "Face Camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "23022709",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face side right",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": null,
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": null,
+                    "description": "Useful range 730 to 1100nm",
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Long pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": "MidOpt",
+                        "name": "Midwest Optical Systems, Inc.",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "LP715-37.5 Near-IR Longpass Filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Fujinon",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": "f/1.8",
+                    "model": "CF16ZA-1S",
+                    "name": "Fujinon CF16ZA-1S 16mm 23MP 1.1\" f/1.8 - f/16 C-Mount Lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Face Camera Assembly",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT713669",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "Body Camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "23347792",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Body",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": null,
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": null,
+                    "description": "Useful Range: 715 to 780 nm",
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Band pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": "MidOpt",
+                        "name": "Midwest Optical Systems, Inc.",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "BP735 IR Bandpass Filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "8",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Navitar",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": "f/1.4",
+                    "model": "NMV-8M1",
+                    "name": "Navitar NMV-8M1 1\" 8mm F1.4 Manual Iris C-Mount Lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Body Camera Assembly",
+                "position": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "daqs": [
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "DO0",
+                        "channel_type": "Digital Output",
+                        "device_name": "Face Camera",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT713669",
+                "core_version": "2.1",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Behavior",
+                    "whoami": 1216
+                },
+                "is_clock_generator": true,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "Harp Behavior",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "basestation_firmware_version": "2.0169",
+                "bsc_firmware_version": "3.2176",
+                "channels": [],
+                "computer_name": "W10DT713668",
+                "data_interface": "PXI",
+                "device_type": "Neuropixels basestation",
+                "firmware_version": null,
+                "hardware_version": null,
+                "manufacturer": {
+                    "abbreviation": "IMEC",
+                    "name": "Interuniversity Microelectronics Center",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "02kcbn207"
+                },
+                "model": null,
+                "name": "Neuropixels Basestation",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "ports": [
+                    {
+                        "index": 1,
+                        "probes": [
+                            "Probe A"
+                        ]
+                    },
+                    {
+                        "index": 2,
+                        "probes": [
+                            "Probe B"
+                        ]
+                    }
+                ],
+                "serial_number": null,
+                "slot": 4
+            },
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "Left channel",
+                        "channel_type": "Analog Output",
+                        "device_name": "Go cue speaker",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT713669",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Sound Card",
+                    "whoami": 1280
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "Harp Sound Card",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "Lick tube input 1",
+                        "channel_type": "Analog Input",
+                        "device_name": "Lick spout left",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT713669",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Lickety Split",
+                    "whoami": 1400
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "Lickety split left",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "Lick tube input 1",
+                        "channel_type": "Analog Input",
+                        "device_name": "Lick spout right",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT713669",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Lickety Split",
+                    "whoami": 1400
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "Lickety split right",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "detectors": [],
+        "digital_micromirror_devices": [],
+        "enclosure": {
+            "additional_settings": {},
+            "air_filtration": false,
+            "device_type": "Enclosure",
+            "external_material": "Plastic",
+            "grounded": false,
+            "internal_material": "Aluminum",
+            "laser_interlock": true,
+            "manufacturer": {
+                "abbreviation": null,
+                "name": "Item",
+                "registry": null,
+                "registry_identifier": null
+            },
+            "model": null,
+            "name": "Ephys enclosure",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "size": {
+                "height": 120,
+                "length": 100,
+                "unit": "centimeter",
+                "width": 131
+            }
+        },
+        "ephys_assemblies": [
+            {
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "46106",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34311"
+                },
+                "name": "Probe A ephys assembly",
+                "probes": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Ephys probe",
+                        "headstage": null,
+                        "lasers": [],
+                        "manufacturer": {
+                            "abbreviation": "IMEC",
+                            "name": "Interuniversity Microelectronics Center",
+                            "registry": {
+                                "abbreviation": "ROR",
+                                "name": "Research Organization Registry"
+                            },
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "name": "Probe A",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "probe_model": "Neuropixels 2.0 (Multi Shank)",
+                        "serial_number": "20403318772"
+                    }
+                ]
+            },
+            {
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "46118",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34693"
+                },
+                "name": "Probe B ephys assembly",
+                "probes": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Ephys probe",
+                        "headstage": null,
+                        "lasers": [],
+                        "manufacturer": {
+                            "abbreviation": "IMEC",
+                            "name": "Interuniversity Microelectronics Center",
+                            "registry": {
+                                "abbreviation": "ROR",
+                                "name": "Research Organization Registry"
+                            },
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "name": "Probe B",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "probe_model": "Neuropixels 2.0 (Multi Shank)",
+                        "serial_number": "20403313263"
+                    }
+                ]
+            },
+            {
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "50204",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34778"
+                },
+                "name": "Probe C ephys assembly",
+                "probes": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Ephys probe",
+                        "headstage": null,
+                        "lasers": [],
+                        "manufacturer": {
+                            "abbreviation": "IMEC",
+                            "name": "Interuniversity Microelectronics Center",
+                            "registry": {
+                                "abbreviation": "ROR",
+                                "name": "Research Organization Registry"
+                            },
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "name": "Probe C",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "probe_model": "Neuropixels 2.0 (Multi Shank)",
+                        "serial_number": "23299119981"
+                    }
+                ]
+            },
+            {
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "50208",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34907"
+                },
+                "name": "Probe D ephys assembly",
+                "probes": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Ephys probe",
+                        "headstage": null,
+                        "lasers": [],
+                        "manufacturer": {
+                            "abbreviation": "IMEC",
+                            "name": "Interuniversity Microelectronics Center",
+                            "registry": {
+                                "abbreviation": "ROR",
+                                "name": "Research Organization Registry"
+                            },
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "name": "Probe D",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "probe_model": "Neuropixels 2.0 (Multi Shank)",
+                        "serial_number": "23299810303"
+                    }
+                ]
+            }
+        ],
+        "fiber_assemblies": [],
+        "filters": [],
+        "laser_assemblies": [
+            {
+                "collimator": {
+                    "additional_settings": {},
+                    "device_type": "Collimator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Thorlabs",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04gsnvb07"
+                    },
+                    "model": "CFC2A",
+                    "name": "Collimator",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null
+                },
+                "fiber": {
+                    "additional_settings": {},
+                    "core_diameter": "125",
+                    "device_type": "Patch",
+                    "manufacturer": null,
+                    "model": null,
+                    "name": "Patch cable",
+                    "notes": null,
+                    "numerical_aperture": "0.12",
+                    "path_to_cad": null,
+                    "photobleaching_date": null,
+                    "port_index": null,
+                    "serial_number": null
+                },
+                "lasers": [
+                    {
+                        "additional_settings": {},
+                        "coupling": "Single-mode fiber",
+                        "coupling_efficiency": null,
+                        "coupling_efficiency_unit": "percent",
+                        "device_type": "Laser",
+                        "item_number": null,
+                        "manufacturer": {
+                            "abbreviation": null,
+                            "name": "Oxxius",
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "maximum_power": null,
+                        "model": null,
+                        "name": "Oxxius Red Laser 1",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "power_unit": "milliwatt",
+                        "serial_number": "LAS-08677",
+                        "wavelength": 638,
+                        "wavelength_unit": "nanometer"
+                    },
+                    {
+                        "additional_settings": {},
+                        "coupling": "Single-mode fiber",
+                        "coupling_efficiency": null,
+                        "coupling_efficiency_unit": "percent",
+                        "device_type": "Laser",
+                        "item_number": null,
+                        "manufacturer": {
+                            "abbreviation": null,
+                            "name": "Oxxius",
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "maximum_power": null,
+                        "model": null,
+                        "name": "Oxxius Blue Laser 1",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "power_unit": "milliwatt",
+                        "serial_number": "LAS-08788",
+                        "wavelength": 473,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "45879",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "33711"
+                },
+                "name": "External 473/638 laser, collimator 1"
+            },
+            {
+                "collimator": {
+                    "additional_settings": {},
+                    "device_type": "Collimator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Thorlabs",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04gsnvb07"
+                    },
+                    "model": "CFC2A",
+                    "name": "Collimator",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null
+                },
+                "fiber": {
+                    "additional_settings": {},
+                    "core_diameter": "125",
+                    "device_type": "Patch",
+                    "manufacturer": null,
+                    "model": null,
+                    "name": "Patch cable",
+                    "notes": null,
+                    "numerical_aperture": "0.12",
+                    "path_to_cad": null,
+                    "photobleaching_date": null,
+                    "port_index": null,
+                    "serial_number": null
+                },
+                "lasers": [
+                    {
+                        "additional_settings": {},
+                        "coupling": "Single-mode fiber",
+                        "coupling_efficiency": null,
+                        "coupling_efficiency_unit": "percent",
+                        "device_type": "Laser",
+                        "item_number": null,
+                        "manufacturer": {
+                            "abbreviation": null,
+                            "name": "Oxxius",
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "maximum_power": null,
+                        "model": null,
+                        "name": "Oxxius Red Laser 2",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "power_unit": "milliwatt",
+                        "serial_number": "LAS-08675",
+                        "wavelength": 638,
+                        "wavelength_unit": "nanometer"
+                    },
+                    {
+                        "additional_settings": {},
+                        "coupling": "Single-mode fiber",
+                        "coupling_efficiency": null,
+                        "coupling_efficiency_unit": "percent",
+                        "device_type": "Laser",
+                        "item_number": null,
+                        "manufacturer": {
+                            "abbreviation": null,
+                            "name": "Oxxius",
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "maximum_power": null,
+                        "model": null,
+                        "name": "Oxxius Blue Laser 2",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "power_unit": "milliwatt",
+                        "serial_number": "LAS-08787",
+                        "wavelength": 473,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "45879",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "33711"
+                },
+                "name": "External 473/638 laser, collimator 2"
+            }
+        ],
+        "lenses": [],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L3",
+                "name": "Face cam illumination LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M730L3",
+                "name": "Body cam illumination LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 730,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "ecephys",
+                "name": "Extracellular electrophysiology"
+            }
+        ],
+        "modification_date": "2025-09-22",
+        "mouse_platform": {
+            "additional_settings": {},
+            "brake_output": null,
+            "date_surface_replaced": null,
+            "device_type": "Wheel",
+            "encoder": {
+                "additional_settings": {},
+                "device_type": "Encoder",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Same Sky",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "AMT102",
+                "name": "CUI Devices Encoder",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "encoder_output": null,
+            "magnetic_brake": {
+                "additional_settings": {},
+                "device_type": "Brake",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Placid Industries",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "B1-2FM",
+                "name": "Placid Industries magnetic brake",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "manufacturer": null,
+            "model": null,
+            "name": "Running Wheel",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "pulse_per_revolution": 32800,
+            "radius": "8.5",
+            "serial_number": null,
+            "size_unit": "millimeter",
+            "surface_material": null,
+            "torque_output": null,
+            "torque_sensor": {
+                "additional_settings": {},
+                "device_type": "Torque sensor",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Transducer Techniques",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "RTS-10",
+                "name": "Transducer Techniques torque sensor",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "width": "5"
+        },
+        "notes": null,
+        "objectives": [],
+        "origin": null,
+        "patch_cords": [],
+        "pockels_cells": [],
+        "polygonal_scanners": [],
+        "rig_axes": null,
+        "rig_id": "323_EPHYS1_20250922",
+        "schema_version": "1.0.4",
+        "stick_microscopes": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Color",
+                    "computer_name": "W10DT713668",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-120S4C",
+                    "name": "Probe Camera 1",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/1.7",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 3000,
+                    "sensor_width": 4000,
+                    "serial_number": "22438385",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Brain surface",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "max_aperture": null,
+                    "model": "InfiniProbe S-25",
+                    "name": "Probe lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Probe camera 1",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Color",
+                    "computer_name": "W10DT713668",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-120S4C",
+                    "name": "Probe Camera 2",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/1.7",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 3000,
+                    "sensor_width": 4000,
+                    "serial_number": "20105611",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Brain surface",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "max_aperture": null,
+                    "model": "InfiniProbe S-25",
+                    "name": "Probe lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Probe camera 2",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Color",
+                    "computer_name": "W10DT713668",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-120S4C",
+                    "name": "Probe Camera 3",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/1.7",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 3000,
+                    "sensor_width": 4000,
+                    "serial_number": "22438379",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Brain surface",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "max_aperture": null,
+                    "model": "InfiniProbe S-25",
+                    "name": "Probe lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Probe camera 3",
+                "position": null
+            }
+        ],
+        "stimulus_devices": [
+            {
+                "additional_settings": {},
+                "device_type": "Speaker",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "Digikey-XT25SC90-04",
+                "name": "Go cue speaker",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "serial_number": null
+            },
+            {
+                "device_type": "Reward delivery",
+                "reward_spouts": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Harp device",
+                            "manufacturer": {
+                                "abbreviation": "OEPS",
+                                "name": "Open Ephys Production Site",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "007rkz355"
+                            },
+                            "model": null,
+                            "name": "Lickety split left",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Lick spout left",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Left",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid Valve",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDB1233518H",
+                            "name": "LHD series 3-way control solenoid valve",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    },
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Harp device",
+                            "manufacturer": {
+                                "abbreviation": "OEPS",
+                                "name": "Open Ephys Production Site",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "007rkz355"
+                            },
+                            "model": null,
+                            "name": "Lickety split right",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Lick spout right",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Right",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid Valve",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDB1233518H",
+                            "name": "LHD series 3-way control solenoid valve",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    }
+                ],
+                "stage_type": {
+                    "additional_settings": {},
+                    "device_type": "Motorized stage",
+                    "firmware": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "NewScaleMotor for LickSpouts",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34348",
+                    "travel": "15.0",
+                    "travel_unit": "millimeter"
+                }
+            }
+        ]
+    },
+    "processing": {
+        "object_type": "Processing",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "schema_version": "2.1.0",
+        "data_processes": [
+            {
+                "object_type": "Data process",
+                "process_type": "Other",
+                "name": "Other_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "ghcr.io/allenneuraldynamics/aind-ephys-transformation",
+                    "name": "Other",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "input_source": "/allen/aind/scratch/ephys/temp/800779_2025-09-26_12-57-44",
+                        "output_directory": "/allen/aind/stage/svc_aind_airflow/prod/ecephys_800779_2025-09-26_12-57-44_2ac244bb33/ecephys"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "AIND Scientific Computing"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-09-26T22:00:56.061760Z",
+                "end_date_time": "2025-09-26T22:55:00.411178Z",
+                "output_path": "/allen/aind/stage/svc_aind_airflow/prod/ecephys_800779_2025-09-26_12-57-44_2ac244bb33/ecephys",
+                "output_parameters": {},
+                "notes": "(v1v2 upgrade) Process type is unknown, no notes were provided.",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Other",
+                "name": "Other_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "ghcr.io/allenneuraldynamics/aind-behavior-video-transformation",
+                    "name": "Other",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "compression_requested": {
+                            "compression_enum": "gamma fix colorspace"
+                        },
+                        "input_source": "/allen/aind/scratch/ephys_rig_behavior_transfer/323_EPHYS1/800779/behavior_800779_2025-09-26_12-57-46/behavior-videos",
+                        "output_directory": "/allen/aind/stage/svc_aind_airflow/prod/ecephys_800779_2025-09-26_12-57-44_2ac244bb33/behavior-videos"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "AIND Scientific Computing"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-09-26T22:00:58.069562Z",
+                "end_date_time": "2025-09-27T19:52:26.913467Z",
+                "output_path": "/allen/aind/stage/svc_aind_airflow/prod/ecephys_800779_2025-09-26_12-57-44_2ac244bb33/behavior-videos",
+                "output_parameters": {},
+                "notes": "(v1v2 upgrade) Process type is unknown, no notes were provided.",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Other",
+                "name": "Other_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Other",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "input_source": "/allen/aind/scratch/ephys_rig_behavior_transfer/323_EPHYS1/800779/behavior_800779_2025-09-26_12-57-46/behavior"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "AIND Scientific Computing"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-09-26T22:00:58.114199Z",
+                "end_date_time": "2025-09-26T22:02:59.197927Z",
+                "output_path": ".",
+                "output_parameters": {},
+                "notes": "Data was copied",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:08:35.241486Z",
+                "end_date_time": "2025-10-07T11:11:15.241486Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 8 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_9",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:08:37.281258Z",
+                "end_date_time": "2025-10-07T11:18:07.281258Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 2 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:11:56.957929Z",
+                "end_date_time": "2025-10-07T11:25:08.957929Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 4 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_11",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:11:58.017695Z",
+                "end_date_time": "2025-10-07T11:25:08.017695Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 4 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:12:00.803395Z",
+                "end_date_time": "2025-10-07T11:16:29.803395Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 8 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_12",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:12:01.268797Z",
+                "end_date_time": "2025-10-07T11:16:02.268797Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 9 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_8",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:12:27.272759Z",
+                "end_date_time": "2025-10-07T11:30:28.272759Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 2 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_13",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:12:29.082698Z",
+                "end_date_time": "2025-10-07T11:30:29.082698Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_10",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:12:29.560761Z",
+                "end_date_time": "2025-10-07T11:30:33.560761Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_14",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:12:30.508392Z",
+                "end_date_time": "2025-10-07T11:16:39.508392Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 8 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:13:59.169535Z",
+                "end_date_time": "2025-10-07T11:16:47.169535Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 9 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:14:02.282602Z",
+                "end_date_time": "2025-10-07T11:17:21.282602Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 5 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_7",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:14:02.764122Z",
+                "end_date_time": "2025-10-07T11:25:09.764122Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 0 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys preprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:14:03.024394Z",
+                "end_date_time": "2025-10-07T11:25:09.024394Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 2 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_9",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:15:33.987316Z",
+                "end_date_time": "2025-10-07T11:17:00.987316Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 77 units, 77 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:17:35.156703Z",
+                "end_date_time": "2025-10-07T11:19:26.156703Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 115 units, 115 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_14",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:20:09.103562Z",
+                "end_date_time": "2025-10-07T11:22:07.103562Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 140 units, 140 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_7",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:21:34.794905Z",
+                "end_date_time": "2025-10-07T11:22:59.794905Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 80 units, 80 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_12",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:21:40.147438Z",
+                "end_date_time": "2025-10-07T11:24:03.147438Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 88 units, 88 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:23:47.367413Z",
+                "end_date_time": "2025-10-07T11:48:45.367413Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 172 units, 172 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_10",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:24:26.564653Z",
+                "end_date_time": "2025-10-07T11:27:00.564653Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 99 units, 99 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:28:52.806878Z",
+                "end_date_time": "2025-10-07T11:58:43.806878Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 139 units, 139 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:31:21.597716Z",
+                "end_date_time": "2025-10-07T11:59:50.597716Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 161 units, 161 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:31:25.774117Z",
+                "end_date_time": "2025-10-07T12:00:31.774117Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 268 units, 268 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_13",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:33:29.247797Z",
+                "end_date_time": "2025-10-07T11:58:05.247797Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 117 units, 117 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:37:44.572035Z",
+                "end_date_time": "2025-10-07T12:06:50.572035Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 119 units, 119 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_8",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:39:42.071791Z",
+                "end_date_time": "2025-10-07T12:04:22.071791Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 194 units, 194 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_11",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Spike sorting",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T11:41:40.324963Z",
+                "end_date_time": "2025-10-07T12:09:56.324963Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- KS4 found 276 units, 276 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:18:47.088828Z",
+                "end_date_time": "2025-10-07T12:19:49.088828Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 1 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:20:59.934099Z",
+                "end_date_time": "2025-10-07T12:21:06.934099Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 10/76Noise: 73 / 76\nSUA: 1 / 76\nMUA: 2 / 76\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:29:56.349021Z",
+                "end_date_time": "2025-10-07T12:30:58.349021Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 2 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:31:01.845235Z",
+                "end_date_time": "2025-10-07T12:45:46.845235Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 1 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_14",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:31:25.681081Z",
+                "end_date_time": "2025-10-07T12:37:19.681081Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 2 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_10",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:31:32.271072Z",
+                "end_date_time": "2025-10-07T12:59:03.271072Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:31:44.033108Z",
+                "end_date_time": "2025-10-07T12:42:22.033108Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 2 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:31:55.010800Z",
+                "end_date_time": "2025-10-07T12:33:39.010800Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:32:05.351066Z",
+                "end_date_time": "2025-10-07T12:45:41.351066Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 1 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:32:08.010700Z",
+                "end_date_time": "2025-10-07T12:32:15.010700Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 12/78Noise: 45 / 78\nSUA: 13 / 78\nMUA: 20 / 78\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_11",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:32:34.145161Z",
+                "end_date_time": "2025-10-07T12:50:45.145161Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 5 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_12",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:32:38.116312Z",
+                "end_date_time": "2025-10-07T12:59:12.116312Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 3 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:34:38.943663Z",
+                "end_date_time": "2025-10-07T12:34:46.943663Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 13/88Noise: 85 / 88\nSUA: 1 / 88\nMUA: 2 / 88\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_7",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:38:01.298700Z",
+                "end_date_time": "2025-10-07T12:46:29.298700Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 2 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_8",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:38:02.987535Z",
+                "end_date_time": "2025-10-07T12:41:42.987535Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_13",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:38:24.813428Z",
+                "end_date_time": "2025-10-07T12:42:39.813428Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 2 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_9",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys postprocessing",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:39:12.946474Z",
+                "end_date_time": "2025-10-07T12:49:40.946474Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_14",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:39:42.456024Z",
+                "end_date_time": "2025-10-07T12:40:02.456024Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 64/138Noise: 26 / 138\nSUA: 44 / 138\nMUA: 68 / 138\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:43:11.732397Z",
+                "end_date_time": "2025-10-07T12:43:25.732397Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 40/99Noise: 63 / 99\nSUA: 18 / 99\nMUA: 18 / 99\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_7",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:44:37.655751Z",
+                "end_date_time": "2025-10-07T12:44:56.655751Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 36/115Noise: 74 / 115\nSUA: 21 / 115\nMUA: 20 / 115\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_13",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:44:44.308711Z",
+                "end_date_time": "2025-10-07T12:44:58.308711Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 45/113Noise: 60 / 113\nSUA: 28 / 113\nMUA: 25 / 113\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_8",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:47:48.611024Z",
+                "end_date_time": "2025-10-07T12:48:12.611024Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 54/117Noise: 48 / 117\nSUA: 35 / 117\nMUA: 34 / 117\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:47:53.509205Z",
+                "end_date_time": "2025-10-07T12:48:33.509205Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 87/160Noise: 61 / 160\nSUA: 49 / 160\nMUA: 50 / 160\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:47:54.617718Z",
+                "end_date_time": "2025-10-07T12:48:27.617718Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 76/138Noise: 65 / 138\nSUA: 32 / 138\nMUA: 41 / 138\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_9",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:50:43.968801Z",
+                "end_date_time": "2025-10-07T12:50:58.968801Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 93/172Noise: 54 / 172\nSUA: 34 / 172\nMUA: 84 / 172\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_11",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T12:53:11.331319Z",
+                "end_date_time": "2025-10-07T12:53:25.331319Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 103/189Noise: 59 / 189\nSUA: 50 / 189\nMUA: 80 / 189\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_12",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:00:21.406035Z",
+                "end_date_time": "2025-10-07T13:00:43.406035Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 175/273Noise: 91 / 273\nSUA: 79 / 273\nMUA: 103 / 273\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_10",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys curation",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:00:54.396703Z",
+                "end_date_time": "2025-10-07T13:01:35.396703Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 171/268Noise: 78 / 268\nSUA: 92 / 268\nMUA: 98 / 268\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:47:41.096989Z",
+                "end_date_time": "2025-10-07T13:52:53.096989Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:d96f4ba3cf959a64e6efc06db8650412d31dec81&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:b6be2bbe0cfb0ea326e51e555c6208113e183318&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment4_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:47:53.222909Z",
+                "end_date_time": "2025-10-07T13:53:12.222909Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3353782b2ea7894352552242d47f50fe02bb475a&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:49:50.053191Z",
+                "end_date_time": "2025-10-07T13:55:37.053191Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:4e60ff1b52ffbcaa320dbc829f852d6242f5224c&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:122b5b2023e44b4b9e81560fa8524156c4f0bcac&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group0/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_7",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:50:32.403703Z",
+                "end_date_time": "2025-10-07T13:55:56.403703Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:5bb5203fa85db1b137699ee6855e0204f881ac28&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_9",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:50:39.178991Z",
+                "end_date_time": "2025-10-07T13:56:31.178991Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:1ee053f6764b387592e85936b8b05554f6e213c7&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:e77160a0d05a82dda0301f206a278e6a43e8ed38&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group1/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_13",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:08.213712Z",
+                "end_date_time": "2025-10-07T13:57:10.213712Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:ffa8be2ef9f3766a8e4a1b1c25bd1de5865ff47a&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_14",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:10.092758Z",
+                "end_date_time": "2025-10-07T13:56:49.092758Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:f2c25c29e873a744239b6e46a8d6e50ece05a51e&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_12",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:10.936755Z",
+                "end_date_time": "2025-10-07T13:56:53.936755Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3bf9e06aad1490bdea4014f337d1b2ddcc105531&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:14.323863Z",
+                "end_date_time": "2025-10-07T13:55:57.323863Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:30046f6df314a2e02322c215bd00845e64ffe312&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:31ca86f8fd9bf95c87f811a59dab8fd8d6cd00b3&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group2/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_8",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:17.407371Z",
+                "end_date_time": "2025-10-07T13:56:05.407371Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:25a131faf666951a55bc8fbd647148ec53773e39&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:98be1c7776d34fb90fd88cac46153ad7853d4041&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group0/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_11",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:30.800204Z",
+                "end_date_time": "2025-10-07T13:56:19.800204Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:22e31976af16dc06dbe6e57c523b893451bdf099&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:d8573a68f6819ad6dc05560704c81c78e7ce2c58&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group3/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:36.661657Z",
+                "end_date_time": "2025-10-07T13:57:16.661657Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:393ec4ef3f113bba547fecc49a2ab2ec1c261e9f&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:642510a7b52ecad76240343a246318d7a9a7c185&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group1/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_10",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:37.425048Z",
+                "end_date_time": "2025-10-07T13:56:26.425048Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:5740009bac571925bd0752f24660de83eac0f814&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:c04ff33c279e82029f6adaec7a700874fc2650b3&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group2/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Ephys visualization",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "unknown"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-10-07T13:51:37.790248Z",
+                "end_date_time": "2025-10-07T13:57:20.790248Z",
+                "output_path": null,
+                "output_parameters": {},
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:d952a40155b37e295f5dd2ee5691f3af49ecbe1e&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:1a23e3517f8b9613fe33c255c096170166e29714&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group3/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            }
+        ],
+        "pipelines": [
+            {
+                "object_type": "Code",
+                "url": "https://github.com/AllenNeuralDynamics/aind-ephys-pipeline",
+                "name": "AIND ephys pipeline",
+                "version": "kilosort4_0.3.0",
+                "container": null,
+                "run_script": null,
+                "language": null,
+                "language_version": null,
+                "input_data": null,
+                "parameters": null,
+                "core_dependency": null
+            }
+        ],
+        "notes": "Processes were reordered by start_date_time",
+        "dependency_graph": {
+            "Other_1": [],
+            "Other_2": [
+                "Other_1"
+            ],
+            "Other_3": [
+                "Other_2"
+            ],
+            "Ephys preprocessing_1": [
+                "Other_3"
+            ],
+            "Ephys preprocessing_2": [
+                "Ephys preprocessing_1"
+            ],
+            "Ephys preprocessing_3": [
+                "Ephys preprocessing_2"
+            ],
+            "Ephys preprocessing_4": [
+                "Ephys preprocessing_3"
+            ],
+            "Ephys preprocessing_5": [
+                "Ephys preprocessing_4"
+            ],
+            "Ephys preprocessing_6": [
+                "Ephys preprocessing_5"
+            ],
+            "Ephys preprocessing_7": [
+                "Ephys preprocessing_6"
+            ],
+            "Ephys preprocessing_8": [
+                "Ephys preprocessing_7"
+            ],
+            "Ephys preprocessing_9": [
+                "Ephys preprocessing_8"
+            ],
+            "Ephys preprocessing_10": [
+                "Ephys preprocessing_9"
+            ],
+            "Ephys preprocessing_11": [
+                "Ephys preprocessing_10"
+            ],
+            "Ephys preprocessing_12": [
+                "Ephys preprocessing_11"
+            ],
+            "Ephys preprocessing_13": [
+                "Ephys preprocessing_12"
+            ],
+            "Spike sorting_1": [
+                "Ephys preprocessing_13"
+            ],
+            "Ephys preprocessing_14": [
+                "Spike sorting_1"
+            ],
+            "Spike sorting_2": [
+                "Ephys preprocessing_14"
+            ],
+            "Spike sorting_3": [
+                "Spike sorting_2"
+            ],
+            "Spike sorting_4": [
+                "Spike sorting_3"
+            ],
+            "Spike sorting_5": [
+                "Spike sorting_4"
+            ],
+            "Spike sorting_6": [
+                "Spike sorting_5"
+            ],
+            "Spike sorting_7": [
+                "Spike sorting_6"
+            ],
+            "Spike sorting_8": [
+                "Spike sorting_7"
+            ],
+            "Spike sorting_9": [
+                "Spike sorting_8"
+            ],
+            "Spike sorting_10": [
+                "Spike sorting_9"
+            ],
+            "Spike sorting_11": [
+                "Spike sorting_10"
+            ],
+            "Spike sorting_12": [
+                "Spike sorting_11"
+            ],
+            "Spike sorting_13": [
+                "Spike sorting_12"
+            ],
+            "Spike sorting_14": [
+                "Spike sorting_13"
+            ],
+            "Ephys postprocessing_1": [
+                "Spike sorting_14"
+            ],
+            "Ephys postprocessing_2": [
+                "Ephys postprocessing_1"
+            ],
+            "Ephys postprocessing_3": [
+                "Ephys postprocessing_2"
+            ],
+            "Ephys postprocessing_4": [
+                "Ephys postprocessing_3"
+            ],
+            "Ephys postprocessing_5": [
+                "Ephys postprocessing_4"
+            ],
+            "Ephys postprocessing_6": [
+                "Ephys postprocessing_5"
+            ],
+            "Ephys postprocessing_7": [
+                "Ephys postprocessing_6"
+            ],
+            "Ephys postprocessing_8": [
+                "Ephys postprocessing_7"
+            ],
+            "Ephys postprocessing_9": [
+                "Ephys postprocessing_8"
+            ],
+            "Ephys curation_1": [
+                "Ephys postprocessing_9"
+            ],
+            "Ephys postprocessing_10": [
+                "Ephys curation_1"
+            ],
+            "Ephys curation_2": [
+                "Ephys postprocessing_10"
+            ],
+            "Ephys postprocessing_11": [
+                "Ephys curation_2"
+            ],
+            "Ephys postprocessing_12": [
+                "Ephys postprocessing_11"
+            ],
+            "Ephys curation_3": [
+                "Ephys postprocessing_12"
+            ],
+            "Ephys curation_4": [
+                "Ephys curation_3"
+            ],
+            "Ephys postprocessing_13": [
+                "Ephys curation_4"
+            ],
+            "Ephys curation_5": [
+                "Ephys postprocessing_13"
+            ],
+            "Ephys postprocessing_14": [
+                "Ephys curation_5"
+            ],
+            "Ephys curation_6": [
+                "Ephys postprocessing_14"
+            ],
+            "Ephys curation_7": [
+                "Ephys curation_6"
+            ],
+            "Ephys curation_8": [
+                "Ephys curation_7"
+            ],
+            "Ephys curation_9": [
+                "Ephys curation_8"
+            ],
+            "Ephys curation_10": [
+                "Ephys curation_9"
+            ],
+            "Ephys curation_11": [
+                "Ephys curation_10"
+            ],
+            "Ephys curation_12": [
+                "Ephys curation_11"
+            ],
+            "Ephys curation_13": [
+                "Ephys curation_12"
+            ],
+            "Ephys curation_14": [
+                "Ephys curation_13"
+            ],
+            "Ephys visualization_1": [
+                "Ephys curation_14"
+            ],
+            "Ephys visualization_2": [
+                "Ephys visualization_1"
+            ],
+            "Ephys visualization_3": [
+                "Ephys visualization_2"
+            ],
+            "Ephys visualization_4": [
+                "Ephys visualization_3"
+            ],
+            "Ephys visualization_5": [
+                "Ephys visualization_4"
+            ],
+            "Ephys visualization_6": [
+                "Ephys visualization_5"
+            ],
+            "Ephys visualization_7": [
+                "Ephys visualization_6"
+            ],
+            "Ephys visualization_8": [
+                "Ephys visualization_7"
+            ],
+            "Ephys visualization_9": [
+                "Ephys visualization_8"
+            ],
+            "Ephys visualization_10": [
+                "Ephys visualization_9"
+            ],
+            "Ephys visualization_11": [
+                "Ephys visualization_10"
+            ],
+            "Ephys visualization_12": [
+                "Ephys visualization_11"
+            ],
+            "Ephys visualization_13": [
+                "Ephys visualization_12"
+            ],
+            "Ephys visualization_14": [
+                "Ephys visualization_13"
+            ]
+        }
+    },
+    "acquisition": null,
+    "instrument": null,
+    "quality_control": {
+        "object_type": "Quality control",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/quality_control.py",
+        "schema_version": "2.0.7",
+        "metrics": [
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:13.545824Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:4e60ff1b52ffbcaa320dbc829f852d6242f5224c&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/traces_raw.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:13.545824Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 wide-band power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/psd_wide.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:13.545824Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 high-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/psd_hf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:13.545824Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 low-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/psd_lf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:13.545824Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 RMS",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/rms.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:51.578628Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 saturation timeline",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/saturation_timeline.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:51.578628Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 saturation samples",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/saturation_samples.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Trigger artifacts"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:51.578628Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 trigger events",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/trigger_events.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:27.363980Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 probe drift",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/drift_map.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:27.365036Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:122b5b2023e44b4b9e81560fa8524156c4f0bcac&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group0/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/unit_yield.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:38:27.365036Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:38:27.365036Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "reference": null,
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:27.365036Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0 firing rate",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/firing_rate.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:27:02.081616Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:1ee053f6764b387592e85936b8b05554f6e213c7&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/traces_raw.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:27:02.081616Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 wide-band power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/psd_wide.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:27:02.081616Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 high-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/psd_hf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:27:02.081616Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 low-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/psd_lf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:27:02.081616Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 RMS",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/rms.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:27:41.687447Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 saturation timeline",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/saturation_timeline.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:27:41.687447Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 saturation samples",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/saturation_samples.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Trigger artifacts"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:27:41.687447Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 trigger events",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/trigger_events.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:31.531654Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 probe drift",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/drift_map.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:31.533487Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:e77160a0d05a82dda0301f206a278e6a43e8ed38&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group1/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/unit_yield.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:38:31.533487Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:38:31.533487Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "reference": null,
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:31.533487Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1 firing rate",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/firing_rate.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:10.069429Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:5740009bac571925bd0752f24660de83eac0f814&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/traces_raw.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:10.069429Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 wide-band power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/psd_wide.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:10.069429Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 high-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/psd_hf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:10.069429Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 low-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/psd_lf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:10.069429Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 RMS",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/rms.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:47.470832Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 saturation timeline",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/saturation_timeline.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:47.470832Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 saturation samples",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/saturation_samples.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Trigger artifacts"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:47.470832Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 trigger events",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/trigger_events.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:19.907273Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 probe drift",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/drift_map.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:19.908962Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:c04ff33c279e82029f6adaec7a700874fc2650b3&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group2/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/unit_yield.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:38:19.908962Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:38:19.908962Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "reference": null,
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:19.908962Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2 firing rate",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/firing_rate.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:15.822855Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:22e31976af16dc06dbe6e57c523b893451bdf099&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/traces_raw.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:15.822855Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 wide-band power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/psd_wide.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:15.822855Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 high-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/psd_hf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:15.822855Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 low-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/psd_lf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:15.822855Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 RMS",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/rms.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:54.452233Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 saturation timeline",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/saturation_timeline.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:54.452233Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 saturation samples",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/saturation_samples.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Trigger artifacts"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:54.452233Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 trigger events",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/trigger_events.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:30.085836Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 probe drift",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/drift_map.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:30.087183Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:d8573a68f6819ad6dc05560704c81c78e7ce2c58&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group3/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/unit_yield.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:38:30.087183Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:38:30.087183Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "reference": null,
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:38:30.087183Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3 firing rate",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/firing_rate.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:24.254455Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:25a131faf666951a55bc8fbd647148ec53773e39&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/traces_raw.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:24.254455Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 wide-band power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/psd_wide.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:24.254455Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 high-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/psd_hf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:24.254455Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 low-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/psd_lf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:24.254455Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 RMS",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/rms.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:45.679961Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 saturation timeline",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/saturation_timeline.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:45.679961Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 saturation samples",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/saturation_samples.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Trigger artifacts"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:45.679961Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 trigger events",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/trigger_events.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:41:37.816166Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 probe drift",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/drift_map.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:41:37.817192Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:98be1c7776d34fb90fd88cac46153ad7853d4041&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group0/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/unit_yield.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:41:37.817192Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:41:37.817192Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "reference": null,
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:41:37.817192Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0 firing rate",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/firing_rate.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:35.416872Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:393ec4ef3f113bba547fecc49a2ab2ec1c261e9f&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/traces_raw.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:35.416872Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 wide-band power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/psd_wide.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:35.416872Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 high-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/psd_hf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:35.416872Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 low-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/psd_lf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:35.416872Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 RMS",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/rms.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:57.998458Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 saturation timeline",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/saturation_timeline.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:57.998458Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 saturation samples",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/saturation_samples.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Trigger artifacts"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:57.998458Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 trigger events",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/trigger_events.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:42:15.346103Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 probe drift",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/drift_map.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:42:15.347237Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:642510a7b52ecad76240343a246318d7a9a7c185&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group1/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/unit_yield.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:42:15.347237Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:42:15.347237Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "reference": null,
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:42:15.347237Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1 firing rate",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/firing_rate.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:27.248160Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:30046f6df314a2e02322c215bd00845e64ffe312&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/traces_raw.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:30:27.248160Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 wide-band power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/psd_wide.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:27.248160Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 high-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/psd_hf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:27.248160Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 low-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/psd_lf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:30:27.248160Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 RMS",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/rms.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:31:07.169502Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 saturation timeline",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/saturation_timeline.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:31:07.169502Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 saturation samples",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/saturation_samples.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Trigger artifacts"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:31:07.169502Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 trigger events",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/trigger_events.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:43:59.637901Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 probe drift",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/drift_map.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:43:59.638647Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:31ca86f8fd9bf95c87f811a59dab8fd8d6cd00b3&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group2/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/unit_yield.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:43:59.638647Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:43:59.638647Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "reference": null,
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:43:59.638647Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2 firing rate",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/firing_rate.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:32.959711Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:d952a40155b37e295f5dd2ee5691f3af49ecbe1e&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/traces_raw.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:30:32.959711Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 wide-band power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/psd_wide.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:32.959711Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 high-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/psd_hf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:32.959711Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 low-frequency power spectrum density",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/psd_lf.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:30:32.959711Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 RMS",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/rms.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:31:13.182898Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 saturation timeline",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/saturation_timeline.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:31:13.182898Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 saturation samples",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/saturation_samples.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Trigger artifacts"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:31:13.182898Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 trigger events",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/trigger_events.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:44:01.738562Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 probe drift",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/drift_map.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:44:01.739374Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:1a23e3517f8b9613fe33c255c096170166e29714&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group3/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/unit_yield.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:44:01.739374Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:44:01.739374Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "reference": null,
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:44:01.739374Z"
+                    }
+                ],
+                "description": "Evaluation of experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3 firing rate",
+                "reference": "quality_control/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/firing_rate.png",
+                "tags": [
+                    "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:13.868384Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:f2c25c29e873a744239b6e46a8d6e50ece05a51e&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind)",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/traces_raw.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:30:13.868384Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 wide-band power spectrum density",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_wide.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:13.868384Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 high-frequency power spectrum density",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_hf.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:13.868384Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 low-frequency power spectrum density",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_lf.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:30:13.868384Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 RMS",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/rms.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:31:41.214688Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 saturation timeline",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/saturation_timeline.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:31:41.214688Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 saturation samples",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/saturation_samples.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:31:41.214688Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 trigger events",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/trigger_events.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:32:25.310434Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 probe drift",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/drift_map.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:32:25.311592Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 unit metrics yield. [Sortingview link](None)",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/unit_yield.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:32:25.311592Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:32:25.311592Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "reference": null,
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:32:25.311592Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 firing rate",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/firing_rate.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:18.581712Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:ffa8be2ef9f3766a8e4a1b1c25bd1de5865ff47a&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind)",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/traces_raw.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:30:18.581712Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 wide-band power spectrum density",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_wide.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:18.581712Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 high-frequency power spectrum density",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_hf.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:30:18.581712Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 low-frequency power spectrum density",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_lf.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:30:18.581712Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 RMS",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/rms.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:31:45.836127Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 saturation timeline",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/saturation_timeline.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:31:45.836127Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 saturation samples",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/saturation_samples.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:31:45.836127Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 trigger events",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/trigger_events.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:32:29.037430Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 probe drift",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/drift_map.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:32:29.038664Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 unit metrics yield. [Sortingview link](None)",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/unit_yield.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:32:29.038664Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:32:29.038664Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "reference": null,
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:32:29.038664Z"
+                    }
+                ],
+                "description": "Evaluation of experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 firing rate",
+                "reference": "quality_control/experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/firing_rate.png",
+                "tags": [
+                    "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:05.464292Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3353782b2ea7894352552242d47f50fe02bb475a&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind)",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/traces_raw.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:05.464292Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 wide-band power spectrum density",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_wide.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:05.464292Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 high-frequency power spectrum density",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_hf.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:23:05.464292Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 low-frequency power spectrum density",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_lf.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:23:05.464292Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 RMS",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/rms.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:24:22.167718Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 saturation timeline",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/saturation_timeline.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:24:22.167718Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 saturation samples",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/saturation_samples.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:24:22.167718Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 trigger events",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/trigger_events.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:25:08.971764Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 probe drift",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/drift_map.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:25:08.973456Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 unit metrics yield. [Sortingview link](None)",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/unit_yield.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:25:08.973456Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:25:08.973456Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "reference": null,
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:25:08.973456Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 firing rate",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/firing_rate.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:25:08.115860Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:5bb5203fa85db1b137699ee6855e0204f881ac28&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind)",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/traces_raw.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:25:08.115860Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 wide-band power spectrum density",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_wide.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:25:08.115860Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 high-frequency power spectrum density",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_hf.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:25:08.115860Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 low-frequency power spectrum density",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_lf.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:25:08.115860Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 RMS",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/rms.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:26:36.342002Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 saturation timeline",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/saturation_timeline.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:26:36.342002Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 saturation samples",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/saturation_samples.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:26:36.342002Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 trigger events",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/trigger_events.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:27:11.551372Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 probe drift",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/drift_map.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:27:11.552439Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 unit metrics yield. [Sortingview link](None)",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/unit_yield.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:27:11.552439Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:27:11.552439Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "reference": null,
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:27:11.552439Z"
+                    }
+                ],
+                "description": "Evaluation of experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 firing rate",
+                "reference": "quality_control/experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/firing_rate.png",
+                "tags": [
+                    "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:26:44.187738Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3bf9e06aad1490bdea4014f337d1b2ddcc105531&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind)",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/traces_raw.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:26:44.187738Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 wide-band power spectrum density",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_wide.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:26:44.187738Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 high-frequency power spectrum density",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_hf.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:26:44.187738Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 low-frequency power spectrum density",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/psd_lf.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:26:44.187738Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 RMS",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/rms.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:09.879535Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 saturation timeline",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/saturation_timeline.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:09.879535Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 saturation samples",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/saturation_samples.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:09.879535Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 trigger events",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/trigger_events.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:54.305743Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 probe drift",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/drift_map.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:54.307247Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 unit metrics yield. [Sortingview link](None)",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/unit_yield.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:54.307247Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:54.307247Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "reference": null,
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:54.307247Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1 firing rate",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1/firing_rate.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:26:17.424486Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 raw data. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:d96f4ba3cf959a64e6efc06db8650412d31dec81&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind)",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/traces_raw.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Raw Data"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Wide Band) experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:26:17.424486Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 wide-band power spectrum density",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_wide.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (Wide Band)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (High Frequency) experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "High frequency contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:26:17.424486Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 high-frequency power spectrum density",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_hf.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (High Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD (Low Frequency) experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No contamination",
+                        "Line (60 Hz) contamination"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:26:17.424486Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 low-frequency power spectrum density",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/psd_lf.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "PSD (Low Frequency)"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:26:17.424486Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 RMS",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/rms.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "RMS"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:27:51.062055Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 saturation timeline",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/saturation_timeline.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Saturation timeline"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events samples experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:27:51.062055Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 saturation samples",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/saturation_samples.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Saturation samples"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Trigger events experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:27:51.062055Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 trigger events",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/trigger_events.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Trigger events"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:31.089715Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 probe drift",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/drift_map.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Probe Drift"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:31.090980Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 unit metrics yield. [Sortingview link](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:b6be2bbe0cfb0ea326e51e555c6208113e183318&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_800779_2025-09-26_12-57-44/experiment4_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1/kilosort4/curation.json%22}&label=ecephys_800779_2025-09-26_12-57-44%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/unit_yield.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Unit Yield"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Sorting Curation - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {},
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:31.090980Z"
+                    }
+                ],
+                "description": "Sorting Curation for experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Sorting Curation"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Manual annotation of ISI Visual Area Label - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "VISp",
+                        "VISa",
+                        "VISal",
+                        "VISam",
+                        "VISl",
+                        "VISli",
+                        "VISpl",
+                        "VISpm",
+                        "VISpor",
+                        "VISrl",
+                        "VIS"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass",
+                        "Pass"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2025-10-07T15:28:31.090980Z"
+                    }
+                ],
+                "description": "Manual annotation of visual area label based on ISI imaging for experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "reference": null,
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "ISI Visual Area Label"
+                ],
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "checkbox"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2025-10-07T15:28:31.090980Z"
+                    }
+                ],
+                "description": "Evaluation of experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1 firing rate",
+                "reference": "quality_control/experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1/firing_rate.png",
+                "tags": [
+                    "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                    "Firing Rate"
+                ],
+                "evaluated_assets": null
+            }
+        ],
+        "key_experimenters": null,
+        "notes": null,
+        "default_grouping": [
+            "Firing Rate",
+            "ISI Visual Area Label",
+            "PSD (High Frequency)",
+            "PSD (Low Frequency)",
+            "PSD (Wide Band)",
+            "Probe Drift",
+            "RMS",
+            "Raw Data",
+            "Saturation samples",
+            "Saturation timeline",
+            "Sorting Curation",
+            "Trigger events",
+            "Unit Yield",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+            "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+            "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+            "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+            "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+            "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+            "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+        ],
+        "allow_tag_failures": [],
+        "status": {
+            "Trigger events": "Pending",
+            "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": "Pending",
+            "PSD (High Frequency)": "Pending",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0": "Pending",
+            "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": "Pending",
+            "PSD (Low Frequency)": "Pending",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3": "Pending",
+            "Saturation samples": "Pass",
+            "Unit Yield": "Pending",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2": "Pending",
+            "Sorting Curation": "Pass",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0": "Pending",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1": "Pending",
+            "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": "Pending",
+            "RMS": "Pass",
+            "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": "Pending",
+            "Saturation timeline": "Pending",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2": "Pending",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1": "Pending",
+            "PSD (Wide Band)": "Pass",
+            "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": "Pending",
+            "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": "Pending",
+            "Firing Rate": "Pending",
+            "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3": "Pending",
+            "Probe Drift": "Pending",
+            "Raw Data": "Pending",
+            "ISI Visual Area Label": "Pass",
+            "ecephys": "Pending",
+            "Raw data": "Pending",
+            "Processing": "Pending"
+        }
+    }
+}


### PR DESCRIPTION
PR fixes a bug where already >=v2.0.0 metadata with no applicable upgrader would end up being nulled out during the upgrade process.