### PR TITLE
fix: typo causing json func to be evaluated with .get

### DIFF
--- a/src/aind_metadata_upgrader/sync.py
+++ b/src/aind_metadata_upgrader/sync.py
@@ -59,7 +59,7 @@ def upgrade_record(data_dict: dict) -> tuple[Optional[dict], dict]:
             response = client_v2.insert_one_docdb_record(
                 record=upgraded.metadata.model_dump(),
             )
-            v2_id = response.json.get("insertedId", "")
+            v2_id = response.json().get("insertedId", "")
             new_record = None  # already inserted
         else:
             v2_id = records[0]["_id"]


### PR DESCRIPTION
PR fixes a typo that was causing the response.json *function* to be evaluated as if it was a dictionary