### PR TITLE
feat: add support for upgrading software -> Code in tiles

### DIFF
--- a/src/aind_metadata_upgrader/acquisition/v1v2_tiles.py
+++ b/src/aind_metadata_upgrader/acquisition/v1v2_tiles.py
@@ -12,6 +12,7 @@ from aind_data_schema.components.configs import (
     DeviceConfig,
 )
 from aind_data_schema.core.acquisition import DataStream
+from aind_data_schema.components.identifiers import Code
 from aind_data_schema_models.devices import ImmersionMedium
 from aind_data_schema_models.modalities import Modality
 from aind_data_schema_models.units import PowerUnit, SizeUnit, TimeUnit
@@ -297,16 +298,24 @@ def upgrade_tiles_to_data_stream(
     combined_notes = "; ".join(filter(None, tile_notes)) if tile_notes else None
 
     # Handle software
+    codes = None
     if software:
-        print(software)
-        raise NotImplementedError("Software handling is not implemented yet.")
+        codes = []
+        for sw in software:
+            code = Code(
+                url=sw["url"] if "url" in sw and sw["url"] else "(v1v2 upgrade) unknown",
+                name=sw.get("name"),
+                version=sw.get("version"),
+                parameters=sw.get("parameters"),
+            )
+            codes.append(code.model_dump())
 
     # Create single data stream from all tiles
     data_stream = {
         "stream_start_time": stream_start,
         "stream_end_time": stream_end,
         "modalities": modalities,
-        "code": None,
+        "code": codes,
         "notes": combined_notes,
         "active_devices": active_devices,
         "configurations": configurations,

--- a/tests/records/v1/8f1aa962-c05a-4b5f-823a-b5929298a95e.json
+++ b/tests/records/v1/8f1aa962-c05a-4b5f-823a-b5929298a95e.json
@@ -1,0 +1,5000 @@
+{
+    "_id": "8f1aa962-c05a-4b5f-823a-b5929298a95e",
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "schema_version": "1.2.1",
+    "name": "SmartSPIM_839153_2026-02-25_14-13-20_stitched_2026-02-27_08-01-59",
+    "created": "2026-02-27T08:11:58.702908Z",
+    "last_modified": "2026-02-27T11:12:50.206Z",
+    "location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20_stitched_2026-02-27_08-01-59",
+    "metadata_status": "Invalid",
+    "external_links": {
+        "Code Ocean": [
+            "5e702b94-adc6-4c60-bc40-ac4efa83977e",
+            "5fc75f8b-0a70-4008-b26f-a4bc44bfc888"
+        ]
+    },
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Exp-ND-01-001-2416",
+            "maternal_genotype": null,
+            "maternal_id": null,
+            "paternal_genotype": null,
+            "paternal_id": null
+        },
+        "date_of_birth": "2025-10-14",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "wt/wt",
+        "housing": null,
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.3",
+        "sex": "Female",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "839153",
+        "wellness_reports": []
+    },
+    "data_description": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "1.0.4",
+        "license": "CC-BY-4.0",
+        "platform": {
+            "name": "SmartSPIM platform",
+            "abbreviation": "SmartSPIM"
+        },
+        "subject_id": "839153",
+        "creation_time": "2026-02-27T08:01:59.071906Z",
+        "label": null,
+        "name": "SmartSPIM_839153_2026-02-25_14-13-20_stitched_2026-02-27_08-01-59",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "funder": {
+                    "name": "National Institute of Neurological Disorders and Stroke",
+                    "abbreviation": "NINDS",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01s5ya894"
+                },
+                "grant_number": "1U19NS123714-01",
+                "fundee": "Han Hou, Jayaram Chandrashekar, Karel Svoboda, Mathew Summers, Xinxin Yin"
+            }
+        ],
+        "data_level": "derived",
+        "group": null,
+        "investigators": [
+            {
+                "name": "Jayaram Chandrashekar",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Mathew Summers",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "project_name": "Thalamus in the middle - Project 1 Mesoscale thalamic circuits",
+        "restrictions": null,
+        "modality": [
+            {
+                "name": "Selective plane illumination microscopy",
+                "abbreviation": "SPIM"
+            }
+        ],
+        "related_data": [],
+        "data_summary": null,
+        "input_data_name": "SmartSPIM_839153_2026-02-25_14-13-20",
+        "process_name": "stitched"
+    },
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.2.1",
+        "specimen_procedures": [
+            {
+                "antibodies": null,
+                "end_date": "2026-01-24",
+                "experimenter_full_name": "HollyM",
+                "hcr_series": null,
+                "notes": null,
+                "procedure_name": "LifeCanvas Active Whole Mouse Brain Delipidation (UNPUBLISHED)",
+                "procedure_type": "Delipidation",
+                "protocol_id": "https://www.protocols.io/view/whole-mouse-brain-delipidation-lifecanvas-active-cttawnie",
+                "reagents": [
+                    {
+                        "expiration_date": null,
+                        "lot_number": "ON44",
+                        "name": "SH-ON",
+                        "rrid": null,
+                        "source": null
+                    },
+                    {
+                        "expiration_date": null,
+                        "lot_number": "A07T103",
+                        "name": "DB-500",
+                        "rrid": null,
+                        "source": null
+                    },
+                    {
+                        "expiration_date": null,
+                        "lot_number": "A07T103",
+                        "name": "DB-500",
+                        "rrid": null,
+                        "source": null
+                    },
+                    {
+                        "expiration_date": null,
+                        "lot_number": "j245108",
+                        "name": "CB-450",
+                        "rrid": null,
+                        "source": null
+                    }
+                ],
+                "sectioning": null,
+                "specimen_id": "839153",
+                "start_date": "2026-01-16"
+            },
+            {
+                "antibodies": {
+                    "expiration_date": null,
+                    "fluorophore": null,
+                    "immunolabel_class": "Primary",
+                    "mass": null,
+                    "mass_unit": "microgram",
+                    "notes": null,
+                    "rrid": null
+                },
+                "end_date": null,
+                "experimenter_full_name": "HollyM",
+                "hcr_series": null,
+                "notes": null,
+                "procedure_name": "SmartSPIM Labeling",
+                "procedure_type": "Immunolabeling",
+                "protocol_id": null,
+                "reagents": [],
+                "sectioning": null,
+                "specimen_id": "839153",
+                "start_date": null
+            },
+            {
+                "antibodies": {
+                    "expiration_date": null,
+                    "fluorophore": null,
+                    "immunolabel_class": "Secondary",
+                    "mass": null,
+                    "mass_unit": "microgram",
+                    "notes": null,
+                    "rrid": null
+                },
+                "end_date": null,
+                "experimenter_full_name": "HollyM",
+                "hcr_series": null,
+                "notes": null,
+                "procedure_name": "SmartSPIM Labeling",
+                "procedure_type": "Immunolabeling",
+                "protocol_id": null,
+                "reagents": [],
+                "sectioning": null,
+                "specimen_id": "839153",
+                "start_date": null
+            },
+            {
+                "antibodies": null,
+                "end_date": "2026-01-29",
+                "experimenter_full_name": "HollyM",
+                "hcr_series": null,
+                "notes": null,
+                "procedure_name": "Refractive Index Matching - EasyIndex",
+                "procedure_type": "Refractive index matching",
+                "protocol_id": "https://dx.doi.org/10.17504/protocols.io.kxygx965kg8j/v1",
+                "reagents": [
+                    {
+                        "expiration_date": null,
+                        "lot_number": "EI81",
+                        "name": "EI-500-1.52",
+                        "rrid": null,
+                        "source": null
+                    }
+                ],
+                "sectioning": null,
+                "specimen_id": "839153",
+                "start_date": "2026-01-26"
+            }
+        ],
+        "subject_id": "839153",
+        "subject_procedures": [
+            {
+                "anaesthesia": null,
+                "animal_weight_post": null,
+                "animal_weight_prior": null,
+                "experimenter_full_name": "30509",
+                "iacuc_protocol": "2416",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "output_specimen_ids": [
+                            "839153"
+                        ],
+                        "procedure_type": "Perfusion",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.8epv51bejl1b/v6"
+                    }
+                ],
+                "start_date": "2025-12-19",
+                "weight_unit": "gram",
+                "workstation_id": null
+            },
+            {
+                "anaesthesia": {
+                    "duration": "150.0",
+                    "duration_unit": "minute",
+                    "level": "1.5",
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": "16.2",
+                "animal_weight_prior": "16.5",
+                "experimenter_full_name": "NSB-1608",
+                "iacuc_protocol": "2416",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": "-1.6",
+                        "injection_coordinate_depth": [
+                            "2.0"
+                        ],
+                        "injection_coordinate_ml": "3.6",
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Right",
+                        "injection_materials": [
+                            {
+                                "addgene_id": null,
+                                "material_type": "Virus",
+                                "name": null,
+                                "tars_identifiers": {
+                                    "plasmid_tars_alias": null,
+                                    "prep_date": "2023-06-13",
+                                    "prep_lot_number": "230519-16",
+                                    "prep_protocol": null,
+                                    "prep_type": null,
+                                    "virus_tars_id": "AiV300077"
+                                },
+                                "titer": 33800000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "injection_volume": [
+                            "200.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "instrument_id": null,
+                        "procedure_type": "Nanoject injection",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4",
+                        "recovery_time": "5.0",
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    },
+                    {
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": "0.8",
+                        "injection_coordinate_depth": [
+                            "2.0"
+                        ],
+                        "injection_coordinate_ml": "3.2",
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Right",
+                        "injection_materials": [
+                            {
+                                "addgene_id": null,
+                                "material_type": "Virus",
+                                "name": null,
+                                "tars_identifiers": {
+                                    "plasmid_tars_alias": null,
+                                    "prep_date": "2023-06-13",
+                                    "prep_lot_number": "230526-16",
+                                    "prep_protocol": null,
+                                    "prep_type": null,
+                                    "virus_tars_id": "AiV300075"
+                                },
+                                "titer": 353000000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "injection_volume": [
+                            "200.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "instrument_id": null,
+                        "procedure_type": "Nanoject injection",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4",
+                        "recovery_time": "5.0",
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    }
+                ],
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2",
+                "start_date": "2025-11-21",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 3"
+            }
+        ]
+    },
+    "session": null,
+    "rig": null,
+    "processing": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "schema_version": "1.1.4",
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "name": "Image flat-field correction",
+                    "software_version": "0.0.3",
+                    "start_date_time": "2026-02-26T18:47:07.115447Z",
+                    "end_date_time": "2026-02-26T19:47:28.091091Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_561_Em_593",
+                    "output_location": "/tmp/nxf.XoYNfIutJw/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-flatfield-estimation",
+                    "code_version": "0.0.3",
+                    "parameters": {
+                        "shading_parameters": {
+                            "get_darkfield": false,
+                            "smoothness_flatfield": 1,
+                            "smoothness_darkfield": 20,
+                            "sort_intensity": true,
+                            "max_reweight_iterations": 35,
+                            "resize_mode": "skimage_dask",
+                            "max_workers": 4
+                        }
+                    },
+                    "outputs": {
+                        "flatfield_paths": [
+                            "/tmp/nxf.XoYNfIutJw/capsule/results/estimated_flat_laser_Ex_561_Em_593_side_0.tif",
+                            "/tmp/nxf.XoYNfIutJw/capsule/results/estimated_flat_laser_Ex_561_Em_593_side_1.tif"
+                        ]
+                    },
+                    "notes": "Flatfield estimation for channel Ex_561_Em_593",
+                    "resources": null
+                },
+                {
+                    "name": "Image flat-field correction",
+                    "software_version": "0.0.3",
+                    "start_date_time": "2026-02-26T19:47:28.091515Z",
+                    "end_date_time": "2026-02-26T20:39:13.168859Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_488_Em_525",
+                    "output_location": "/tmp/nxf.XoYNfIutJw/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-flatfield-estimation",
+                    "code_version": "0.0.3",
+                    "parameters": {
+                        "shading_parameters": {
+                            "get_darkfield": false,
+                            "smoothness_flatfield": 1,
+                            "smoothness_darkfield": 20,
+                            "sort_intensity": true,
+                            "max_reweight_iterations": 35,
+                            "resize_mode": "skimage_dask",
+                            "max_workers": 4
+                        }
+                    },
+                    "outputs": {
+                        "flatfield_paths": [
+                            "/tmp/nxf.XoYNfIutJw/capsule/results/estimated_flat_laser_Ex_488_Em_525_side_0.tif",
+                            "/tmp/nxf.XoYNfIutJw/capsule/results/estimated_flat_laser_Ex_488_Em_525_side_1.tif"
+                        ]
+                    },
+                    "notes": "Flatfield estimation for channel Ex_488_Em_525",
+                    "resources": null
+                },
+                {
+                    "name": "Image flat-field correction",
+                    "software_version": "0.0.3",
+                    "start_date_time": "2026-02-26T20:39:13.169133Z",
+                    "end_date_time": "2026-02-26T21:23:53.018561Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_639_Em_667",
+                    "output_location": "/tmp/nxf.XoYNfIutJw/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-flatfield-estimation",
+                    "code_version": "0.0.3",
+                    "parameters": {
+                        "shading_parameters": {
+                            "get_darkfield": false,
+                            "smoothness_flatfield": 1,
+                            "smoothness_darkfield": 20,
+                            "sort_intensity": true,
+                            "max_reweight_iterations": 35,
+                            "resize_mode": "skimage_dask",
+                            "max_workers": 4
+                        }
+                    },
+                    "outputs": {
+                        "flatfield_paths": [
+                            "/tmp/nxf.XoYNfIutJw/capsule/results/estimated_flat_laser_Ex_639_Em_667_side_0.tif",
+                            "/tmp/nxf.XoYNfIutJw/capsule/results/estimated_flat_laser_Ex_639_Em_667_side_1.tif"
+                        ]
+                    },
+                    "notes": "Flatfield estimation for channel Ex_639_Em_667",
+                    "resources": null
+                },
+                {
+                    "name": "Image destriping",
+                    "software_version": "0.0.5",
+                    "start_date_time": "2026-02-26T21:25:02.750730Z",
+                    "end_date_time": "2026-02-27T00:56:19.546577Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_639_Em_667",
+                    "output_location": "/tmp/nxf.0Qji2uvoAA/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.5",
+                    "parameters": {
+                        "no_cells_config": {
+                            "wavelet": "db3",
+                            "level": null,
+                            "sigma": 128,
+                            "max_threshold": 12
+                        },
+                        "cells_config": {
+                            "wavelet": "db3",
+                            "level": null,
+                            "sigma": 64,
+                            "max_threshold": 3
+                        },
+                        "retrospective": true
+                    },
+                    "outputs": {},
+                    "notes": "Destriping for channel Ex_639_Em_667 in zarr format",
+                    "resources": null
+                },
+                {
+                    "name": "Image flat-field correction",
+                    "software_version": "0.0.5",
+                    "start_date_time": "2026-02-26T21:25:02.750730Z",
+                    "end_date_time": "2026-02-27T00:56:19.546577Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_639_Em_667",
+                    "output_location": "/tmp/nxf.0Qji2uvoAA/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.5",
+                    "parameters": {},
+                    "outputs": {},
+                    "notes": "The flats were computed from the data             with basicpy, these were applied with the destriping algorithm             and with the current dark from the microscope.\n            ",
+                    "resources": null
+                },
+                {
+                    "name": "Image destriping",
+                    "software_version": "0.0.5",
+                    "start_date_time": "2026-02-26T21:27:02.378891Z",
+                    "end_date_time": "2026-02-27T01:12:14.380601Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_561_Em_593",
+                    "output_location": "/tmp/nxf.l2J4ds0Pkw/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.5",
+                    "parameters": {
+                        "no_cells_config": {
+                            "wavelet": "db3",
+                            "level": null,
+                            "sigma": 128,
+                            "max_threshold": 12
+                        },
+                        "cells_config": {
+                            "wavelet": "db3",
+                            "level": null,
+                            "sigma": 64,
+                            "max_threshold": 3
+                        },
+                        "retrospective": true
+                    },
+                    "outputs": {},
+                    "notes": "Destriping for channel Ex_561_Em_593 in zarr format",
+                    "resources": null
+                },
+                {
+                    "name": "Image flat-field correction",
+                    "software_version": "0.0.5",
+                    "start_date_time": "2026-02-26T21:27:02.378891Z",
+                    "end_date_time": "2026-02-27T01:12:14.380601Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_561_Em_593",
+                    "output_location": "/tmp/nxf.l2J4ds0Pkw/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.5",
+                    "parameters": {},
+                    "outputs": {},
+                    "notes": "The flats were computed from the data             with basicpy, these were applied with the destriping algorithm             and with the current dark from the microscope.\n            ",
+                    "resources": null
+                },
+                {
+                    "name": "Image destriping",
+                    "software_version": "0.0.5",
+                    "start_date_time": "2026-02-26T21:27:07.440082Z",
+                    "end_date_time": "2026-02-27T01:15:26.214588Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_488_Em_525",
+                    "output_location": "/tmp/nxf.5jMntakpiE/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.5",
+                    "parameters": {
+                        "no_cells_config": {
+                            "wavelet": "db3",
+                            "level": null,
+                            "sigma": 128,
+                            "max_threshold": 12
+                        },
+                        "cells_config": {
+                            "wavelet": "db3",
+                            "level": null,
+                            "sigma": 64,
+                            "max_threshold": 3
+                        },
+                        "retrospective": true
+                    },
+                    "outputs": {},
+                    "notes": "Destriping for channel Ex_488_Em_525 in zarr format",
+                    "resources": null
+                },
+                {
+                    "name": "Image flat-field correction",
+                    "software_version": "0.0.5",
+                    "start_date_time": "2026-02-26T21:27:07.440082Z",
+                    "end_date_time": "2026-02-27T01:15:26.214588Z",
+                    "input_location": "s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20/SPIM/Ex_488_Em_525",
+                    "output_location": "/tmp/nxf.5jMntakpiE/capsule/results",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.5",
+                    "parameters": {},
+                    "outputs": {},
+                    "notes": "The flats were computed from the data             with basicpy, these were applied with the destriping algorithm             and with the current dark from the microscope.\n            ",
+                    "resources": null
+                },
+                {
+                    "name": "Image tile alignment",
+                    "software_version": "e112363",
+                    "start_date_time": "2026-02-27T03:05:31.075928Z",
+                    "end_date_time": "2026-02-27T03:12:36.588028Z",
+                    "input_location": "SmartSPIM_839153_2026-02-25_14-13-20",
+                    "output_location": "/tmp/nxf.tsKhJt2BVA/capsule/results/SmartSPIM_839153_2026-02-25_14-13-20_stitch_channel_Ex_561_Em_593_params.json",
+                    "code_url": "",
+                    "code_version": "1.2.7",
+                    "parameters": {
+                        "stitching": [
+                            "bash",
+                            "./bigstitcher_spark_scripts/run_classes.sh",
+                            "--xml",
+                            "/tmp/nxf.tsKhJt2BVA/capsule/results/bigstitcher.xml",
+                            "--downsampling",
+                            "2,2,2",
+                            "--maxShiftZ",
+                            "20",
+                            "--maxShiftY",
+                            "90",
+                            "--maxShiftX",
+                            "110"
+                        ],
+                        "global_optimization": [
+                            "bash",
+                            "./bigstitcher_spark_scripts/run_classes.sh",
+                            "--xml",
+                            "/tmp/nxf.tsKhJt2BVA/capsule/results/bigstitcher.xml",
+                            "--sourcePoints",
+                            "STITCHING"
+                        ]
+                    },
+                    "outputs": {
+                        "output_file": "/tmp/nxf.tsKhJt2BVA/capsule/results/SmartSPIM_839153_2026-02-25_14-13-20_stitch_channel_Ex_561_Em_593_params.json"
+                    },
+                    "notes": "Running stitching and global optimization separately",
+                    "resources": null
+                },
+                {
+                    "name": "Image tile fusing",
+                    "software_version": "0.0.4",
+                    "start_date_time": "2026-02-27T04:05:02.292668Z",
+                    "end_date_time": "2026-02-27T04:49:47.812844Z",
+                    "input_location": "/tmp/nxf.pzcoR3kX7s/capsule/data/bigstitcher.xml",
+                    "output_location": "/tmp/nxf.pzcoR3kX7s/capsule/results/Ex_561_Em_593.zarr",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-fuse",
+                    "code_version": "0.0.4",
+                    "parameters": {},
+                    "outputs": {
+                        "container_params": {
+                            "parameters": [
+                                "-x",
+                                "/tmp/nxf.pzcoR3kX7s/capsule/scratch/bigstitcher.xml",
+                                "-o",
+                                "/tmp/nxf.pzcoR3kX7s/capsule/results/Ex_561_Em_593.zarr",
+                                "-d",
+                                "UINT16",
+                                "-ds",
+                                "1,1,1",
+                                "-ds",
+                                "2,2,2",
+                                "-ds",
+                                "4,4,4",
+                                "-ds",
+                                "8,8,8",
+                                "-ds",
+                                "16,16,16",
+                                "-ds",
+                                "32,32,32",
+                                "-ds",
+                                "64,64,64",
+                                "-ds",
+                                "128,128,128",
+                                "-ds",
+                                "256,256,256",
+                                "--anisotropyFactor",
+                                "1"
+                            ]
+                        },
+                        "affine_fusion_params": {
+                            "parameters": [
+                                "/home/BigStitcher-Spark/affine-fusion",
+                                "-o",
+                                "/tmp/nxf.pzcoR3kX7s/capsule/results/Ex_561_Em_593.zarr",
+                                "-s",
+                                "ZARR",
+                                "--prefetch"
+                            ]
+                        }
+                    },
+                    "notes": "Fusing channel with BigStitcher",
+                    "resources": null
+                },
+                {
+                    "name": "Image tile fusing",
+                    "software_version": "0.0.4",
+                    "start_date_time": "2026-02-27T03:58:36.535381Z",
+                    "end_date_time": "2026-02-27T04:48:34.648780Z",
+                    "input_location": "/tmp/nxf.c8AsqTzKhs/capsule/data/bigstitcher.xml",
+                    "output_location": "/tmp/nxf.c8AsqTzKhs/capsule/results/Ex_639_Em_667.zarr",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-fuse",
+                    "code_version": "0.0.4",
+                    "parameters": {},
+                    "outputs": {
+                        "container_params": {
+                            "parameters": [
+                                "-x",
+                                "/tmp/nxf.c8AsqTzKhs/capsule/scratch/bigstitcher.xml",
+                                "-o",
+                                "/tmp/nxf.c8AsqTzKhs/capsule/results/Ex_639_Em_667.zarr",
+                                "-d",
+                                "UINT16",
+                                "-ds",
+                                "1,1,1",
+                                "-ds",
+                                "2,2,2",
+                                "-ds",
+                                "4,4,4",
+                                "-ds",
+                                "8,8,8",
+                                "-ds",
+                                "16,16,16",
+                                "-ds",
+                                "32,32,32",
+                                "-ds",
+                                "64,64,64",
+                                "-ds",
+                                "128,128,128",
+                                "-ds",
+                                "256,256,256",
+                                "--anisotropyFactor",
+                                "1"
+                            ]
+                        },
+                        "affine_fusion_params": {
+                            "parameters": [
+                                "/home/BigStitcher-Spark/affine-fusion",
+                                "-o",
+                                "/tmp/nxf.c8AsqTzKhs/capsule/results/Ex_639_Em_667.zarr",
+                                "-s",
+                                "ZARR",
+                                "--prefetch"
+                            ]
+                        }
+                    },
+                    "notes": "Fusing channel with BigStitcher",
+                    "resources": null
+                },
+                {
+                    "name": "Image tile fusing",
+                    "software_version": "0.0.4",
+                    "start_date_time": "2026-02-27T04:20:15.245700Z",
+                    "end_date_time": "2026-02-27T05:20:29.507300Z",
+                    "input_location": "/tmp/nxf.scmVfztMuF/capsule/data/bigstitcher.xml",
+                    "output_location": "/tmp/nxf.scmVfztMuF/capsule/results/Ex_488_Em_525.zarr",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-fuse",
+                    "code_version": "0.0.4",
+                    "parameters": {},
+                    "outputs": {
+                        "container_params": {
+                            "parameters": [
+                                "-x",
+                                "/tmp/nxf.scmVfztMuF/capsule/scratch/bigstitcher.xml",
+                                "-o",
+                                "/tmp/nxf.scmVfztMuF/capsule/results/Ex_488_Em_525.zarr",
+                                "-d",
+                                "UINT16",
+                                "-ds",
+                                "1,1,1",
+                                "-ds",
+                                "2,2,2",
+                                "-ds",
+                                "4,4,4",
+                                "-ds",
+                                "8,8,8",
+                                "-ds",
+                                "16,16,16",
+                                "-ds",
+                                "32,32,32",
+                                "-ds",
+                                "64,64,64",
+                                "-ds",
+                                "128,128,128",
+                                "-ds",
+                                "256,256,256",
+                                "--anisotropyFactor",
+                                "1"
+                            ]
+                        },
+                        "affine_fusion_params": {
+                            "parameters": [
+                                "/home/BigStitcher-Spark/affine-fusion",
+                                "-o",
+                                "/tmp/nxf.scmVfztMuF/capsule/results/Ex_488_Em_525.zarr",
+                                "-s",
+                                "ZARR",
+                                "--prefetch"
+                            ]
+                        }
+                    },
+                    "notes": "Fusing channel with BigStitcher",
+                    "resources": null
+                },
+                {
+                    "name": "Image importing",
+                    "software_version": "0.0.35",
+                    "start_date_time": "2026-02-27T06:29:45.271324Z",
+                    "end_date_time": "2026-02-27T06:29:49.996885Z",
+                    "input_location": "/tmp/nxf.H7Q3VMExdD/capsule/data/fused/Ex_639_Em_667.zarr/3",
+                    "output_location": "/tmp/nxf.H7Q3VMExdD/capsule/data/fused/Ex_639_Em_667.zarr/3",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-ccf-registration",
+                    "code_version": "0.0.35",
+                    "parameters": {},
+                    "outputs": {},
+                    "notes": "Importing fused data for alignment",
+                    "resources": null
+                },
+                {
+                    "name": "Image atlas alignment",
+                    "software_version": "0.0.35",
+                    "start_date_time": "2026-02-27T06:29:50.004051Z",
+                    "end_date_time": "2026-02-27T07:05:44.759200Z",
+                    "input_location": "/tmp/nxf.H7Q3VMExdD/capsule/data/fused/Ex_639_Em_667.zarr/3",
+                    "output_location": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata",
+                    "code_url": "https://github.com/ANTsX/ANTs",
+                    "code_version": "0.4.2",
+                    "parameters": {
+                        "spacing": [
+                            0.016,
+                            0.0144,
+                            0.0144
+                        ],
+                        "unit": "millimetre",
+                        "template_orientations": {
+                            "anterior_to_posterior": 1,
+                            "superior_to_inferior": 2,
+                            "right_to_left": 0
+                        },
+                        "rigid_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_rigid.nii.gz",
+                        "affine_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_affine.nii.gz",
+                        "moved_to_template_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ls_to_template.nii.gz",
+                        "moved_to_ccf_path": "../results/ccf_Ex_639_Em_667/moved_ls_to_ccf.nii.gz",
+                        "ccf_anno_to_brain_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ccf_anno_to_ls.nii.gz",
+                        "new_spacing": [
+                            25,
+                            25,
+                            25
+                        ]
+                    },
+                    "outputs": {},
+                    "notes": "Template based registration: LS -> template -> Allen CCFv3 Atlas",
+                    "resources": null
+                },
+                {
+                    "name": "File format conversion",
+                    "software_version": "0.0.35",
+                    "start_date_time": "2026-02-27T07:05:44.761151Z",
+                    "end_date_time": "2026-02-27T07:06:04.032981Z",
+                    "input_location": "In memory array",
+                    "output_location": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/OMEZarr/image.zarr",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-ccf-registration",
+                    "code_version": "0.0.35",
+                    "parameters": {
+                        "pixel_sizes": [
+                            25,
+                            25,
+                            25
+                        ],
+                        "OMEZarr_params": {
+                            "clevel": 1,
+                            "compressor": "zstd",
+                            "chunks": [
+                                64,
+                                64,
+                                64
+                            ]
+                        }
+                    },
+                    "outputs": {},
+                    "notes": "Converting registered image to OMEZarr",
+                    "resources": null
+                },
+                {
+                    "name": "Image atlas alignment",
+                    "software_version": "0.0.35",
+                    "start_date_time": "2026-02-27T07:05:44.761151Z",
+                    "end_date_time": "2026-02-27T07:13:52.630451Z",
+                    "input_location": "/tmp/nxf.H7Q3VMExdD/capsule/data/fused/Ex_639_Em_667.zarr/3",
+                    "output_location": "In memory array",
+                    "code_url": "https://github.com/ANTsX/ANTs",
+                    "code_version": "0.4.2",
+                    "parameters": {
+                        "spacing": [
+                            0.016,
+                            0.0144,
+                            0.0144
+                        ],
+                        "unit": "millimetre",
+                        "template_orientations": {
+                            "anterior_to_posterior": 1,
+                            "superior_to_inferior": 2,
+                            "right_to_left": 0
+                        },
+                        "rigid_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_rigid.nii.gz",
+                        "affine_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_affine.nii.gz",
+                        "moved_to_template_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ls_to_template.nii.gz",
+                        "moved_to_ccf_path": "../results/ccf_Ex_639_Em_667/moved_ls_to_ccf.nii.gz",
+                        "ccf_anno_to_brain_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ccf_anno_to_ls.nii.gz",
+                        "new_spacing": [
+                            25,
+                            25,
+                            25
+                        ]
+                    },
+                    "outputs": {},
+                    "notes": "Template based reversed registration: annotations in template space -> LS",
+                    "resources": null
+                },
+                {
+                    "name": "Image atlas alignment",
+                    "software_version": "0.0.35",
+                    "start_date_time": "2026-02-27T07:13:52.632197Z",
+                    "end_date_time": "2026-02-27T07:14:53.672140Z",
+                    "input_location": "/tmp/nxf.H7Q3VMExdD/capsule/data/fused/Ex_488_Em_525.zarr/3",
+                    "output_location": "In memory array",
+                    "code_url": "https://github.com/ANTsX/ANTs",
+                    "code_version": "0.4.2",
+                    "parameters": {
+                        "spacing": [
+                            0.016,
+                            0.0144,
+                            0.0144
+                        ],
+                        "unit": "millimetre",
+                        "template_orientations": {
+                            "anterior_to_posterior": 1,
+                            "superior_to_inferior": 2,
+                            "right_to_left": 0
+                        },
+                        "rigid_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_rigid.nii.gz",
+                        "affine_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_affine.nii.gz",
+                        "moved_to_template_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ls_to_template.nii.gz",
+                        "moved_to_ccf_path": "../results/ccf_Ex_639_Em_667/moved_ls_to_ccf.nii.gz",
+                        "ccf_anno_to_brain_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ccf_anno_to_ls.nii.gz",
+                        "new_spacing": [
+                            25,
+                            25,
+                            25
+                        ]
+                    },
+                    "outputs": {},
+                    "notes": "Template based registration using transforms: Ex_488_Em_525",
+                    "resources": null
+                },
+                {
+                    "name": "File format conversion",
+                    "software_version": "0.0.35",
+                    "start_date_time": "2026-02-27T07:14:53.673983Z",
+                    "end_date_time": "2026-02-27T07:15:10.525969Z",
+                    "input_location": "In memory array",
+                    "output_location": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_488_Em_525/OMEZarr/image.zarr",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-ccf-registration",
+                    "code_version": "0.0.35",
+                    "parameters": {
+                        "pixel_sizes": [
+                            25,
+                            25,
+                            25
+                        ],
+                        "OMEZarr_params": {
+                            "clevel": 1,
+                            "compressor": "zstd",
+                            "chunks": [
+                                64,
+                                64,
+                                64
+                            ]
+                        }
+                    },
+                    "outputs": {},
+                    "notes": "Converting registered image for channel Ex_488_Em_525 to OMEZarr",
+                    "resources": null
+                },
+                {
+                    "name": "Image atlas alignment",
+                    "software_version": "0.0.35",
+                    "start_date_time": "2026-02-27T07:15:10.528041Z",
+                    "end_date_time": "2026-02-27T07:16:00.492403Z",
+                    "input_location": "/tmp/nxf.H7Q3VMExdD/capsule/data/fused/Ex_561_Em_593.zarr/3",
+                    "output_location": "In memory array",
+                    "code_url": "https://github.com/ANTsX/ANTs",
+                    "code_version": "0.4.2",
+                    "parameters": {
+                        "spacing": [
+                            0.016,
+                            0.0144,
+                            0.0144
+                        ],
+                        "unit": "millimetre",
+                        "template_orientations": {
+                            "anterior_to_posterior": 1,
+                            "superior_to_inferior": 2,
+                            "right_to_left": 0
+                        },
+                        "rigid_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_rigid.nii.gz",
+                        "affine_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_affine.nii.gz",
+                        "moved_to_template_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ls_to_template.nii.gz",
+                        "moved_to_ccf_path": "../results/ccf_Ex_639_Em_667/moved_ls_to_ccf.nii.gz",
+                        "ccf_anno_to_brain_path": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ccf_anno_to_ls.nii.gz",
+                        "new_spacing": [
+                            25,
+                            25,
+                            25
+                        ]
+                    },
+                    "outputs": {},
+                    "notes": "Template based registration using transforms: Ex_561_Em_593",
+                    "resources": null
+                },
+                {
+                    "name": "File format conversion",
+                    "software_version": "0.0.35",
+                    "start_date_time": "2026-02-27T07:16:00.494148Z",
+                    "end_date_time": "2026-02-27T07:16:18.481320Z",
+                    "input_location": "In memory array",
+                    "output_location": "/tmp/nxf.H7Q3VMExdD/capsule/results/ccf_Ex_561_Em_593/OMEZarr/image.zarr",
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-ccf-registration",
+                    "code_version": "0.0.35",
+                    "parameters": {
+                        "pixel_sizes": [
+                            25,
+                            25,
+                            25
+                        ],
+                        "OMEZarr_params": {
+                            "clevel": 1,
+                            "compressor": "zstd",
+                            "chunks": [
+                                64,
+                                64,
+                                64
+                            ]
+                        }
+                    },
+                    "outputs": {},
+                    "notes": "Converting registered image for channel Ex_561_Em_593 to OMEZarr",
+                    "resources": null
+                }
+            ],
+            "processor_full_name": "Camilo Laiton",
+            "pipeline_version": "5.0.0",
+            "pipeline_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-pipeline",
+            "note": null
+        },
+        "analyses": [],
+        "notes": "New folder structure in cell detection creating a proposals folder and visualization of proposals"
+    },
+    "acquisition": {
+        "active_objectives": [
+            "LCT 3.6x"
+        ],
+        "axes": [
+            {
+                "dimension": 0,
+                "direction": "Superior_to_inferior",
+                "name": "Z",
+                "unit": "micrometer"
+            },
+            {
+                "dimension": 1,
+                "direction": "Anterior_to_posterior",
+                "name": "Y",
+                "unit": "micrometer"
+            },
+            {
+                "dimension": 2,
+                "direction": "Left_to_right",
+                "name": "X",
+                "unit": "micrometer"
+            }
+        ],
+        "calibrations": [],
+        "chamber_immersion": {
+            "medium": "oil",
+            "refractive_index": "1.517"
+        },
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
+        "experimenter_full_name": [
+            "ND"
+        ],
+        "external_storage_directory": null,
+        "instrument_id": "440_SmartSPIM1_20250116",
+        "local_storage_directory": "D:/SmartSPIM_Data",
+        "maintenance": [],
+        "notes": null,
+        "processing_steps": [],
+        "protocol_id": [],
+        "sample_immersion": {
+            "medium": "easy index",
+            "refractive_index": "1.5157"
+        },
+        "schema_version": "1.0.0",
+        "session_end_time": "2026-02-25T18:05:18-08:00",
+        "session_start_time": "2026-02-25T14:13:20-08:00",
+        "session_type": null,
+        "software": [
+            {
+                "name": "SmartSPIM",
+                "parameters": {},
+                "url": null,
+                "version": "6.0.0.108"
+            }
+        ],
+        "specimen_id": "839153",
+        "subject_id": "839153",
+        "tiles": [
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/435530/435530_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/435530/435530_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/435530/435530_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/467930/467930_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/467930/467930_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/467930/467930_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/500330/500330_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/500330/500330_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/500330/500330_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/532730/532730_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/532730/532730_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "19305.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/532730/532730_193050/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/435530/435530_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/435530/435530_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/435530/435530_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/467930/467930_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/467930/467930_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/467930/467930_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/500330/500330_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/500330/500330_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/500330/500330_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/532730/532730_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/532730/532730_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "21897.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/532730/532730_218970/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/435530/435530_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/435530/435530_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/435530/435530_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/467930/467930_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/467930/467930_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/467930/467930_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/500330/500330_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/500330/500330_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/500330/500330_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/532730/532730_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/532730/532730_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "24489.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/532730/532730_244890/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/435530/435530_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/435530/435530_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/435530/435530_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/467930/467930_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/467930/467930_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/467930/467930_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/500330/500330_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/500330/500330_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/500330/500330_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/532730/532730_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/532730/532730_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "27081.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/532730/532730_270810/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/435530/435530_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/435530/435530_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/435530/435530_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/467930/467930_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/467930/467930_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/467930/467930_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/500330/500330_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/500330/500330_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/500330/500330_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/532730/532730_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/532730/532730_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "29673.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/532730/532730_296730/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/435530/435530_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/435530/435530_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43553.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/435530/435530_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 35,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/467930/467930_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 43.5,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/467930/467930_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 45,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46793.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/467930/467930_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/500330/500330_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/500330/500330_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "50033.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/500330/500330_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 30,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/532730/532730_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/532730/532730_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 41.6,
+                    "excitation_power_unit": "milliwatt",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53273.0",
+                            "32265.0",
+                            "-17.9"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/532730/532730_322650/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is based on measured values at sample location.\nSee the notes in calibration file at`raw data top directory`/SPIM/derivatives/laser_calibration."
+            }
+        ]
+    },
+    "instrument": {
+        "additional_devices": [
+            {
+                "additional_settings": {},
+                "device_type": "Additional imaging device",
+                "imaging_device_type": "Other",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Julabo",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "200F",
+                "name": "Chiller",
+                "notes": "Water chiller for camera cooling",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "10436130"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Additional imaging device",
+                "imaging_device_type": "Other",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Optotune",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "EL-16-40-TC",
+                "name": "tunable lens",
+                "notes": "Electrically tunable lens",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Additional imaging device",
+                "imaging_device_type": "Other",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Optotune",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "EL-16-40-TC",
+                "name": "tunable lens",
+                "notes": "Electrically tunable lens",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Additional imaging device",
+                "imaging_device_type": "Sample Chamber",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "LifeCanvas",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "Large-uncoated-glass",
+                "name": "Sample Chamber",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1"
+            }
+        ],
+        "calibration_data": null,
+        "calibration_date": null,
+        "com_ports": [
+            {
+                "com_port": "COM3",
+                "hardware_name": "Laser Launch"
+            },
+            {
+                "com_port": "COM5",
+                "hardware_name": "Applied Scientific Instrumentation Tiger"
+            },
+            {
+                "com_port": "COM10",
+                "hardware_name": "MightyZap"
+            }
+        ],
+        "daqs": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
+        "detectors": [
+            {
+                "additional_settings": {},
+                "bin_height": null,
+                "bin_mode": "None",
+                "bin_unit": "pixel",
+                "bin_width": null,
+                "bit_depth": null,
+                "chroma": null,
+                "computer_name": null,
+                "cooling": "Water",
+                "crop_height": null,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": null,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": null,
+                "immersion": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Hamamatsu",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03natb733"
+                },
+                "model": "C14440-20UP",
+                "name": "Camera",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "220302-SYS-060443",
+                "size_unit": "pixel"
+            }
+        ],
+        "enclosure": null,
+        "fluorescence_filters": [
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 0,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-469/35-32",
+                "name": "Em_469",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 1,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF03-525/50-32",
+                "name": "Em_525",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 2,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-593/40-32",
+                "name": "Em_593",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 3,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-624/40-32",
+                "name": "Em_624",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 4,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Chroma",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "ET667/30m",
+                "name": "Em_667",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-3",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 700,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Long pass",
+                "filter_wheel_index": 5,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FELH0700",
+                "name": "Em_700",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Long pass",
+                "filter_wheel_index": 6,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "none000",
+                "name": "Em_000",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": "0.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            }
+        ],
+        "humidity_control": false,
+        "instrument_id": "440_SmartSPIM1_20250116",
+        "instrument_type": "SmartSPIM",
+        "lenses": [],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "150",
+                "model": "Stradus",
+                "name": "Ex_445",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 445,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "150",
+                "model": "Stradus",
+                "name": "Ex_488",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 488,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "150",
+                "model": "Obis",
+                "name": "Ex_561",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "",
+                "wavelength": 561,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "150",
+                "model": "Stradus",
+                "name": "Ex_594",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 594,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "160",
+                "model": "Stradus",
+                "name": "Ex_639",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "",
+                "wavelength": 639,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "160",
+                "model": "Stradus",
+                "name": "Ex_665",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 665,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "manufacturer": {
+            "abbreviation": null,
+            "name": "LifeCanvas",
+            "registry": null,
+            "registry_identifier": null
+        },
+        "modification_date": "2025-01-16",
+        "motorized_stages": [
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-100",
+                "name": "Focus stage",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-0",
+                "travel": "100",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": "Cylindrical lens #1",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1",
+                "travel": "41",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": "Cylindrical lens #2",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "travel": "41",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": "Cylindrical lens #3",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-3",
+                "travel": "41",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": "Cylindrical lens #4",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-4",
+                "travel": "41",
+                "travel_unit": "millimeter"
+            }
+        ],
+        "notes": null,
+        "objectives": [
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "multi",
+                "magnification": "3.6",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "TL4X-SAP",
+                "name": "LCT 3.6x",
+                "notes": "Thorlabs TL4X-SAP with LifeCanvas dipping cap and correction optics.",
+                "numerical_aperture": "0.2",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "multi",
+                "magnification": "1.6",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "TL2X-SAP",
+                "name": "LCT 1.625x",
+                "notes": null,
+                "numerical_aperture": "0.1",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "water",
+                "magnification": "16.0",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Nikon",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "0280y9h11"
+                },
+                "model": "MRD77220",
+                "name": "Nikon16x",
+                "notes": null,
+                "numerical_aperture": "0.8",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown"
+            }
+        ],
+        "optical_tables": [
+            {
+                "additional_settings": {},
+                "device_type": "Optical table",
+                "length": "29.5",
+                "manufacturer": {
+                    "abbreviation": "TMC",
+                    "name": "Technical Manufacturing Corporation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "63-533 micro-g",
+                "name": "Table McTable Face",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "2008983",
+                "table_size_unit": "inch",
+                "vibration_control": true,
+                "width": "35.5"
+            }
+        ],
+        "scanning_stages": [
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": "Sample stage Z",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-0",
+                "stage_axis_direction": "Detection axis",
+                "stage_axis_name": "Z",
+                "travel": "50",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": "Sample stage X",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1",
+                "stage_axis_direction": "Illumination axis",
+                "stage_axis_name": "X",
+                "travel": "50",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": "Sample stage Y",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "stage_axis_direction": "Perpendicular axis",
+                "stage_axis_name": "Y",
+                "travel": "50",
+                "travel_unit": "millimeter"
+            }
+        ],
+        "schema_version": "1.0.0",
+        "temperature_control": false
+    },
+    "quality_control": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/quality_control.py",
+        "schema_version": "1.2.2",
+        "evaluations": [
+            {
+                "modality": {
+                    "name": "Selective plane illumination microscopy",
+                    "abbreviation": "SPIM"
+                },
+                "stage": "Processing",
+                "name": "Neuroglancer Link Evaluation",
+                "description": "Checks that the whole-brain neuroglancer link was created",
+                "metrics": [
+                    {
+                        "name": "Dataset neuroglancer link",
+                        "value": "",
+                        "status_history": [
+                            {
+                                "evaluator": "Automated",
+                                "status": "Pending",
+                                "timestamp": "2026-02-27T00:02:05.606378-08:00"
+                            }
+                        ],
+                        "description": "",
+                        "reference": "https://neuroglancer-demo.appspot.com/#!s3://aind-open-data/SmartSPIM_839153_2026-02-25_14-13-20_stitched_2026-02-27_08-01-59/neuroglancer_config.json",
+                        "evaluated_assets": null
+                    }
+                ],
+                "tags": null,
+                "notes": "",
+                "allow_failed_metrics": false,
+                "latest_status": "Pending",
+                "created": "2026-02-27T00:02:05.606378-08:00"
+            }
+        ],
+        "notes": null
+    }
+}


### PR DESCRIPTION
PR adds support for upgrading the software field from the old tiles to the DataStream Code object. Includes a new test asset that requires this code to upgrade.