### PR TITLE
fix: allow BrainInjections to be built with missing coordinates

### DIFF
--- a/src/aind_metadata_upgrader/procedures/v1v2_injections.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2_injections.py
@@ -199,6 +199,13 @@ def build_relative_position_from_hemisphere(data: dict) -> list:
     return relative_position
 
 
+def ensure_coordinates_match_dynamics(coordinates: list, dynamics: list) -> list:
+    """Ensure coordinates list has an entry for each dynamic, filling with empty translations if needed"""
+    if not coordinates:
+        coordinates = [[Translation(translation=[]).model_dump()] for _ in dynamics]
+    return coordinates
+
+
 def ensure_injection_materials_with_default(injection_materials: list) -> list:
     """Ensure injection materials list has at least one item, adding default if empty"""
     if len(injection_materials) == 0:
@@ -259,6 +266,8 @@ def upgrade_nanoject_injection(data: dict) -> tuple[dict, list]:
             ).model_dump()
         )
 
+    coordinates = ensure_coordinates_match_dynamics(data.get("coordinates", []), dynamics)
+
     injection = BrainInjection(
         injection_materials=injection_materials,
         targeted_structure=upgrade_targeted_structure(data.get("targeted_structure")),
@@ -266,7 +275,7 @@ def upgrade_nanoject_injection(data: dict) -> tuple[dict, list]:
         dynamics=dynamics,
         protocol_id=data.get("protocol_id", None),
         coordinate_system_name=CoordinateSystemLibrary.BREGMA_ARID.name,
-        coordinates=data.get("coordinates", []),
+        coordinates=coordinates,
     )
 
     return injection.model_dump(), measured_coordinates
@@ -323,7 +332,7 @@ def upgrade_iontophoresis_injection(data: dict) -> tuple[dict, list]:
         dynamics=dynamics,
         protocol_id=data.get("protocol_id", None),
         coordinate_system_name=CoordinateSystemLibrary.BREGMA_ARID.name,
-        coordinates=data.get("coordinates", []),
+        coordinates=ensure_coordinates_match_dynamics(data.get("coordinates", []), dynamics),
     )
 
     return injection.model_dump(), measured_coordinates

