### PR TITLE
fix: properly add mouse_platform_name="unknown" in all situations

### DIFF
--- a/src/aind_metadata_upgrader/acquisition/v1v2.py
+++ b/src/aind_metadata_upgrader/acquisition/v1v2.py
@@ -198,9 +198,13 @@ class AcquisitionV1V2(CoreUpgrader):
         # Determine acquisition type
         acquisition_type = self._determine_acquisition_type(data)
 
-        subject_details = AcquisitionSubjectDetails(
-            mouse_platform_name="N/A",
-        )
+        raw_subject_details = data.get("subject_details")
+        if raw_subject_details:
+            subject_details = raw_subject_details
+        else:
+            subject_details = AcquisitionSubjectDetails(
+                mouse_platform_name="unknown",
+            ).model_dump()
 
         # Build V2 acquisition object
         output = {

--- a/src/aind_metadata_upgrader/acquisition/v2v2.py
+++ b/src/aind_metadata_upgrader/acquisition/v2v2.py
@@ -2,6 +2,8 @@
 
 from typing import Optional
 
+from aind_data_schema.core.acquisition import AcquisitionSubjectDetails
+
 from aind_metadata_upgrader.base import CoreUpgrader
 
 
@@ -41,9 +43,18 @@ class AcquisitionUpgraderV2V2(CoreUpgrader):
         data["experimenters"] = upgraded
         return data
 
+    def _upgrade_subject_details(self, data: dict) -> dict:
+        """Create default subject_details if missing or null"""
+        if not data.get("subject_details"):
+            data["subject_details"] = AcquisitionSubjectDetails(
+                mouse_platform_name="unknown",
+            ).model_dump()
+        return data
+
     def upgrade(self, data: dict, schema_version: str, metadata: Optional[dict] = None) -> dict:
         """Upgrade the acquisition data within the 2.x series"""
         data = self._upgrade_calibrations(data)
         data = self._upgrade_experimenters(data)
+        data = self._upgrade_subject_details(data)
         data["schema_version"] = schema_version
         return data

--- a/src/aind_metadata_upgrader/session/v1v2.py
+++ b/src/aind_metadata_upgrader/session/v1v2.py
@@ -937,7 +937,7 @@ class SessionV1V2(CoreUpgrader):
         animal_weight_post = session_data.get("animal_weight_post")
         weight_unit = session_data.get("weight_unit", "gram")
         anaesthesia = session_data.get("anaesthesia")
-        mouse_platform_name = session_data.get("mouse_platform_name", "Unknown Platform")
+        mouse_platform_name = session_data.get("mouse_platform_name") or "unknown"
         reward_consumed_total = session_data.get("reward_consumed_total")
         reward_consumed_unit = session_data.get("reward_consumed_unit", "milliliter")
 


### PR DESCRIPTION
PR standardizes the use of "unknown" for mouse_platform_name when it wasn't available during upgrading, and adds it to the v2v2 upgrader for Acquisition (which upgrades existing V2 acquisitions that were generated without this field).