### PR TITLE
fix: refactor and repair Injection upgrader, which was missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ exclude = '''
 '''
 
 [tool.coverage.run]
-omit = ["*__init__*"]
+omit = ["*__init__*", "scripts/*"]
 source = ["aind_metadata_upgrader", "tests"]
 
 [tool.coverage.report]

--- a/scripts/upgrade_one.py
+++ b/scripts/upgrade_one.py
@@ -3,13 +3,9 @@
 import argparse
 import json
 import os
-import sys
 import traceback
 
-# Add src to path so we can import the upgrader
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
-from aind_metadata_upgrader.upgrade import Upgrade, CORE_FILES, CORE_MAPPING  # noqa: E402
+from aind_metadata_upgrader.upgrade import Upgrade, CORE_FILES, CORE_MAPPING
 
 RECORDS_DIR = os.path.join(os.path.dirname(__file__), "..", "tests", "records", "v1")
 

--- a/scripts/upgrade_one.py
+++ b/scripts/upgrade_one.py
@@ -9,7 +9,7 @@ import traceback
 # Add src to path so we can import the upgrader
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
-from aind_metadata_upgrader.upgrade import Upgrade, CORE_FILES, CORE_MAPPING
+from aind_metadata_upgrader.upgrade import Upgrade, CORE_FILES, CORE_MAPPING  # noqa: E402
 
 RECORDS_DIR = os.path.join(os.path.dirname(__file__), "..", "tests", "records", "v1")
 

--- a/scripts/upgrade_one.py
+++ b/scripts/upgrade_one.py
@@ -51,6 +51,7 @@ def upgrade_core_files_individually(data_dict: dict) -> dict:
 
 
 def main():
