### PR TITLE
fix: don't delete external_links before upgrading

### DIFF
--- a/src/aind_metadata_upgrader/metadata/v1v2.py
+++ b/src/aind_metadata_upgrader/metadata/v1v2.py
@@ -12,14 +12,14 @@ class MetadataUpgraderV1V2(CoreUpgrader):
 
         data["schema_version"] = schema_version
 
+        # Rename fields that have changed
+        data["other_identifiers"] = data.get("external_links", {})
+        remove(data, "external_links")
+
         # Remove fields that are gone in v2.0
         remove(data, "id")
         remove(data, "created")
         remove(data, "last_modified")
-        remove(data, "external_links")
-
-        # Rename fields that have changed
-        data["other_identifiers"] = data.get("external_links", {})
 
         # Check that name and location are present
         if "name" not in data:


### PR DESCRIPTION
This PR re-orders two lines of code that were mis-ordered, causing the `Metadata.other_identifiers` to get deleted in all assets.