### PR TITLE
fix: improved handling for LED upgrades

### DIFF
--- a/src/aind_metadata_upgrader/utils/v1v2_utils.py
+++ b/src/aind_metadata_upgrader/utils/v1v2_utils.py
@@ -566,6 +566,15 @@ def upgrade_light_source(data: dict) -> dict:
     elif "lamp" in device_type or "wavelength_min" in data:
         light_source = Lamp(**data)
     elif "led" in device_type or "light emitting diode" in device_type or "led" in data["name"].lower():
+        if "calibration_data" in data and data["calibration_data"]:
+            raise NotImplementedError("Upgrading LEDs with calibration data is not currently supported.")
+        remove(data, "calibration_data")
+        remove(data, "calibration_date")
+        if "coupling" in data and data["coupling"]:
+            raise NotImplementedError("Upgrading LEDs with coupling data is not currently supported.")
+        remove(data, "coupling")
+        remove(data, "coupling_efficiency")
+        remove(data, "coupling_efficiency_unit")
         light_source = LightEmittingDiode(**data)
     elif "Axon 920-2 TPC" in data.get("name", ""):
         light_source = Laser(**data)


### PR DESCRIPTION
This PR adds some new conditions for when a user seems to have tried to create an LED but used the Laser object from v1. This strips out calibration and coupling information ONLY if the fields are empty and allows upgrading.

No test asset is included because the test asset that identified this issue didn't have a session and fails to upgrade.