+    """Main function to parse arguments, load record, attempt upgrade, and save output."""
     parser = argparse.ArgumentParser(description="Upgrade a single metadata record by _id.")
     parser.add_argument("record_id", help="The _id of the record, e.g. 00318acb-e8f9-4072-ad32-0c5f2ee9798f")
     parser.add_argument(

--- a/scripts/upgrade_one.py
+++ b/scripts/upgrade_one.py
@@ -11,6 +11,7 @@ RECORDS_DIR = os.path.join(os.path.dirname(__file__), "..", "tests", "records", 
 
 
 def load_record(record_id: str) -> dict:
+    """Load a record JSON by _id from the records directory."""
     file_path = os.path.join(RECORDS_DIR, f"{record_id}.json")
     if not os.path.exists(file_path):
         raise FileNotFoundError(f"Record not found: {file_path}")

--- a/scripts/upgrade_one.py
+++ b/scripts/upgrade_one.py
@@ -1,0 +1,97 @@
+"""Upgrade a single record by _id and write the result to a JSON file."""
+
+import argparse
+import json
+import os
+import sys
+import traceback
+
+# Add src to path so we can import the upgrader
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from aind_metadata_upgrader.upgrade import Upgrade, CORE_FILES, CORE_MAPPING
+
+RECORDS_DIR = os.path.join(os.path.dirname(__file__), "..", "tests", "records", "v1")
+
+
+def load_record(record_id: str) -> dict:
+    file_path = os.path.join(RECORDS_DIR, f"{record_id}.json")
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"Record not found: {file_path}")
+    with open(file_path, "r") as f:
+        return json.load(f)
+
+
+def upgrade_core_files_individually(data_dict: dict) -> dict:
+    """Attempt to upgrade each core file individually with skip_metadata_validation=True."""
+    result = data_dict.copy()
+    for core_file in CORE_FILES:
+        if core_file not in data_dict or not data_dict[core_file]:
+            continue
+        target_key = CORE_MAPPING.get(core_file, core_file)
+        try:
+            # Build a minimal wrapper record with just this core file
+            wrapper = {core_file: data_dict[core_file]}
+            if "name" not in wrapper:
+                wrapper["name"] = data_dict.get("name", "fakesubj_1000-01-01_00-00-00")
+            if "location" not in wrapper:
+                wrapper["location"] = data_dict.get("location", "fake_location_for_testing")
+            upgraded = Upgrade(wrapper, skip_metadata_validation=True)
+            upgraded_value = getattr(upgraded.metadata, target_key, None)
+            if upgraded_value is not None:
+                result[target_key] = (
+                    upgraded_value.model_dump(mode="json")
+                    if hasattr(upgraded_value, "model_dump")
+                    else upgraded_value
+                )
+                print(f"  Individually upgraded: {core_file}")
+            else:
+                print(f"  No output for: {core_file}")
+        except Exception:
+            print(f"  Failed to individually upgrade {core_file}:")
+            traceback.print_exc()
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Upgrade a single metadata record by _id.")
+    parser.add_argument("record_id", help="The _id of the record, e.g. 00318acb-e8f9-4072-ad32-0c5f2ee9798f")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Output JSON file path (default: <record_id>_upgraded.json in current directory)",
+    )
+    args = parser.parse_args()
+
+    record_id = args.record_id
+    output_path = args.output or f"{record_id}_upgraded.json"
+
+    print(f"Loading record: {record_id}")
+    data_dict = load_record(record_id)
+
+    # Add fake fields if missing (mirrors test_upgrade.py behaviour)
+    if "name" not in data_dict:
+        data_dict["name"] = "fakesubj_1000-01-01_00-00-00"
+        print("  Added fake 'name' field")
+    if "location" not in data_dict:
+        data_dict["location"] = "fake_location_for_testing"
+        print("  Added fake 'location' field")
+
+    print("Attempting full upgrade...")
+    try:
+        upgraded = Upgrade(data_dict, skip_metadata_validation=False)
+        result = upgraded.metadata.model_dump(mode="json")
+        print("Full upgrade succeeded.")
+    except Exception as e:
+        print(f"Full upgrade failed: {e}")
+        print("Falling back to per-core-file upgrade (skip_metadata_validation=True)...")
+        result = upgrade_core_files_individually(data_dict)
+
+    with open(output_path, "w") as f:
+        json.dump(result, f, indent=2, default=str)
+    print(f"Saved upgraded record to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/aind_metadata_upgrader/procedures/v1v2.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2.py
@@ -22,6 +22,7 @@ from aind_metadata_upgrader.procedures.v1v2_injections import (
     upgrade_iontophoresis_injection,
     upgrade_nanoject_injection,
     upgrade_retro_orbital_injection,
+    upgrade_typeless_base_injection,
 )
 from aind_metadata_upgrader.procedures.v1v2_procedures import (
     repair_generic_surgery_procedure,
@@ -371,11 +372,21 @@ class ProceduresUpgraderV1V2(CoreUpgrader):
         for field in surgery_level_fields:
             remove(data, field)
 
+        # Handle typeless injection entries (base Injection class in pre-v1 records that
+        # lack a procedure_type field). Presence of injection_coordinate_ap key indicates
+        # a BrainInjection; absence indicates a base Injection.
+        if procedure_type is None:
+            if data.get("injection_coordinate_ap") is not None:
+                return upgrade_nanoject_injection(data)
+            else:
+                return upgrade_typeless_base_injection(data)
+
         # Map V1 procedure types to their upgrade functions
 
         if procedure_type in PROC_UPGRADE_MAP:
             return PROC_UPGRADE_MAP[procedure_type](data)
         else:
+            print(data)
             raise ValueError(f"Unsupported procedure type: {procedure_type}")
 
     def _process_surgery_procedures(self, data: dict) -> None:

--- a/src/aind_metadata_upgrader/procedures/v1v2_injections.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2_injections.py
@@ -233,117 +233,49 @@ def get_targeted_structure_or_none(data: dict) -> dict | None:
     return None
 
 
-def upgrade_nanoject_injection(data: dict) -> tuple[dict, list]:
-    """Upgrade NanojectInjection procedure from V1 to V2"""
-
-    upgraded_data = data.copy()
-    upgraded_data.pop("procedure_type", None)
-
-    upgraded_data = upgrade_generic_injection(upgraded_data)
-
-    # full list of fields to handle
-    dynamics = build_volume_injection_dynamics(data)
-
-    # Check reference
-    reference = data.get("injection_coordinate_reference", None)
-    # Check to make sure someone doesn't give us lambda or something, that would be a big problem
-    if reference is not None and not reference == "Bregma":
-        raise ValueError(f"Unsupported injection_coordinate_reference value: {reference}. " "Expected 'Bregma'.")
-
+def upgrade_brain_injection(data: dict, dynamics: list) -> tuple[dict, list]:
+    """Shared upgrade logic for all V1 BrainInjection subclasses → V2 BrainInjection."""
+    validate_injection_coordinate_reference(data)
     data = upgrade_injection_coordinates(data)
-
     data, measured_coordinates = retrieve_bl_distance(data)
-
-    relative_position = []
-    if "injection_hemisphere" in data and data["injection_hemisphere"] is not None:
-        if data["injection_hemisphere"] == "Left":
-            relative_position.append(AnatomicalRelative.LEFT)
-        elif data["injection_hemisphere"] == "Right":
-            relative_position.append(AnatomicalRelative.RIGHT)
-        elif data["injection_hemisphere"] == "Midline":
-            relative_position.append(AnatomicalRelative.ORIGIN)
-        else:
-            raise ValueError(f"Unsupported injection_hemisphere value: {data['injection_hemisphere']}")
-
-    injection_materials = upgrade_injection_materials(data.get("injection_materials", []))
-
-    if len(injection_materials) == 0:
-        injection_materials.append(
-            ViralMaterial(
-                name="(v1v2 upgrade) No injection material provided",
-            ).model_dump()
-        )
-
-    coordinates = ensure_coordinates_match_dynamics(data.get("coordinates", []), dynamics)
-
     injection = BrainInjection(
-        injection_materials=injection_materials,
-        targeted_structure=upgrade_targeted_structure(data.get("targeted_structure")),
-        relative_position=relative_position,
-        dynamics=dynamics,
-        protocol_id=data.get("protocol_id", None),
-        coordinate_system_name=CoordinateSystemLibrary.BREGMA_ARID.name,
-        coordinates=coordinates,
-    )
-
-    return injection.model_dump(), measured_coordinates
-
-
-def upgrade_iontophoresis_injection(data: dict) -> tuple[dict, list]:
-    """Upgrade IontophoresisInjection procedure from V1 to V2"""
-    upgraded_data = data.copy()
-    upgraded_data.pop("procedure_type", None)
-
-    upgraded_data = upgrade_generic_injection(upgraded_data)
-
-    # Build dynamics for current-based injection
-    dynamics = build_current_injection_dynamics(data)
-
-    # Check reference
-    reference = data.get("injection_coordinate_reference", None)
-    # Check to make sure someone doesn't give us lambda or something, that would be a big problem
-    if reference is not None and not reference == "Bregma":
-        raise ValueError(f"Unsupported injection_coordinate_reference value: {reference}. " "Expected 'Bregma'.")
-
-    data = upgrade_injection_coordinates(data)
-
-    data, measured_coordinates = retrieve_bl_distance(data)
-
-    relative_position = []
-    if "injection_hemisphere" in data and data["injection_hemisphere"] is not None:
-        if data["injection_hemisphere"] == "Left":
-            relative_position.append(AnatomicalRelative.LEFT)
-        elif data["injection_hemisphere"] == "Right":
-            relative_position.append(AnatomicalRelative.RIGHT)
-        elif data["injection_hemisphere"] == "Midline":
-            relative_position.append(AnatomicalRelative.ORIGIN)
-        else:
-            raise ValueError(f"Unsupported injection_hemisphere value: {data['injection_hemisphere']}")
-
-    injection_materials = upgrade_injection_materials(data.get("injection_materials", []))
-
-    if len(injection_materials) == 0:
-        injection_materials.append(
-            ViralMaterial(
-                name="(v1v2 upgrade) No injection material provided",
-            ).model_dump()
-        )
-
-    targeted_structure = None
-    if data.get("targeted_structure"):
-        targeted_structure = upgrade_targeted_structure(data.get("targeted_structure"))
-
-    injection = BrainInjection(
-        injection_materials=injection_materials,
-        targeted_structure=targeted_structure,
-        relative_position=relative_position,
+        injection_materials=ensure_injection_materials_with_default(
+            upgrade_injection_materials(data.get("injection_materials", []))
+        ),
+        targeted_structure=get_targeted_structure_or_none(data),
+        relative_position=build_relative_position_from_hemisphere(data),
         dynamics=dynamics,
         protocol_id=data.get("protocol_id", None),
         coordinate_system_name=CoordinateSystemLibrary.BREGMA_ARID.name,
         coordinates=ensure_coordinates_match_dynamics(data.get("coordinates", []), dynamics),
     )
-
     return injection.model_dump(), measured_coordinates
+
+
+def upgrade_nanoject_injection(data: dict) -> tuple[dict, list]:
+    """Upgrade NanojectInjection (or typeless BrainInjection) procedure from V1 to V2"""
+    data = upgrade_generic_injection(data)
+    return upgrade_brain_injection(data, build_volume_injection_dynamics(data))
+
+
+def upgrade_iontophoresis_injection(data: dict) -> tuple[dict, list]:
+    """Upgrade IontophoresisInjection procedure from V1 to V2"""
+    data = upgrade_generic_injection(data)
+    return upgrade_brain_injection(data, build_current_injection_dynamics(data))
+
+
+def upgrade_typeless_base_injection(data: dict) -> dict:
+    """Upgrade a typeless base Injection (no brain coordinates) from V1 to V2."""
+    data = upgrade_generic_injection(data)
+    return Injection(
+        injection_materials=ensure_injection_materials_with_default(
+            upgrade_injection_materials(data.get("injection_materials", []))
+        ),
+        targeted_structure=get_targeted_structure_or_none(data),
+        relative_position=build_relative_position_from_hemisphere(data),
+        dynamics=build_volume_injection_dynamics(data),
+        protocol_id=data.get("protocol_id", None),
+    ).model_dump()
 
 
 def upgrade_icv_injection(data: dict) -> dict:

--- a/tests/records/v1/00318acb-e8f9-4072-ad32-0c5f2ee9798f.json
+++ b/tests/records/v1/00318acb-e8f9-4072-ad32-0c5f2ee9798f.json
@@ -1,0 +1,977 @@
+{
+    "_id": "00318acb-e8f9-4072-ad32-0c5f2ee9798f",
+    "acquisition": null,
+    "created": "2025-03-25T04:07:39.534691",
+    "data_description": {
+        "creation_time": "2025-03-24T09:34:00-07:00",
+        "data_level": "raw",
+        "data_summary": null,
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "funding_source": [
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "AI",
+                    "name": "Allen Institute",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null
+            },
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": null,
+                    "name": "Simons Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01cmst727"
+                },
+                "grant_number": "NC-GB-CULM-00003265-03"
+            }
+        ],
+        "group": null,
+        "institution": {
+            "abbreviation": "AIND",
+            "name": "Allen Institute for Neural Dynamics",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "investigators": [
+            {
+                "abbreviation": null,
+                "name": "Galen Lynch",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Josh Siegle",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Yoni Browning",
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "label": null,
+        "license": "CC-BY-4.0",
+        "modality": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            }
+        ],
+        "name": "behavior_781371_2025-03-24_09-34-00",
+        "platform": {
+            "abbreviation": "behavior",
+            "name": "Behavior platform"
+        },
+        "project_name": "Discovery-Brain Wide Circuit Dynamics",
+        "related_data": [],
+        "restrictions": null,
+        "schema_version": "1.0.3",
+        "subject_id": "781371"
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "6a798d93-5611-49bb-b026-1f389d523d31"
+        ]
+    },
+    "instrument": null,
+    "last_modified": "2026-03-10T04:57:09.589Z",
+    "location": "s3://aind-private-data-prod-o5171v/behavior_781371_2025-03-24_09-34-00",
+    "metadata_status": "Missing",
+    "name": "behavior_781371_2025-03-24_09-34-00",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "schema_version": "1.2.1",
+        "subject_id": "781371",
+        "subject_procedures": [
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2025-02-06",
+                "experimenter_full_name": "NSB-2864",
+                "iacuc_protocol": "2414",
+                "animal_weight_prior": "27.6",
+                "animal_weight_post": "29.6",
+                "weight_unit": "gram",
+                "anaesthesia": {
+                    "type": "isoflurane",
+                    "duration": "150.0",
+                    "duration_unit": "minute",
+                    "level": "1.5"
+                },
+                "workstation_id": "SWS 9",
+                "procedures": [
+                    {
+                        "procedure_type": "Craniotomy",
+                        "craniotomy_type": "Whole hemisphere craniotomy",
+                        "craniotomy_hemisphere": null,
+                        "bregma_to_lambda_distance": "4.125",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "implant_part_number": "3004 (25% puralube/systane)",
+                        "dura_removed": null,
+                        "protective_material": null,
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute"
+                    },
+                    {
+                        "procedure_type": "Headframe",
+                        "headframe_type": "WHC NP (Zirconia)",
+                        "headframe_part_number": null,
+                        "headframe_material": null,
+                        "well_part_number": "0160-055-08",
+                        "well_type": "WHC NP"
+                    },
+                    {
+                        "injection_materials": [],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": null,
+                        "injection_coordinate_ap": null,
+                        "injection_coordinate_depth": null,
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.125",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": null,
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": [],
+                        "injection_hemisphere": "Left"
+                    }
+                ],
+                "notes": null,
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2"
+            },
+            {
+                "procedure_type": "Water restriction",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "baseline_weight": "29.23",
+                "weight_unit": "gram",
+                "start_date": "2025-02-21",
+                "end_date": null
+            }
+        ],
+        "specimen_procedures": [],
+        "notes": null
+    },
+    "processing": {
+        "analyses": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "notes": null,
+        "processing_pipeline": {
+            "data_processes": [],
+            "note": null,
+            "pipeline_url": null,
+            "pipeline_version": null,
+            "processor_full_name": "AIND Scientific Computing"
+        },
+        "schema_version": "1.1.3"
+    },
+    "quality_control": null,
+    "rig": {
+        "additional_devices": [],
+        "calibrations": [
+            {
+                "calibration_date": "2025-03-18T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.0317
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.25
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-12T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.0317
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        1.75
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-10T00:00:00-07:00",
+                "description": "Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        1.09,
+                        1.87
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-18T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0321
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        0.075
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-12T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0321
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.05
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-10T00:00:00-07:00",
+                "description": "Water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        1.09,
+                        1.84
+                    ]
+                }
+            }
+        ],
+        "cameras": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT714673",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "Right size of face camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "23349424",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face side right",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Fujinon",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "CF16ZA-1S",
+                    "name": "Behavior Video Lens Right Side",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Right Camera assembly",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT714673",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "bottom of face camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "23349426",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face bottom",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "25",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Other",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "LM25HC",
+                    "name": "Behavior Video Lens Bottom of face",
+                    "notes": "Manufacturer is Kowa",
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Bottom Camera assembly",
+                "position": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "daqs": [
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714673",
+                "core_version": "1.11",
+                "data_interface": "Ethernet",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Behavior",
+                    "whoami": 1216
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp behavior board",
+                "notes": "Left lick spout and Right lick spout, as well as reward delivery solenoids are connected via ethernet cables",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714673",
+                "core_version": "1.4",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Sound Card",
+                    "whoami": 1280
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp sound card",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714673",
+                "core_version": "",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Clock Synchronizer",
+                    "whoami": 1152
+                },
+                "is_clock_generator": true,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp clock synchronization board",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714673",
+                "core_version": "",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Input Expander",
+                    "whoami": 1106
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp sound amplifier",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "detectors": [],
+        "digital_micromirror_devices": [],
+        "enclosure": {
+            "additional_settings": {},
+            "air_filtration": false,
+            "device_type": "Enclosure",
+            "external_material": "",
+            "grounded": false,
+            "internal_material": "",
+            "laser_interlock": false,
+            "manufacturer": {
+                "abbreviation": "AIND",
+                "name": "Allen Institute for Neural Dynamics",
+                "registry": {
+                    "abbreviation": "ROR",
+                    "name": "Research Organization Registry"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "name": "Behavior enclosure",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "size": {
+                "height": 54,
+                "length": 54,
+                "unit": "centimeter",
+                "width": 54
+            }
+        },
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "filters": [],
+        "laser_assemblies": [],
+        "lenses": [],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "name": "IR LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            }
+        ],
+        "modification_date": "2025-03-18",
+        "mouse_platform": {
+            "additional_settings": {},
+            "date_surface_replaced": null,
+            "device_type": "Tube",
+            "diameter": "3.0",
+            "diameter_unit": "centimeter",
+            "manufacturer": {
+                "abbreviation": null,
+                "name": "Custom",
+                "registry": null,
+                "registry_identifier": null
+            },
+            "model": null,
+            "name": "mouse_tube_foraging",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "surface_material": null
+        },
+        "notes": null,
+        "objectives": [],
+        "origin": null,
+        "patch_cords": [],
+        "pockels_cells": [],
+        "polygonal_scanners": [],
+        "rig_axes": null,
+        "rig_id": "446_6C_20250318",
+        "schema_version": "1.0.1",
+        "stick_microscopes": [],
+        "stimulus_devices": [
+            {
+                "device_type": "Reward delivery",
+                "reward_spouts": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Lick Sensor",
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Lick Sensor Left",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Left lick spout",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Left",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "name": "Solenoid Left",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    },
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Lick Sensor",
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Lick Sensor Right",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Right lick spout",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Right",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "name": "Solenoid Right",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    }
+                ],
+                "stage_type": {
+                    "additional_settings": {},
+                    "device_type": "Motorized stage",
+                    "firmware": null,
+                    "manufacturer": {
+                        "abbreviation": "AIND",
+                        "name": "Allen Institute for Neural Dynamics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04szwah67"
+                    },
+                    "model": null,
+                    "name": "AIND lick spout stage",
+                    "notes": "https://allenneuraldynamics.github.io/Bonsai.AllenNeuralDynamics/articles/aind-manipulator.html",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "travel": "30",
+                    "travel_unit": "millimeter"
+                }
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Speaker",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Tymphany",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "XT25SC90-04",
+                "name": "Stimulus Speaker",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "serial_number": null
+            }
+        ]
+    },
+    "schema_version": "1.1.1",
+    "session": {
+        "active_mouse_platform": false,
+        "anaesthesia": null,
+        "animal_weight_post": "23.4",
+        "animal_weight_prior": null,
+        "calibrations": [],
+        "data_streams": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "experimenter_full_name": [
+            "Huy Nguyen"
+        ],
+        "headframe_registration": null,
+        "iacuc_protocol": "2414",
+        "maintenance": [],
+        "mouse_platform_name": "mouse_tube_foraging",
+        "notes": "",
+        "protocol_id": [
+            ""
+        ],
+        "reward_consumed_total": "252.0",
+        "reward_consumed_unit": "microliter",
+        "reward_delivery": null,
+        "rig_id": "446_6C_20250318",
+        "schema_version": "1.0.1",
+        "session_end_time": "2025-03-24T10:45:29.656556-07:00",
+        "session_start_time": "2025-03-24T09:34:00.504117-07:00",
+        "session_type": "Uncoupled Without Baiting",
+        "stimulus_epochs": [
+            {
+                "light_source_config": [],
+                "notes": "The duration of go cue is 100 ms. The frequency is 7500 Hz. Amplitude is 60dB. The total reward consumed in the session is 252.0 microliters. The total reward including consumed in the session and supplementary water is 1.716 milliliters.",
+                "output_parameters": {
+                    "meta": {
+                        "box": "446-6-C",
+                        "session_run_time_in_min": 71
+                    },
+                    "performance": {
+                        "foraging_efficiency": 0.5655296229802512,
+                        "foraging_efficiency_with_actual_random_seed": 0.5526315789473684
+                    },
+                    "task_parameters": {
+                        "BlockBeta": "20",
+                        "BlockMax": "35",
+                        "BlockMin": "20",
+                        "DelayBeta": "0.0",
+                        "DelayMax": "1.0",
+                        "DelayMin": "1.0",
+                        "ITIBeta": "3.0",
+                        "ITIMax": "30.0",
+                        "ITIMin": "1.0",
+                        "LeftValue_volume": "2.00",
+                        "RightValue_volume": "2.00",
+                        "Task": "Uncoupled Without Baiting",
+                        "reward_probability": "0.1, 0.4, 0.7",
+                        "curriculum_in_use": "Uncoupled Without Baiting (v2.3@1.0)",
+                        "stage_in_use": "STAGE_FINAL"
+                    },
+                    "water": {
+                        "water_after_session": 1.446,
+                        "water_day_total": 1.716,
+                        "water_in_session_foraging": 0.252,
+                        "water_in_session_manual": 0.018000000000000016,
+                        "water_in_session_total": 0.27
+                    }
+                },
+                "reward_consumed_during_epoch": "252.0",
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "dynamic-foraging-task",
+                        "parameters": {},
+                        "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                        "version": "behavior branch:production_testing   commit ID:de91d4e28f0f6269f3adeafb29dc5252ab7aedc6    version:1.6.28; metadata branch: production_testing   commit ID:de91d4e28f0f6269f3adeafb29dc5252ab7aedc6   version:1.6.28"
+                    }
+                ],
+                "speaker_config": {
+                    "name": "Stimulus Speaker",
+                    "volume": "60",
+                    "volume_unit": "decibels"
+                },
+                "stimulus_device_names": [
+                    "Stimulus Speaker"
+                ],
+                "stimulus_end_time": "2025-03-24T10:45:29.656556-07:00",
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_name": "The behavior auditory go cue",
+                "stimulus_parameters": [
+                    {
+                        "amplitude_modulation_frequency": 7500,
+                        "bandpass_filter_type": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_low_frequency": null,
+                        "bandpass_order": null,
+                        "frequency_unit": "hertz",
+                        "notes": null,
+                        "sample_frequency": "96000",
+                        "stimulus_name": "auditory go cue",
+                        "stimulus_type": "Auditory Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-03-24T09:34:00.504117-07:00",
+                "trials_finished": 320,
+                "trials_rewarded": 126,
+                "trials_total": 398
+            }
+        ],
+        "subject_id": "781371",
+        "weight_unit": "gram"
+    },
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": null,
+        "date_of_birth": "2024-10-22",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "wt/wt",
+        "housing": {
+            "cage_id": "8286269",
+            "cohoused_subjects": [],
+            "home_cage_enrichment": [],
+            "light_cycle": null,
+            "room_id": "221"
+        },
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.2",
+        "sex": "Male",
+        "source": {
+            "abbreviation": null,
+            "name": "Other",
+            "registry": null,
+            "registry_identifier": null
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "781371",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
This PR fixes the Injection/BrainInjection upgrader code, which I noticed was missing the ability to upgrade an Injection procedure that is embedded inside of a Surgery. The injection upgrade code was getting complex so I took the opportunity to clean it up as well. 

I added a test case to cover the new condition.

I also got tired of manually upgrading records and saving them as JSON to check if they upgraded properly so I wrote myself a helper function for this in `scripts/upgrade_one.py`.