--- a/tests/records/v1/f65ce519-b23b-4a26-be79-0380dec84be7.json
+++ b/tests/records/v1/f65ce519-b23b-4a26-be79-0380dec84be7.json
@@ -1,0 +1,3266 @@
+{
+    "_id": "f65ce519-b23b-4a26-be79-0380dec84be7",
+    "acquisition": {
+        "active_objectives": null,
+        "axes": [
+            {
+                "dimension": 0,
+                "direction": "Superior_to_inferior",
+                "name": "Z",
+                "unit": "micrometer"
+            },
+            {
+                "dimension": 1,
+                "direction": "Anterior_to_posterior",
+                "name": "Y",
+                "unit": "micrometer"
+            },
+            {
+                "dimension": 2,
+                "direction": "Left_to_right",
+                "name": "X",
+                "unit": "micrometer"
+            }
+        ],
+        "calibrations": [],
+        "chamber_immersion": {
+            "medium": "oil",
+            "refractive_index": "1.5178"
+        },
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
+        "experimenter_full_name": [
+            "John Rohde"
+        ],
+        "external_storage_directory": "",
+        "instrument_id": "440_SmartSPIM1_20240325",
+        "local_storage_directory": "D:/SmartSPIM_Data",
+        "maintenance": [],
+        "notes": "Chamber immersion: Cargille 1.52 - Sample immersion: EasyIndex",
+        "processing_steps": [],
+        "protocol_id": [],
+        "sample_immersion": {
+            "medium": "other",
+            "refractive_index": "1.5156"
+        },
+        "schema_version": "0.6.8",
+        "session_end_time": "2024-04-13T12:53:36",
+        "session_start_time": "2024-04-12T21:51:26",
+        "session_type": null,
+        "specimen_id": "",
+        "subject_id": "716005",
+        "tiles": [
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "49933.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/426910.0/426910.0_499330.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "49933.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/426910.0/426910.0_499330.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "52525.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/459310.0/459310.0_525250.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "52525.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/459310.0/459310.0_525250.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "52525.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/491710.0/491710.0_525250.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "52525.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/491710.0/491710.0_525250.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "52525.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/524110.0/524110.0_525250.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "52525.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/524110.0/524110.0_525250.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "55117.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/426910.0/426910.0_551170.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "55117.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/426910.0/426910.0_551170.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "55117.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/459310.0/459310.0_551170.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "55117.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/459310.0/459310.0_551170.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "49933.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/459310.0/459310.0_499330.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "55117.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/491710.0/491710.0_551170.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "55117.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/491710.0/491710.0_551170.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "55117.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/524110.0/524110.0_551170.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "55117.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/524110.0/524110.0_551170.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "57709.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/426910.0/426910.0_577090.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "57709.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/426910.0/426910.0_577090.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "57709.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/459310.0/459310.0_577090.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "57709.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/459310.0/459310.0_577090.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "57709.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/491710.0/491710.0_577090.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "57709.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/491710.0/491710.0_577090.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "49933.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/459310.0/459310.0_499330.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "57709.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/524110.0/524110.0_577090.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "57709.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/524110.0/524110.0_577090.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "60301.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/426910.0/426910.0_603010.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "60301.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/426910.0/426910.0_603010.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "60301.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/459310.0/459310.0_603010.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "60301.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/459310.0/459310.0_603010.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "60301.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/491710.0/491710.0_603010.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "60301.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/491710.0/491710.0_603010.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "60301.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/524110.0/524110.0_603010.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "60301.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/524110.0/524110.0_603010.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "49933.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/491710.0/491710.0_499330.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "62893.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/426910.0/426910.0_628930.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "62893.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/426910.0/426910.0_628930.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "62893.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/459310.0/459310.0_628930.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "62893.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/459310.0/459310.0_628930.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "62893.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/491710.0/491710.0_628930.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "62893.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/491710.0/491710.0_628930.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "62893.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/524110.0/524110.0_628930.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "62893.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/524110.0/524110.0_628930.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "65485.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/426910.0/426910.0_654850.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "65485.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/426910.0/426910.0_654850.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "49933.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/491710.0/491710.0_499330.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "65485.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/459310.0/459310.0_654850.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "45931.0",
+                            "65485.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/459310.0/459310.0_654850.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "65485.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/491710.0/491710.0_654850.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49171.0",
+                            "65485.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/491710.0/491710.0_654850.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "65485.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/524110.0/524110.0_654850.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "65485.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/524110.0/524110.0_654850.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "49933.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/524110.0/524110.0_499330.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "52411.0",
+                            "49933.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/524110.0/524110.0_499330.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "488",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 25,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 1,
+                    "light_source_name": "488"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "52525.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_488_Em_525/426910.0/426910.0_525250.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "42691.0",
+                            "52525.0",
+                            "61.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/426910.0/426910.0_525250.0/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            }
+        ]
+    },
+    "created": "2024-06-20T21:10:50.238599",
+    "data_description": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "1.0.0",
+        "license": "CC-BY-4.0",
+        "platform": {
+            "name": "SmartSPIM platform",
+            "abbreviation": "SmartSPIM"
+        },
+        "subject_id": "716005",
+        "creation_time": "2024-04-12T21:51:26-04:00",
+        "label": null,
+        "name": "SmartSPIM_716005_2024-04-12_21-51-26",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "funder": {
+                    "name": "National Institute of Neurological Disorders and Stroke",
+                    "abbreviation": "NINDS",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01s5ya894"
+                },
+                "grant_number": "1U19NS123714-01",
+                "fundee": "Han Hou, Jayaram Chandrashekar, Karel Svoboda, Mathew Summers, Xinxin Yin"
+            }
+        ],
+        "data_level": "raw",
+        "group": null,
+        "investigators": [
+            {
+                "name": "Jayaram Chandrashekar",
+                "abbreviation": null,
+                "registry": {
+                    "name": "Open Researcher and Contributor ID",
+                    "abbreviation": "ORCID"
+                },
+                "registry_identifier": null
+            },
+            {
+                "name": "Mathew Summers",
+                "abbreviation": null,
+                "registry": {
+                    "name": "Open Researcher and Contributor ID",
+                    "abbreviation": "ORCID"
+                },
+                "registry_identifier": null
+            }
+        ],
+        "project_name": "Thalamus in the middle - Project 2 Cell-type specific thalamocortical projectome",
+        "restrictions": null,
+        "modality": [
+            {
+                "name": "Selective plane illumination microscopy",
+                "abbreviation": "SPIM"
+            }
+        ],
+        "related_data": [],
+        "data_summary": null
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "13815d8f-69ff-4d2f-9ab6-d056e2fce88c"
+        ]
+    },
+    "instrument": {
+        "additional_devices": [
+            {
+                "device_type": "AdditionalImagingDevice",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Julabo",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "200F",
+                "name": null,
+                "notes": null,
+                "serial_number": "10436130",
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Optotune",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "EL-16-40-TC",
+                "name": null,
+                "notes": null,
+                "serial_number": "Unknown-1",
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Optotune",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "EL-16-40-TC",
+                "name": null,
+                "notes": null,
+                "serial_number": "Unknown-2",
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "LifeCanvas",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "Large-uncoated-glass",
+                "name": null,
+                "notes": null,
+                "serial_number": "Unknown-1",
+                "type": "Sample Chamber"
+            }
+        ],
+        "calibration_data": null,
+        "calibration_date": null,
+        "com_ports": [
+            {
+                "com_port": "COM3",
+                "hardware_name": "Laser Launch"
+            },
+            {
+                "com_port": "COM5",
+                "hardware_name": "Applied Scientific Instrumentation Tiger"
+            },
+            {
+                "com_port": "COM10",
+                "hardware_name": "MightyZap"
+            }
+        ],
+        "daqs": null,
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
+        "detectors": [
+            {
+                "bin_height": null,
+                "bin_mode": "none",
+                "bin_unit": "pixel",
+                "bin_width": null,
+                "bit_depth": null,
+                "chroma": null,
+                "cooling": "water",
+                "crop_height": null,
+                "crop_unit": "pixel",
+                "crop_width": null,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "device_type": "Detector",
+                "gain": null,
+                "immersion": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Hamamatsu",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03natb733"
+                },
+                "model": "C14440-20UP",
+                "name": null,
+                "notes": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "220302-SYS-060443",
+                "size_unit": "pixel"
+            }
+        ],
+        "fluorescence_filters": [
+            {
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": 32,
+                "filter_type": "Band pass",
+                "filter_wheel_index": 0,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-469/35-32",
+                "name": "Em_469",
+                "notes": null,
+                "serial_number": "Unknown-1",
+                "size_unit": "millimeter",
+                "thickness": 2,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": 25,
+                "filter_type": "Band pass",
+                "filter_wheel_index": 1,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF03-525/50-32",
+                "name": "Em_525",
+                "notes": null,
+                "serial_number": "Unknown-1",
+                "size_unit": "millimeter",
+                "thickness": 2,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": 32,
+                "filter_type": "Band pass",
+                "filter_wheel_index": 2,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-593/40-32",
+                "name": "Em_593",
+                "notes": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": 2,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": 32,
+                "filter_type": "Band pass",
+                "filter_wheel_index": 3,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-624/40-32",
+                "name": "Em_624",
+                "notes": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": 2,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": 32,
+                "filter_type": "Band pass",
+                "filter_wheel_index": 4,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Chroma",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "ET667/30m",
+                "name": "Em_667",
+                "notes": null,
+                "serial_number": "Unknown-3",
+                "size_unit": "millimeter",
+                "thickness": 2,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": 32,
+                "filter_type": "Long pass",
+                "filter_wheel_index": 5,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FELH0700",
+                "name": "Em_700",
+                "notes": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": 2,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            }
+        ],
+        "humidity_control": false,
+        "instrument_id": "440_SmartSPIM1_20240325",
+        "instrument_type": "SmartSPIM",
+        "lenses": null,
+        "light_sources": [
+            {
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": 150,
+                "model": "Stradus",
+                "name": "Ex_445",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 445,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": 150,
+                "model": "Stradus",
+                "name": "Ex_488",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 488,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": 150,
+                "model": "Obis",
+                "name": "Ex_561",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "power_unit": "milliwatt",
+                "serial_number": "",
+                "wavelength": 561,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": 150,
+                "model": "Stradus",
+                "name": "Ex_594",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 594,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": 160,
+                "model": "Stradus",
+                "name": "Ex_639",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "power_unit": "milliwatt",
+                "serial_number": "",
+                "wavelength": 639,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": 160,
+                "model": "Stradus",
+                "name": "Ex_665",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 665,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "manufacturer": {
+            "abbreviation": null,
+            "name": "LifeCanvas",
+            "registry": null,
+            "registry_identifier": null
+        },
+        "modification_date": "2024-03-25",
+        "motorized_stages": [
+            {
+                "device_type": "MotorizedStage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-100",
+                "name": null,
+                "notes": "Focus stage",
+                "serial_number": "Unknown-0",
+                "travel": 100,
+                "travel_unit": "millimeter"
+            },
+            {
+                "device_type": "MotorizedStage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": null,
+                "notes": "Cylindrical lens #1",
+                "serial_number": "Unknown-1",
+                "travel": 41,
+                "travel_unit": "millimeter"
+            },
+            {
+                "device_type": "MotorizedStage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": null,
+                "notes": "Cylindrical lens #2",
+                "serial_number": "Unknown-2",
+                "travel": 41,
+                "travel_unit": "millimeter"
+            },
+            {
+                "device_type": "MotorizedStage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": null,
+                "notes": "Cylindrical lens #3",
+                "serial_number": "Unknown-3",
+                "travel": 41,
+                "travel_unit": "millimeter"
+            },
+            {
+                "device_type": "MotorizedStage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": null,
+                "notes": "Cylindrical lens #4",
+                "serial_number": "Unknown-4",
+                "travel": 41,
+                "travel_unit": "millimeter"
+            }
+        ],
+        "notes": null,
+        "objectives": [
+            {
+                "device_type": "Objective",
+                "immersion": "multi",
+                "magnification": 3.6,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "TL4X-SAP",
+                "name": null,
+                "notes": "Thorlabs TL4X-SAP with LifeCanvas dipping cap and correction optics.",
+                "numerical_aperture": 0.2,
+                "serial_number": "Unknown"
+            },
+            {
+                "device_type": "Objective",
+                "immersion": "multi",
+                "magnification": 1.6,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "TL2X-SAP",
+                "name": null,
+                "notes": null,
+                "numerical_aperture": 0.1,
+                "serial_number": "Unknown"
+            },
+            {
+                "device_type": "Objective",
+                "immersion": "water",
+                "magnification": 16,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Nikon",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "0280y9h11"
+                },
+                "model": "MRD77220",
+                "name": null,
+                "notes": null,
+                "numerical_aperture": 0.8,
+                "serial_number": "Unknown"
+            }
+        ],
+        "optical_tables": [
+            {
+                "device_type": "OpticalTable",
+                "length": 29.5,
+                "manufacturer": {
+                    "abbreviation": "TMC",
+                    "name": "Technical Manufacturing Corporation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "63-533 micro-g",
+                "name": null,
+                "notes": null,
+                "serial_number": "2008983",
+                "table_size_unit": "inch",
+                "vibration_control": true,
+                "width": 35.5
+            }
+        ],
+        "scanning_stages": [
+            {
+                "device_type": "MotorizedStage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": null,
+                "notes": "Sample stage Z",
+                "serial_number": "Unknown-0",
+                "stage_axis_direction": "Detection axis",
+                "stage_axis_name": "Z",
+                "travel": 50,
+                "travel_unit": "millimeter"
+            },
+            {
+                "device_type": "MotorizedStage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": null,
+                "notes": "Sample stage X",
+                "serial_number": "Unknown-1",
+                "stage_axis_direction": "Illumination axis",
+                "stage_axis_name": "X",
+                "travel": 50,
+                "travel_unit": "millimeter"
+            },
+            {
+                "device_type": "MotorizedStage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": null,
+                "notes": "Sample stage Y",
+                "serial_number": "Unknown-2",
+                "stage_axis_direction": "Perpendicular axis",
+                "stage_axis_name": "Y",
+                "travel": 50,
+                "travel_unit": "millimeter"
+            }
+        ],
+        "schema_version": "0.9.0",
+        "temperature_control": false
+    },
+    "last_modified": "2025-11-07T19:02:10.019Z",
+    "location": "s3://aind-open-data/SmartSPIM_716005_2024-04-12_21-51-26",
+    "metadata_status": "Unknown",
+    "name": "SmartSPIM_716005_2024-04-12_21-51-26",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "schema_version": "1.2.1",
+        "subject_id": "716005",
+        "subject_procedures": [
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2024-03-28",
+                "experimenter_full_name": "30770",
+                "iacuc_protocol": "2109",
+                "animal_weight_prior": null,
+                "animal_weight_post": null,
+                "weight_unit": "gram",
+                "anaesthesia": null,
+                "workstation_id": null,
+                "procedures": [
+                    {
+                        "procedure_type": "Perfusion",
+                        "output_specimen_ids": [
+                            "716005"
+                        ],
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.8epv51bejl1b/v6"
+                    }
+                ],
+                "notes": null
+            },
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2024-02-07",
+                "experimenter_full_name": "NSB-562",
+                "iacuc_protocol": "2109",
+                "animal_weight_prior": "27.1",
+                "animal_weight_post": "27.1",
+                "weight_unit": "gram",
+                "anaesthesia": {
+                    "type": "isoflurane",
+                    "duration": "78.0",
+                    "duration_unit": "minute",
+                    "level": "1.5"
+                },
+                "workstation_id": "SWS 4",
+                "procedures": [
+                    {
+                        "injection_materials": [],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "2.0",
+                        "injection_coordinate_ap": "-7.5",
+                        "injection_coordinate_depth": [
+                            "1.75",
+                            "0.9"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": null,
+                        "injection_hemisphere": "Right",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "100.0",
+                            "100.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4"
+                    },
+                    {
+                        "injection_materials": [],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "-2.0",
+                        "injection_coordinate_ap": "-7.5",
+                        "injection_coordinate_depth": [
+                            "1.75",
+                            "0.9"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": null,
+                        "injection_hemisphere": "Left",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "100.0",
+                            "100.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4"
+                    },
+                    {
+                        "injection_materials": [],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "0.0",
+                        "injection_coordinate_ap": "-5.75",
+                        "injection_coordinate_depth": [
+                            "-0.5"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": null,
+                        "injection_hemisphere": null,
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "100.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4"
+                    },
+                    {
+                        "injection_materials": [],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": null,
+                        "injection_coordinate_ap": null,
+                        "injection_coordinate_depth": null,
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": null,
+                        "injection_hemisphere": "Left",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "100.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4"
+                    }
+                ],
+                "notes": null,
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2"
+            }
+        ],
+        "specimen_procedures": [],
+        "notes": null
+    },
+    "processing": null,
+    "rig": null,
+    "schema_version": "0.2.7",
+    "session": null,
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "RCL-H2B-GFP(ND)",
+            "maternal_genotype": "RCL-H2B-GFP/RCL-H2B-GFP",
+            "maternal_id": "697309",
+            "paternal_genotype": "RCL-H2B-GFP/RCL-H2B-GFP",
+            "paternal_id": "697306"
+        },
+        "date_of_birth": "2023-12-09",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "RCL-H2B-GFP/RCL-H2B-GFP",
+        "housing": null,
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "0.5.5",
+        "sex": "Male",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "abbreviation": null,
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "10090"
+        },
+        "subject_id": "716005",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
This PR allows BrainInjection objects to be constructed when the coordinates are completely missing from the procedures. It uses blank `Translation(translation=[])` objects to do this. This only happens if the coordinates are ALL missing for that specific injection so there's no danger of mixing known coordinates with these blank ones. 

You can see the issue for this subject 716005: http://aind-metadata-service/api/v2/procedures/716005. The fourth injection is actually not real -- this mouse had 5 injections (2/2/1 in the previous procedures) but the requestor incorrectly added information about a 4th burr hole and sixth injection. The metadata service attempts to coerce this by creating a procedure for it with missing coordinate info. This fix now handles this properly by generating the empty translation object to reflect that this wasn't real. We will need to go back and repair this in the surgery request forms eventually, I opened a separate ticket for that.