### PR TITLE
fix: handle a calibration that was missed

### DIFF
--- a/src/aind_metadata_upgrader/utils/v1v2_utils.py
+++ b/src/aind_metadata_upgrader/utils/v1v2_utils.py
@@ -813,6 +813,20 @@ def _upgrade_power_calibration_led(data: dict) -> Optional[PowerCalibration]:
     )
 
 
+def _upgrade_power_calibration_voltage_input(data: dict) -> Optional[PowerCalibration]:
+    """Handle laser power calibration with voltage (V) input and power (mW) output."""
+
+    return PowerCalibration(
+        calibration_date=data["calibration_date"],
+        device_name=data["device_name"],
+        input=data["input"]["voltage (V)"],
+        input_unit=VoltageUnit.V,
+        output=data["output"]["power (mW)"],
+        output_unit=PowerUnit.MW,
+        notes=data.get("notes"),
+    )
+
+
 def _upgrade_power_calibration(data: dict) -> Optional[dict]:
     """Upgrade power calibration data (laser, LED)."""
     description = data.get("description", "").lower()
@@ -832,6 +846,8 @@ def _upgrade_power_calibration(data: dict) -> Optional[dict]:
         calibration = _upgrade_power_calibration_percent_laser(data)
     elif "led calibration" in description:
         calibration = _upgrade_power_calibration_led(data)
+    elif "voltage (V)" in input_data and "power (mW)" in output_data:
+        calibration = _upgrade_power_calibration_voltage_input(data)
     else:
         return None
 

--- a/tests/records/v1/be57b9c9-58c6-4472-a23f-d063a4f01e10.json
+++ b/tests/records/v1/be57b9c9-58c6-4472-a23f-d063a4f01e10.json
@@ -1,0 +1,21914 @@
+{
+    "_id": "be57b9c9-58c6-4472-a23f-d063a4f01e10",
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "schema_version": "1.2.1",
+    "name": "ecephys_834198_2026-02-26_15-05-56_sorted_2026-02-28_07-38-12",
+    "created": "2026-02-28T08:22:18.888001Z",
+    "last_modified": "2026-02-28T08:22:20.639Z",
+    "location": "s3://aind-open-data/ecephys_834198_2026-02-26_15-05-56_sorted_2026-02-28_07-38-12",
+    "metadata_status": "Invalid",
+    "external_links": {
+        "Code Ocean": [
+            "c42972ef-577f-4171-b2de-9ad2182f5794"
+        ]
+    },
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Exp-ND-01-036-2414",
+            "maternal_genotype": "Drd2-Cre_ER44/wt",
+            "maternal_id": "803093",
+            "paternal_genotype": "Oi9(H11-CAG-LSL-Cas9)/wt",
+            "paternal_id": "805219"
+        },
+        "date_of_birth": "2025-10-15",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "Drd2-Cre_ER44/wt;Oi9(H11-CAG-LSL-Cas9)/wt",
+        "housing": {
+            "cage_id": "8317422",
+            "cohoused_subjects": [],
+            "home_cage_enrichment": [],
+            "light_cycle": null,
+            "room_id": "217"
+        },
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.3",
+        "sex": "Female",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "834198",
+        "wellness_reports": []
+    },
+    "data_description": {
+        "object_type": "Data description",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "2.3.0",
+        "license": "CC-BY-4.0",
+        "subject_id": "834198",
+        "creation_time": "2026-02-28T07:38:12.406646Z",
+        "tags": null,
+        "name": "ecephys_834198_2026-02-26_15-05-56_sorted_2026-02-28_07-38-12",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": "Research Organization Registry (ROR)",
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "object_type": "Funding",
+                "funder": {
+                    "name": "Allen Institute",
+                    "abbreviation": "AI",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null,
+                "fundee": [
+                    {
+                        "object_type": "Person",
+                        "name": "unknown",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": null
+                    }
+                ]
+            }
+        ],
+        "data_level": "derived",
+        "group": "ephys",
+        "investigators": [
+            {
+                "object_type": "Person",
+                "name": "Bowen Tan",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": null
+            }
+        ],
+        "project_name": "GPP",
+        "restrictions": null,
+        "modalities": [
+            {
+                "name": "Extracellular electrophysiology",
+                "abbreviation": "ecephys"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            },
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            }
+        ],
+        "source_data": [
+            "ecephys_834198_2026-02-26_15-05-56"
+        ],
+        "data_summary": "Integrating genetic perturbation tools with technologies that record neural activity in vivo"
+    },
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.2.1",
+        "specimen_procedures": [],
+        "subject_id": "834198",
+        "subject_procedures": [
+            {
+                "baseline_weight": "26.0",
+                "end_date": null,
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "procedure_type": "Water restriction",
+                "start_date": "2026-02-06",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "weight_unit": "gram"
+            }
+        ]
+    },
+    "session": {
+        "active_mouse_platform": false,
+        "anaesthesia": null,
+        "animal_weight_post": "22.7",
+        "animal_weight_prior": null,
+        "calibrations": [],
+        "data_streams": [
+            {
+                "camera_names": [
+                    "Face Camera Assembly",
+                    "Body Camera Assembly"
+                ],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "11163.0",
+                            "y": "9469.0",
+                            "z": "12510.0"
+                        },
+                        "module_angle": "-15.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "BLA",
+                            "atlas": "CCFv3",
+                            "id": "295",
+                            "name": "Basolateral amygdalar nucleus"
+                        },
+                        "rotation_angle": "180",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "10197.0",
+                            "y": "9812.0",
+                            "z": "10437.0"
+                        },
+                        "module_angle": "10.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-5.0",
+                        "assembly_name": "Probe C assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "9755.0",
+                            "y": "6873.0",
+                            "z": "7575.0"
+                        },
+                        "module_angle": "22.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "SNr",
+                            "atlas": "CCFv3",
+                            "id": "381",
+                            "name": "Substantia nigra, reticular part"
+                        },
+                        "rotation_angle": "90",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2026-02-26T15:55:08-08:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    },
+                    {
+                        "abbreviation": "behavior-videos",
+                        "name": "Behavior videos"
+                    },
+                    {
+                        "abbreviation": "behavior",
+                        "name": "Behavior"
+                    }
+                ],
+                "stream_start_time": "2026-02-26T15:05:56-08:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "11163.0",
+                            "y": "9469.0",
+                            "z": "12510.0"
+                        },
+                        "module_angle": "-15.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "BLA",
+                            "atlas": "CCFv3",
+                            "id": "295",
+                            "name": "Basolateral amygdalar nucleus"
+                        },
+                        "rotation_angle": "180",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "10197.0",
+                            "y": "9812.0",
+                            "z": "10437.0"
+                        },
+                        "module_angle": "10.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-5.0",
+                        "assembly_name": "Probe C assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "9755.0",
+                            "y": "6873.0",
+                            "z": "7575.0"
+                        },
+                        "module_angle": "22.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "SNr",
+                            "atlas": "CCFv3",
+                            "id": "381",
+                            "name": "Substantia nigra, reticular part"
+                        },
+                        "rotation_angle": "90",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2026-02-26T15:56:15-08:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2026-02-26T15:55:14-08:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "11163.0",
+                            "y": "9469.0",
+                            "z": "12510.0"
+                        },
+                        "module_angle": "-15.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "BLA",
+                            "atlas": "CCFv3",
+                            "id": "295",
+                            "name": "Basolateral amygdalar nucleus"
+                        },
+                        "rotation_angle": "180",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "10197.0",
+                            "y": "9812.0",
+                            "z": "10437.0"
+                        },
+                        "module_angle": "10.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-5.0",
+                        "assembly_name": "Probe C assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "9755.0",
+                            "y": "6873.0",
+                            "z": "7575.0"
+                        },
+                        "module_angle": "22.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "SNr",
+                            "atlas": "CCFv3",
+                            "id": "381",
+                            "name": "Substantia nigra, reticular part"
+                        },
+                        "rotation_angle": "90",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2026-02-26T15:57:17-08:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2026-02-26T15:56:16-08:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "11163.0",
+                            "y": "9469.0",
+                            "z": "12510.0"
+                        },
+                        "module_angle": "-15.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "BLA",
+                            "atlas": "CCFv3",
+                            "id": "295",
+                            "name": "Basolateral amygdalar nucleus"
+                        },
+                        "rotation_angle": "180",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "10197.0",
+                            "y": "9812.0",
+                            "z": "10437.0"
+                        },
+                        "module_angle": "10.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-5.0",
+                        "assembly_name": "Probe C assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "9755.0",
+                            "y": "6873.0",
+                            "z": "7575.0"
+                        },
+                        "module_angle": "22.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "SNr",
+                            "atlas": "CCFv3",
+                            "id": "381",
+                            "name": "Substantia nigra, reticular part"
+                        },
+                        "rotation_angle": "90",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2026-02-26T15:58:19-08:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2026-02-26T15:57:18-08:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "11163.0",
+                            "y": "9469.0",
+                            "z": "12510.0"
+                        },
+                        "module_angle": "-15.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "BLA",
+                            "atlas": "CCFv3",
+                            "id": "295",
+                            "name": "Basolateral amygdalar nucleus"
+                        },
+                        "rotation_angle": "180",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "10197.0",
+                            "y": "9812.0",
+                            "z": "10437.0"
+                        },
+                        "module_angle": "10.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-5.0",
+                        "assembly_name": "Probe C assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "9755.0",
+                            "y": "6873.0",
+                            "z": "7575.0"
+                        },
+                        "module_angle": "22.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "SNr",
+                            "atlas": "CCFv3",
+                            "id": "381",
+                            "name": "Substantia nigra, reticular part"
+                        },
+                        "rotation_angle": "90",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2026-02-26T15:59:21-08:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2026-02-26T15:58:20-08:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "11163.0",
+                            "y": "9469.0",
+                            "z": "12510.0"
+                        },
+                        "module_angle": "-15.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "BLA",
+                            "atlas": "CCFv3",
+                            "id": "295",
+                            "name": "Basolateral amygdalar nucleus"
+                        },
+                        "rotation_angle": "180",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "10197.0",
+                            "y": "9812.0",
+                            "z": "10437.0"
+                        },
+                        "module_angle": "10.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-5.0",
+                        "assembly_name": "Probe C assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "9755.0",
+                            "y": "6873.0",
+                            "z": "7575.0"
+                        },
+                        "module_angle": "22.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "SNr",
+                            "atlas": "CCFv3",
+                            "id": "381",
+                            "name": "Substantia nigra, reticular part"
+                        },
+                        "rotation_angle": "90",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2026-02-26T16:00:23-08:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2026-02-26T15:59:22-08:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "Harp Behavior",
+                    "Neuropixels Basestation",
+                    "Harp Sound Card",
+                    "Lickety split left",
+                    "Lickety split right"
+                ],
+                "detectors": [],
+                "ephys_modules": [
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe A assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "11163.0",
+                            "y": "9469.0",
+                            "z": "12510.0"
+                        },
+                        "module_angle": "-15.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "BLA",
+                            "atlas": "CCFv3",
+                            "id": "295",
+                            "name": "Basolateral amygdalar nucleus"
+                        },
+                        "rotation_angle": "180",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-25.0",
+                        "assembly_name": "Probe B assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "10197.0",
+                            "y": "9812.0",
+                            "z": "10437.0"
+                        },
+                        "module_angle": "10.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "ACB",
+                            "atlas": "CCFv3",
+                            "id": "56",
+                            "name": "Nucleus accumbens"
+                        },
+                        "rotation_angle": "135",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    },
+                    {
+                        "anatomical_coordinates": null,
+                        "anatomical_reference": null,
+                        "angle_unit": "degrees",
+                        "arc_angle": "-5.0",
+                        "assembly_name": "Probe C assembly",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "dye": "DiD",
+                        "implant_hole_number": 0,
+                        "manipulator_coordinates": {
+                            "unit": "micrometer",
+                            "x": "9755.0",
+                            "y": "6873.0",
+                            "z": "7575.0"
+                        },
+                        "module_angle": "22.0",
+                        "notes": null,
+                        "other_targeted_structure": null,
+                        "primary_targeted_structure": {
+                            "acronym": "SNr",
+                            "atlas": "CCFv3",
+                            "id": "381",
+                            "name": "Substantia nigra, reticular part"
+                        },
+                        "rotation_angle": "90",
+                        "surface_z": null,
+                        "surface_z_unit": "micrometer",
+                        "targeted_ccf_coordinates": []
+                    }
+                ],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 1",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "did not record angles, did not calibrate.",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 2",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    },
+                    {
+                        "angle_unit": "degrees",
+                        "arc_angle": "-180",
+                        "assembly_name": "Probe camera 3",
+                        "calibration_date": null,
+                        "coordinate_transform": null,
+                        "module_angle": "-180",
+                        "notes": "Did not record angles, did not calibrate",
+                        "rotation_angle": "0"
+                    }
+                ],
+                "stream_end_time": "2026-02-26T16:01:25-08:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "ecephys",
+                        "name": "Extracellular electrophysiology"
+                    }
+                ],
+                "stream_start_time": "2026-02-26T16:00:24-08:00"
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "experimenter_full_name": [
+            "Anna Lakunina",
+            "Bowen Tan",
+            "Josh Siegle"
+        ],
+        "headframe_registration": null,
+        "iacuc_protocol": "2414",
+        "maintenance": [],
+        "mouse_platform_name": "Running Wheel",
+        "notes": "nan",
+        "protocol_id": [],
+        "reward_consumed_total": "0",
+        "reward_consumed_unit": "milliliter",
+        "reward_delivery": null,
+        "rig_id": "323_EPHYS1_20260213",
+        "schema_version": "1.1.1",
+        "session_end_time": "2026-02-26T16:01:25-08:00",
+        "session_start_time": "2026-02-26T15:05:56-08:00",
+        "session_type": "Optotagging and dynamic foraging",
+        "stimulus_epochs": [
+            {
+                "light_source_config": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "Oxxius Red Laser 1",
+                        "wavelength": 638,
+                        "wavelength_unit": "nanometer"
+                    },
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "Oxxius Blue Laser 1",
+                        "wavelength": 473,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "notes": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "np-opto-stim",
+                    "parameters": {},
+                    "url": "https://github.com/AllenNeuralDynamics/np-opto-stim",
+                    "version": "commit: 2d45704cfc82608fa34f667a9f3f0ab29fc9f408"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "Python",
+                        "parameters": {},
+                        "url": null,
+                        "version": "3.7"
+                    }
+                ],
+                "speaker_config": null,
+                "stimulus_device_names": [
+                    "Oxxius Red Laser 1",
+                    "Oxxius Blue Laser 1"
+                ],
+                "stimulus_end_time": "2026-02-26T15:55:00-08:00",
+                "stimulus_modalities": [
+                    "Optogenetics"
+                ],
+                "stimulus_name": "Laser pulses for optotagging",
+                "stimulus_parameters": [
+                    {
+                        "baseline_duration": "1200",
+                        "baseline_duration_unit": "second",
+                        "fixed_pulse_train_interval": false,
+                        "notes": null,
+                        "number_pulse_trains": [
+                            5
+                        ],
+                        "other_parameters": {},
+                        "pulse_frequency": [
+                            "20.0"
+                        ],
+                        "pulse_frequency_unit": "hertz",
+                        "pulse_shape": "Ramp",
+                        "pulse_train_duration": [
+                            "0.25"
+                        ],
+                        "pulse_train_duration_unit": "second",
+                        "pulse_train_interval": null,
+                        "pulse_train_interval_unit": "second",
+                        "pulse_width": [
+                            10
+                        ],
+                        "pulse_width_unit": "millisecond",
+                        "stimulus_name": "Laser pulses",
+                        "stimulus_type": "Opto Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2026-02-26T15:51:06-08:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": "0.9000000000000007",
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "dynamic-foraging-task",
+                    "parameters": {
+                        "interval_beta": "4",
+                        "interval_distribution": "Exponential",
+                        "interval_max": "30",
+                        "interval_min": "4",
+                        "left_reward_volume": "2,5,8",
+                        "reward_number_each_condition": "30",
+                        "right_reward_volume": "2,5,8",
+                        "spout": "Both"
+                    },
+                    "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                    "version": "behavior branch:main   commit ID:653293091179fa284c22c6dccff4f0bd49848b1e    version:1.6.66; metadata branch: main   commit ID:653293091179fa284c22c6dccff4f0bd49848b1e   version:1.6.66"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "Bonsai",
+                        "parameters": {},
+                        "url": null,
+                        "version": "2.8.0"
+                    }
+                ],
+                "speaker_config": {
+                    "name": "Go cue speaker",
+                    "volume": "60",
+                    "volume_unit": "decibels"
+                },
+                "stimulus_device_names": [
+                    "Go cue speaker"
+                ],
+                "stimulus_end_time": "2026-02-26T15:55:02.181573-08:00",
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_name": "Auditory go cue for foraging task",
+                "stimulus_parameters": [
+                    {
+                        "amplitude_modulation_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_low_frequency": null,
+                        "bandpass_order": null,
+                        "frequency_unit": "hertz",
+                        "notes": null,
+                        "sample_frequency": "7500",
+                        "stimulus_name": "Auditory go cue",
+                        "stimulus_type": "Auditory Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2026-02-26T15:06:02.634381-08:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": 179
+            }
+        ],
+        "subject_id": "834198",
+        "weight_unit": "gram"
+    },
+    "rig": {
+        "additional_devices": [],
+        "calibrations": [
+            {
+                "calibration_date": "2026-02-13T00:00:00-08:00",
+                "description": "Reduced power laser calibration fiber",
+                "device_name": "Oxxius Red Laser 1",
+                "input": {
+                    "voltage (V)": [
+                        0.5,
+                        1,
+                        1.5,
+                        2,
+                        2.5,
+                        3,
+                        3.5,
+                        4,
+                        4.5,
+                        5
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.251,
+                        0.612,
+                        0.972,
+                        1.313,
+                        1.653,
+                        2.017,
+                        2.37,
+                        2.74,
+                        3.06,
+                        3.4
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2026-02-13T00:00:00-08:00",
+                "description": "Reduced power laser calibration fiber",
+                "device_name": "Oxxius Blue Laser 1",
+                "input": {
+                    "voltage (V)": [
+                        0.5,
+                        1,
+                        1.5,
+                        2,
+                        2.5,
+                        3,
+                        3.5,
+                        4,
+                        4.5,
+                        5
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "power (mW)": [
+                        0.18,
+                        0.426,
+                        0.673,
+                        0.947,
+                        1.21,
+                        1.46,
+                        1.7,
+                        1.94,
+                        2.23,
+                        2.54
+                    ]
+                }
+            }
+        ],
+        "cameras": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT713669",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "Face Camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "23022709",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face side right",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": null,
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": null,
+                    "description": "Useful range 730 to 1100nm",
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Long pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": "MidOpt",
+                        "name": "Midwest Optical Systems, Inc.",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "LP715-37.5 Near-IR Longpass Filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Fujinon",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": "f/1.8",
+                    "model": "CF16ZA-1S",
+                    "name": "Fujinon CF16ZA-1S 16mm 23MP 1.1\" f/1.8 - f/16 C-Mount Lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Face Camera Assembly",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT713669",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "Body Camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "23347792",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Body",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": null,
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": null,
+                    "description": "Useful Range: 715 to 780 nm",
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Band pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": "MidOpt",
+                        "name": "Midwest Optical Systems, Inc.",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "BP735 IR Bandpass Filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "8",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Navitar",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": "f/1.4",
+                    "model": "NMV-8M1",
+                    "name": "Navitar NMV-8M1 1\" 8mm F1.4 Manual Iris C-Mount Lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Body Camera Assembly",
+                "position": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "daqs": [
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "DO0",
+                        "channel_type": "Digital Output",
+                        "device_name": "Face Camera",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT713669",
+                "core_version": "2.1",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Behavior",
+                    "whoami": 1216
+                },
+                "is_clock_generator": true,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "Harp Behavior",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "basestation_firmware_version": "2.0169",
+                "bsc_firmware_version": "3.2176",
+                "channels": [],
+                "computer_name": "W10DT713668",
+                "data_interface": "PXI",
+                "device_type": "Neuropixels basestation",
+                "firmware_version": null,
+                "hardware_version": null,
+                "manufacturer": {
+                    "abbreviation": "IMEC",
+                    "name": "Interuniversity Microelectronics Center",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "02kcbn207"
+                },
+                "model": null,
+                "name": "Neuropixels Basestation",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "ports": [
+                    {
+                        "index": 1,
+                        "probes": [
+                            "Probe A"
+                        ]
+                    },
+                    {
+                        "index": 2,
+                        "probes": [
+                            "Probe B"
+                        ]
+                    }
+                ],
+                "serial_number": null,
+                "slot": 4
+            },
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "Left channel",
+                        "channel_type": "Analog Output",
+                        "device_name": "Go cue speaker",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT713669",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Sound Card",
+                    "whoami": 1280
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "Harp Sound Card",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "Lick tube input 1",
+                        "channel_type": "Analog Input",
+                        "device_name": "Lick spout left",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT713669",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Lickety Split",
+                    "whoami": 1400
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "Lickety split left",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "Lick tube input 1",
+                        "channel_type": "Analog Input",
+                        "device_name": "Lick spout right",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT713669",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Lickety Split",
+                    "whoami": 1400
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "Lickety split right",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "detectors": [],
+        "digital_micromirror_devices": [],
+        "enclosure": {
+            "additional_settings": {},
+            "air_filtration": false,
+            "device_type": "Enclosure",
+            "external_material": "Plastic",
+            "grounded": false,
+            "internal_material": "Aluminum",
+            "laser_interlock": true,
+            "manufacturer": {
+                "abbreviation": null,
+                "name": "Item",
+                "registry": null,
+                "registry_identifier": null
+            },
+            "model": null,
+            "name": "Ephys enclosure",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "size": {
+                "height": 120,
+                "length": 100,
+                "unit": "centimeter",
+                "width": 131
+            }
+        },
+        "ephys_assemblies": [
+            {
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "46106",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34311"
+                },
+                "name": "Probe A ephys assembly",
+                "probes": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Ephys probe",
+                        "headstage": null,
+                        "lasers": [],
+                        "manufacturer": {
+                            "abbreviation": "IMEC",
+                            "name": "Interuniversity Microelectronics Center",
+                            "registry": {
+                                "abbreviation": "ROR",
+                                "name": "Research Organization Registry"
+                            },
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "name": "Probe A",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "probe_model": "Neuropixels 2.0 (Multi Shank)",
+                        "serial_number": "22420013284"
+                    }
+                ]
+            },
+            {
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "46118",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34693"
+                },
+                "name": "Probe B ephys assembly",
+                "probes": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Ephys probe",
+                        "headstage": null,
+                        "lasers": [],
+                        "manufacturer": {
+                            "abbreviation": "IMEC",
+                            "name": "Interuniversity Microelectronics Center",
+                            "registry": {
+                                "abbreviation": "ROR",
+                                "name": "Research Organization Registry"
+                            },
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "name": "Probe B",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "probe_model": "Neuropixels 2.0 (Multi Shank)",
+                        "serial_number": "23299810303"
+                    }
+                ]
+            },
+            {
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "50204",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34778"
+                },
+                "name": "Probe C ephys assembly",
+                "probes": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Ephys probe",
+                        "headstage": null,
+                        "lasers": [],
+                        "manufacturer": {
+                            "abbreviation": "IMEC",
+                            "name": "Interuniversity Microelectronics Center",
+                            "registry": {
+                                "abbreviation": "ROR",
+                                "name": "Research Organization Registry"
+                            },
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "name": "Probe C",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "probe_model": "Neuropixels 2.0 (Multi Shank)",
+                        "serial_number": "23299124391"
+                    }
+                ]
+            },
+            {
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "50208",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34907"
+                },
+                "name": "Probe D ephys assembly",
+                "probes": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Ephys probe",
+                        "headstage": null,
+                        "lasers": [],
+                        "manufacturer": {
+                            "abbreviation": "IMEC",
+                            "name": "Interuniversity Microelectronics Center",
+                            "registry": {
+                                "abbreviation": "ROR",
+                                "name": "Research Organization Registry"
+                            },
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "name": "Probe D",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "probe_model": "Neuropixels 2.0 (Multi Shank)",
+                        "serial_number": "23107811892"
+                    }
+                ]
+            }
+        ],
+        "fiber_assemblies": [],
+        "filters": [],
+        "laser_assemblies": [
+            {
+                "collimator": {
+                    "additional_settings": {},
+                    "device_type": "Collimator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Thorlabs",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04gsnvb07"
+                    },
+                    "model": "CFC2A",
+                    "name": "Collimator",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null
+                },
+                "fiber": {
+                    "additional_settings": {},
+                    "core_diameter": "125",
+                    "device_type": "Patch",
+                    "manufacturer": null,
+                    "model": null,
+                    "name": "Patch cable",
+                    "notes": null,
+                    "numerical_aperture": "0.12",
+                    "path_to_cad": null,
+                    "photobleaching_date": null,
+                    "port_index": null,
+                    "serial_number": null
+                },
+                "lasers": [
+                    {
+                        "additional_settings": {},
+                        "coupling": "Single-mode fiber",
+                        "coupling_efficiency": null,
+                        "coupling_efficiency_unit": "percent",
+                        "device_type": "Laser",
+                        "item_number": null,
+                        "manufacturer": {
+                            "abbreviation": null,
+                            "name": "Oxxius",
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "maximum_power": null,
+                        "model": null,
+                        "name": "Oxxius Red Laser 1",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "power_unit": "milliwatt",
+                        "serial_number": "LAS-08677",
+                        "wavelength": 638,
+                        "wavelength_unit": "nanometer"
+                    },
+                    {
+                        "additional_settings": {},
+                        "coupling": "Single-mode fiber",
+                        "coupling_efficiency": null,
+                        "coupling_efficiency_unit": "percent",
+                        "device_type": "Laser",
+                        "item_number": null,
+                        "manufacturer": {
+                            "abbreviation": null,
+                            "name": "Oxxius",
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "maximum_power": null,
+                        "model": null,
+                        "name": "Oxxius Blue Laser 1",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "power_unit": "milliwatt",
+                        "serial_number": "LAS-08788",
+                        "wavelength": 473,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator": {
+                    "additional_settings": {},
+                    "device_type": "Manipulator",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "45879",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "33711"
+                },
+                "name": "External 473/638 laser, collimator 1"
+            }
+        ],
+        "lenses": [],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L3",
+                "name": "Face cam illumination LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M730L3",
+                "name": "Body cam illumination LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 730,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "ecephys",
+                "name": "Extracellular electrophysiology"
+            }
+        ],
+        "modification_date": "2026-02-13",
+        "mouse_platform": {
+            "additional_settings": {},
+            "brake_output": null,
+            "date_surface_replaced": null,
+            "device_type": "Wheel",
+            "encoder": {
+                "additional_settings": {},
+                "device_type": "Encoder",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Same Sky",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "AMT102",
+                "name": "CUI Devices Encoder",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "encoder_output": null,
+            "magnetic_brake": {
+                "additional_settings": {},
+                "device_type": "Brake",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Placid Industries",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "B1-2FM",
+                "name": "Placid Industries magnetic brake",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "manufacturer": null,
+            "model": null,
+            "name": "Running Wheel",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "pulse_per_revolution": 32800,
+            "radius": "8.5",
+            "serial_number": null,
+            "size_unit": "millimeter",
+            "surface_material": null,
+            "torque_output": null,
+            "torque_sensor": {
+                "additional_settings": {},
+                "device_type": "Torque sensor",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Transducer Techniques",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "RTS-10",
+                "name": "Transducer Techniques torque sensor",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "width": "5"
+        },
+        "notes": null,
+        "objectives": [],
+        "origin": null,
+        "patch_cords": [],
+        "pockels_cells": [],
+        "polygonal_scanners": [],
+        "rig_axes": null,
+        "rig_id": "323_EPHYS1_20260213",
+        "schema_version": "1.0.4",
+        "stick_microscopes": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Color",
+                    "computer_name": "W10DT713668",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-120S4C",
+                    "name": "Probe Camera 1",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/1.7",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 3000,
+                    "sensor_width": 4000,
+                    "serial_number": "22438385",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Brain surface",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "max_aperture": null,
+                    "model": "InfiniProbe S-25",
+                    "name": "Probe lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Probe camera 1",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Color",
+                    "computer_name": "W10DT713668",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-120S4C",
+                    "name": "Probe Camera 2",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/1.7",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 3000,
+                    "sensor_width": 4000,
+                    "serial_number": "20105611",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Brain surface",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "max_aperture": null,
+                    "model": "InfiniProbe S-25",
+                    "name": "Probe lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Probe camera 2",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Color",
+                    "computer_name": "W10DT713668",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-120S4C",
+                    "name": "Probe Camera 3",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/1.7",
+                    "sensor_format_unit": "inches",
+                    "sensor_height": 3000,
+                    "sensor_width": 4000,
+                    "serial_number": "22438379",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Brain surface",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "max_aperture": null,
+                    "model": "InfiniProbe S-25",
+                    "name": "Probe lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Probe camera 3",
+                "position": null
+            }
+        ],
+        "stimulus_devices": [
+            {
+                "additional_settings": {},
+                "device_type": "Speaker",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "Digikey-XT25SC90-04",
+                "name": "Go cue speaker",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "serial_number": null
+            },
+            {
+                "device_type": "Reward delivery",
+                "reward_spouts": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Harp device",
+                            "manufacturer": {
+                                "abbreviation": "OEPS",
+                                "name": "Open Ephys Production Site",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "007rkz355"
+                            },
+                            "model": null,
+                            "name": "Lickety split left",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Lick spout left",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Left",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid Valve",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDB1233518H",
+                            "name": "LHD series 3-way control solenoid valve",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    },
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Harp device",
+                            "manufacturer": {
+                                "abbreviation": "OEPS",
+                                "name": "Open Ephys Production Site",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "007rkz355"
+                            },
+                            "model": null,
+                            "name": "Lickety split right",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Lick spout right",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Right",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid Valve",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDB1233518H",
+                            "name": "LHD series 3-way control solenoid valve",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    }
+                ],
+                "stage_type": {
+                    "additional_settings": {},
+                    "device_type": "Motorized stage",
+                    "firmware": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "New Scale Technologies",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "name": "NewScaleMotor for LickSpouts",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "34348",
+                    "travel": "15.0",
+                    "travel_unit": "millimeter"
+                }
+            }
+        ]
+    },
+    "processing": {
+        "object_type": "Processing",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "schema_version": "2.2.0",
+        "data_processes": [
+            {
+                "object_type": "Data process",
+                "process_type": "Other",
+                "name": "Other_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "ghcr.io/allenneuraldynamics/aind-ephys-transformation",
+                    "name": "Other",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "check_timestamps": "FALSE",
+                        "input_source": "/allen/aind/scratch/ephys/temp/834198_2026-02-26_15-05-56",
+                        "output_directory": "/allen/aind/stage/svc_aind_airflow/prod/ecephys_834198_2026-02-26_15-05-56_aaf83c38c4/ecephys"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "AIND Scientific Computing"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2026-02-27T19:05:38Z",
+                "end_date_time": "2026-02-27T20:14:51Z",
+                "output_path": "/allen/aind/stage/svc_aind_airflow/prod/ecephys_834198_2026-02-26_15-05-56_aaf83c38c4/ecephys",
+                "output_parameters": {},
+                "notes": "(v1v2 upgrade) Process type is unknown, no notes were provided.",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Other",
+                "name": "Other_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "ghcr.io/allenneuraldynamics/aind-behavior-video-transformation",
+                    "name": "Other",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "compression_requested": {
+                            "compression_enum": "gamma fix colorspace"
+                        },
+                        "input_source": "/allen/aind/scratch/ephys/temp/behavior_834198_2026-02-26_15-05-57/behavior-videos",
+                        "output_directory": "/allen/aind/stage/svc_aind_airflow/prod/ecephys_834198_2026-02-26_15-05-56_aaf83c38c4/behavior-videos"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "AIND Scientific Computing"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2026-02-27T19:05:38Z",
+                "end_date_time": "2026-02-28T04:34:37Z",
+                "output_path": "/allen/aind/stage/svc_aind_airflow/prod/ecephys_834198_2026-02-26_15-05-56_aaf83c38c4/behavior-videos",
+                "output_parameters": {},
+                "notes": "(v1v2 upgrade) Process type is unknown, no notes were provided.",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Other",
+                "name": "Other_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "",
+                    "name": "Other",
+                    "version": "unknown",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "input_source": "/allen/aind/scratch/ephys/temp/behavior_834198_2026-02-26_15-05-57/behavior"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "AIND Scientific Computing"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2026-02-27T19:05:38Z",
+                "end_date_time": "2026-02-27T19:05:39Z",
+                "output_path": ".",
+                "output_parameters": {},
+                "notes": "Data was copied",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment2_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:08:15.371464Z",
+                "end_date_time": "2026-02-28T05:08:15.371464Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.222033333333336s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:08:15.495337Z",
+                "end_date_time": "2026-02-28T05:13:49.495337Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:08:15.506579Z",
+                "end_date_time": "2026-02-28T05:08:15.506579Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.222166666666666s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:08:15.516401Z",
+                "end_date_time": "2026-02-28T05:13:34.516401Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "noise",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:09:47.063302Z",
+                "end_date_time": "2026-02-28T05:17:43.063302Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 2 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:09:47.941728Z",
+                "end_date_time": "2026-02-28T05:17:13.941728Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "noise",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:09:48.028639Z",
+                "end_date_time": "2026-02-28T05:17:39.028639Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:18.406092Z",
+                "end_date_time": "2026-02-28T05:11:19.406092Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.400733333333335s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment5_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:19.467997Z",
+                "end_date_time": "2026-02-28T05:11:20.467997Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.3862s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment6_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:20.053956Z",
+                "end_date_time": "2026-02-28T05:11:21.053956Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.3647s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment5_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:32.520895Z",
+                "end_date_time": "2026-02-28T05:11:32.520895Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.38333333333333s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment4_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:33.880654Z",
+                "end_date_time": "2026-02-28T05:11:33.880654Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.29816666666667s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:36.159678Z",
+                "end_date_time": "2026-02-28T05:15:30.159678Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 0 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment6_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:36.470065Z",
+                "end_date_time": "2026-02-28T05:11:36.470065Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.35286666666667s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment5_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:36.555084Z",
+                "end_date_time": "2026-02-28T05:11:36.555084Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.38636666666667s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment7_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:36.753234Z",
+                "end_date_time": "2026-02-28T05:11:36.753234Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.374233333333336s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment6_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:36.853850Z",
+                "end_date_time": "2026-02-28T05:11:36.853850Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.3564s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:37.157985Z",
+                "end_date_time": "2026-02-28T05:11:37.157985Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.29833333333333s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:37.181824Z",
+                "end_date_time": "2026-02-28T05:11:37.181824Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.4007s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:37.187805Z",
+                "end_date_time": "2026-02-28T05:15:41.187805Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "noise",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "noise",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 6 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:37.454689Z",
+                "end_date_time": "2026-02-28T05:19:09.454689Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 0 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:37.948378Z",
+                "end_date_time": "2026-02-28T05:11:37.948378Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.298233333333336s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:38.972129Z",
+                "end_date_time": "2026-02-28T05:17:14.972129Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 0 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment7_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:39.114540Z",
+                "end_date_time": "2026-02-28T05:11:39.114540Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.37526666666667s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:40.238429Z",
+                "end_date_time": "2026-02-28T05:17:29.238429Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "dead",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 3 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment3_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:41.228342Z",
+                "end_date_time": "2026-02-28T05:11:41.228342Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.424166666666665s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:41.495375Z",
+                "end_date_time": "2026-02-28T05:11:41.495375Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.22206666666667s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:41.760971Z",
+                "end_date_time": "2026-02-28T05:19:44.760971Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "win_step_norm": 0.1,
+                                "win_scale_norm": 0.1
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment7_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:41.872145Z",
+                "end_date_time": "2026-02-28T05:11:41.872145Z",
+                "output_path": "../results",
+                "output_parameters": {},
+                "notes": "\n- Recording is too short (60.375233333333334s). Skipping further processing\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "job_kwargs": {
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": "spawn",
+                            "n_jobs": 16
+                        },
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "bandpass_filter": {
+                            "freq_min": 300,
+                            "freq_max": 6000,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "motion_correction": {
+                            "preset": "dredge_fast",
+                            "detect_kwargs": {},
+                            "select_kwargs": {},
+                            "localize_peaks_kwargs": {},
+                            "estimate_motion_kwargs": {
+                                "bin_s": 2,
+                                "win_step_um": 70.5,
+                                "win_scale_um": 70.5
+                            },
+                            "interpolate_motion_kwargs": {},
+                            "compute": true,
+                            "apply": false
+                        },
+                        "filter_type": "highpass",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:11:41.949067Z",
+                "end_date_time": "2026-02-28T05:19:36.949067Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "noise",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "noise",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "noise",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 3 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:15:17.082338Z",
+                "end_date_time": "2026-02-28T05:28:47.082338Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 87 units, 87 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:15:23.456920Z",
+                "end_date_time": "2026-02-28T05:29:59.456920Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 236 units, 236 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:20:19.762651Z",
+                "end_date_time": "2026-02-28T05:33:42.762651Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 88 units, 88 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:22:56.124021Z",
+                "end_date_time": "2026-02-28T05:38:38.124021Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 209 units, 209 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:22:57.335144Z",
+                "end_date_time": "2026-02-28T05:38:53.335144Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 242 units, 242 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:22:57.338166Z",
+                "end_date_time": "2026-02-28T05:38:04.338166Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 125 units, 125 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:24:26.593757Z",
+                "end_date_time": "2026-02-28T05:37:57.593757Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 106 units, 106 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:24:26.601215Z",
+                "end_date_time": "2026-02-28T05:38:20.601215Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 120 units, 120 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:24:26.683306Z",
+                "end_date_time": "2026-02-28T05:38:21.683306Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 122 units, 122 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:26:37.269795Z",
+                "end_date_time": "2026-02-28T05:42:22.269795Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 186 units, 186 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:26:37.884247Z",
+                "end_date_time": "2026-02-28T05:41:52.884247Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 92 units, 92 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort4",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort4",
+                        "sorter_params": {
+                            "fs": 30000,
+                            "batch_size": 60000,
+                            "nblocks": 5,
+                            "Th_universal": 9,
+                            "Th_learned": 8,
+                            "nt": 61,
+                            "shift": null,
+                            "scale": null,
+                            "artifact_threshold": null,
+                            "nskip": 25,
+                            "whitening_range": 32,
+                            "highpass_cutoff": 300,
+                            "binning_depth": 5,
+                            "sig_interp": 20,
+                            "drift_smoothing": [
+                                0.5,
+                                0.5,
+                                0.5
+                            ],
+                            "nt0min": null,
+                            "dmin": null,
+                            "dminx": 32,
+                            "min_template_size": 10,
+                            "template_sizes": 5,
+                            "nearest_chans": 10,
+                            "nearest_templates": 100,
+                            "max_channel_distance": null,
+                            "max_peels": 100,
+                            "templates_from_data": true,
+                            "n_templates": 6,
+                            "n_pcs": 6,
+                            "Th_single_ch": 6,
+                            "acg_threshold": 0.2,
+                            "ccg_threshold": 0.25,
+                            "cluster_downsampling": 20,
+                            "x_centers": null,
+                            "duplicate_spike_ms": 0.25,
+                            "position_limit": 100,
+                            "do_CAR": true,
+                            "invert_sign": false,
+                            "save_extra_vars": false,
+                            "save_preprocessed_copy": false,
+                            "torch_device": "auto",
+                            "bad_channels": null,
+                            "clear_cache": false,
+                            "do_correction": true,
+                            "skip_kilosort_preprocessing": false,
+                            "keep_good_only": false,
+                            "use_binary_file": null,
+                            "delete_recording_dat": true,
+                            "pool_engine": "process",
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_worker": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:26:38.353606Z",
+                "end_date_time": "2026-02-28T05:42:59.353606Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS4 found 150 units, 150 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T05:56:28.929445Z",
+                "end_date_time": "2026-02-28T06:11:18.929445Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 2
+                },
+                "notes": "\n- Removed 2 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:00:45.487378Z",
+                "end_date_time": "2026-02-28T06:08:46.487378Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 0
+                },
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:00:49.944892Z",
+                "end_date_time": "2026-02-28T06:09:06.944892Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 3
+                },
+                "notes": "\n- Removed 3 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:01:01.042932Z",
+                "end_date_time": "2026-02-28T06:11:07.042932Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 0
+                },
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:01:50.925163Z",
+                "end_date_time": "2026-02-28T06:08:04.925163Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 0
+                },
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:01:51.644093Z",
+                "end_date_time": "2026-02-28T06:08:47.644093Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 2
+                },
+                "notes": "\n- Removed 2 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:09:26.212836Z",
+                "end_date_time": "2026-02-28T06:09:35.212836Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 122,
+                    "passing_qc": 83,
+                    "failing_qc": 39,
+                    "noise_units": 21,
+                    "neural_units": 101,
+                    "sua_units": 60,
+                    "mua_units": 41
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 83/122Noise: 21 / 122\nSUA: 60 / 122\nMUA: 41 / 122\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:10:01.385428Z",
+                "end_date_time": "2026-02-28T06:10:09.385428Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 87,
+                    "passing_qc": 67,
+                    "failing_qc": 20,
+                    "noise_units": 28,
+                    "neural_units": 59,
+                    "sua_units": 46,
+                    "mua_units": 13
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 67/87Noise: 28 / 87\nSUA: 46 / 87\nMUA: 13 / 87\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:10:02.772157Z",
+                "end_date_time": "2026-02-28T06:10:21.772157Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 148,
+                    "passing_qc": 88,
+                    "failing_qc": 60,
+                    "noise_units": 21,
+                    "neural_units": 127,
+                    "sua_units": 73,
+                    "mua_units": 54
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 88/148Noise: 21 / 148\nSUA: 73 / 148\nMUA: 54 / 148\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:10:17.577138Z",
+                "end_date_time": "2026-02-28T06:10:38.577138Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 206,
+                    "passing_qc": 114,
+                    "failing_qc": 92,
+                    "noise_units": 51,
+                    "neural_units": 155,
+                    "sua_units": 69,
+                    "mua_units": 86
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 114/206Noise: 51 / 206\nSUA: 69 / 206\nMUA: 86 / 206\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:11:07.945550Z",
+                "end_date_time": "2026-02-28T06:16:53.945550Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 0
+                },
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:11:18.783750Z",
+                "end_date_time": "2026-02-28T06:15:29.783750Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 1
+                },
+                "notes": "\n- Removed 1 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:11:20.061225Z",
+                "end_date_time": "2026-02-28T06:17:48.061225Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 14
+                },
+                "notes": "\n- Removed 14 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:11:28.931518Z",
+                "end_date_time": "2026-02-28T06:20:25.931518Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 0
+                },
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:11:33.477126Z",
+                "end_date_time": "2026-02-28T06:20:38.477126Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 3
+                },
+                "notes": "\n- Removed 3 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "return_scaled": true,
+                        "random_spikes": {
+                            "max_spikes_per_unit": 500,
+                            "method": "uniform",
+                            "margin_size": null,
+                            "seed": null
+                        },
+                        "noise_levels": {
+                            "num_chunks_per_segment": 20,
+                            "chunk_size": 10000,
+                            "seed": null
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "dtype": null
+                        },
+                        "templates": {},
+                        "spike_amplitudes": {
+                            "peak_sign": "neg"
+                        },
+                        "template_similarity": {
+                            "method": "l1"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isi_histograms": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:11:37.193870Z",
+                "end_date_time": "2026-02-28T06:16:06.193870Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 0
+                },
+                "notes": "\n- Removed 0 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:12:14.127161Z",
+                "end_date_time": "2026-02-28T06:12:22.127161Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 125,
+                    "passing_qc": 94,
+                    "failing_qc": 31,
+                    "noise_units": 25,
+                    "neural_units": 100,
+                    "sua_units": 75,
+                    "mua_units": 25
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 94/125Noise: 25 / 125\nSUA: 75 / 125\nMUA: 25 / 125\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:12:41.930662Z",
+                "end_date_time": "2026-02-28T06:13:18.930662Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 234,
+                    "passing_qc": 114,
+                    "failing_qc": 120,
+                    "noise_units": 33,
+                    "neural_units": 201,
+                    "sua_units": 72,
+                    "mua_units": 129
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 114/234Noise: 33 / 234\nSUA: 72 / 234\nMUA: 129 / 234\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:16:35.089907Z",
+                "end_date_time": "2026-02-28T06:16:48.089907Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 87,
+                    "passing_qc": 50,
+                    "failing_qc": 37,
+                    "noise_units": 26,
+                    "neural_units": 61,
+                    "sua_units": 33,
+                    "mua_units": 28
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 50/87Noise: 26 / 87\nSUA: 33 / 87\nMUA: 28 / 87\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:16:57.765051Z",
+                "end_date_time": "2026-02-28T06:17:09.765051Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 106,
+                    "passing_qc": 60,
+                    "failing_qc": 46,
+                    "noise_units": 30,
+                    "neural_units": 76,
+                    "sua_units": 41,
+                    "mua_units": 35
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 60/106Noise: 30 / 106\nSUA: 41 / 106\nMUA: 35 / 106\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:18:03.806492Z",
+                "end_date_time": "2026-02-28T06:18:16.806492Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 92,
+                    "passing_qc": 46,
+                    "failing_qc": 46,
+                    "noise_units": 21,
+                    "neural_units": 71,
+                    "sua_units": 34,
+                    "mua_units": 37
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 46/92Noise: 21 / 92\nSUA: 34 / 92\nMUA: 37 / 92\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:18:50.129714Z",
+                "end_date_time": "2026-02-28T06:19:01.129714Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 106,
+                    "passing_qc": 54,
+                    "failing_qc": 52,
+                    "noise_units": 48,
+                    "neural_units": 58,
+                    "sua_units": 31,
+                    "mua_units": 27
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 54/106Noise: 48 / 106\nSUA: 31 / 106\nMUA: 27 / 106\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:21:27.741031Z",
+                "end_date_time": "2026-02-28T06:21:44.741031Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 186,
+                    "passing_qc": 102,
+                    "failing_qc": 84,
+                    "noise_units": 49,
+                    "neural_units": 137,
+                    "sua_units": 60,
+                    "mua_units": 77
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 102/186Noise: 49 / 186\nSUA: 60 / 186\nMUA: 77 / 186\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": null,
+                    "version": "2.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "query": "isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1",
+                        "noise_neural_classifier": "SpikeInterface/UnitRefine_noise_neural_classifier",
+                        "sua_mua_classifier": "SpikeInterface/UnitRefine_sua_mua_classifier",
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:21:40.110472Z",
+                "end_date_time": "2026-02-28T06:22:01.110472Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 239,
+                    "passing_qc": 141,
+                    "failing_qc": 98,
+                    "noise_units": 38,
+                    "neural_units": 201,
+                    "sua_units": 106,
+                    "mua_units": 95
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\nPassing default QC: 141/239Noise: 38 / 239\nSUA: 106 / 239\nMUA: 95 / 239\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:32:18.081706Z",
+                "end_date_time": "2026-02-28T06:34:46.081706Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8a2bf933c00aab42a73fda7dbe78de1718b47228&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8a2bf933c00aab42a73fda7dbe78de1718b47228&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment7_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:32:35.176303Z",
+                "end_date_time": "2026-02-28T06:35:08.176303Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:40686b4fd98d0d2323fcce312319f81681f2472f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:40686b4fd98d0d2323fcce312319f81681f2472f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment3_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:32:48.246864Z",
+                "end_date_time": "2026-02-28T06:35:12.246864Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9aaead9f76137b5e55151a1d554597d04498f65d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9aaead9f76137b5e55151a1d554597d04498f65d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment7_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:32:48.759845Z",
+                "end_date_time": "2026-02-28T06:35:08.759845Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:40609168baa3d3b345f521006d165319dca95447&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:40609168baa3d3b345f521006d165319dca95447&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:33:11.094754Z",
+                "end_date_time": "2026-02-28T06:35:19.094754Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:7dc69fcf0833755641a32b675e208f9f4de2e69e&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:7dc69fcf0833755641a32b675e208f9f4de2e69e&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment4_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:33:37.494631Z",
+                "end_date_time": "2026-02-28T06:35:46.494631Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8c8e19473f8f73803acf96cb3d6bfab5477849b8&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8c8e19473f8f73803acf96cb3d6bfab5477849b8&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:33:44.411613Z",
+                "end_date_time": "2026-02-28T06:36:06.411613Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:368db50eb290aaf7e30c679813a5c6cf32a36039&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:05977c33a69d95c37b1ec340e276c7b16f758ea4&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:368db50eb290aaf7e30c679813a5c6cf32a36039&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:05977c33a69d95c37b1ec340e276c7b16f758ea4&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group0/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment6_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:34:28.215769Z",
+                "end_date_time": "2026-02-28T06:36:28.215769Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9b570bac1d82f1069a60d798c437f0e108d3d0b8&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9b570bac1d82f1069a60d798c437f0e108d3d0b8&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment5_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:34:38.320137Z",
+                "end_date_time": "2026-02-28T06:36:40.320137Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:883b86035ec4cebbcdafb7ae384d455f295e8956&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:883b86035ec4cebbcdafb7ae384d455f295e8956&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment5_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:34:42.372470Z",
+                "end_date_time": "2026-02-28T06:36:42.372470Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:085faaddcd20d9a5ae82409cd545543172527389&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:085faaddcd20d9a5ae82409cd545543172527389&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment7_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:34:45.478362Z",
+                "end_date_time": "2026-02-28T06:36:44.478362Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:83d168fcd176e3aabc870d09c4e4c1a2d60e94fe&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:83d168fcd176e3aabc870d09c4e4c1a2d60e94fe&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment6_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:34:50.809186Z",
+                "end_date_time": "2026-02-28T06:36:49.809186Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:32db6e0e8ccad39af443269d959741d4bd73179d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:32db6e0e8ccad39af443269d959741d4bd73179d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:35:04.808726Z",
+                "end_date_time": "2026-02-28T06:37:05.808726Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:ec64a3ff9e6e43d169fd8db122cf2d84239dc589&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:ec64a3ff9e6e43d169fd8db122cf2d84239dc589&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:35:06.142440Z",
+                "end_date_time": "2026-02-28T06:37:07.142440Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:f78e25474c8f1228566d0b1e7cd4322324ef659f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:f78e25474c8f1228566d0b1e7cd4322324ef659f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment5_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:35:45.278322Z",
+                "end_date_time": "2026-02-28T06:38:54.278322Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9b91d84782cfe1875dfa4ca19c6bed0cca5b4b04&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9b91d84782cfe1875dfa4ca19c6bed0cca5b4b04&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:35:46.710128Z",
+                "end_date_time": "2026-02-28T06:38:52.710128Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:628cbdbe4f1b68655fbfa52a42a1aea99588fcec&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:628cbdbe4f1b68655fbfa52a42a1aea99588fcec&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:35:52.065858Z",
+                "end_date_time": "2026-02-28T06:38:57.065858Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:2fb473fd770fd8b1e3c39c0c46687d859bed4392&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:2fb473fd770fd8b1e3c39c0c46687d859bed4392&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment6_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:35:52.243530Z",
+                "end_date_time": "2026-02-28T06:38:57.243530Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:e86c45e754a25279230080f9ff250662ce065e8d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:e86c45e754a25279230080f9ff250662ce065e8d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeC_recording1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:35:59.637596Z",
+                "end_date_time": "2026-02-28T06:38:47.637596Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3c81c29c6fa36dbeaee67a092ccf7cf141ac5852&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3c81c29c6fa36dbeaee67a092ccf7cf141ac5852&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:40:35.331215Z",
+                "end_date_time": "2026-02-28T06:44:50.331215Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:b73bf13856760d63a391c624820707463b0352e9&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:49cc9ee71ebaf74a2bb1851de9718c79edc8742f&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:b73bf13856760d63a391c624820707463b0352e9&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:49cc9ee71ebaf74a2bb1851de9718c79edc8742f&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group1/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:40:46.134396Z",
+                "end_date_time": "2026-02-28T06:45:37.134396Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:855d596602880bdb381c39690be81e608d4104a3&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:bab5ddcb372bb7c40a4d39056fe4c895172a9a03&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:855d596602880bdb381c39690be81e608d4104a3&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:bab5ddcb372bb7c40a4d39056fe4c895172a9a03&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group2/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:41:10.203239Z",
+                "end_date_time": "2026-02-28T06:45:05.203239Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:618cbd4912014bba13a47b89e51d126d6824addc&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group3&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:76ef0613f3af380188c85686e640e3c23cb9d05c&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:618cbd4912014bba13a47b89e51d126d6824addc&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group3&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:76ef0613f3af380188c85686e640e3c23cb9d05c&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeC_recording1_group3/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:41:10.917239Z",
+                "end_date_time": "2026-02-28T06:45:57.917239Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8d7ebfea35d4b91480179afc48d1c54d9c94d043&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:dfd792e536bc16c4e88cad7a3cb8b0de20038ea4&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8d7ebfea35d4b91480179afc48d1c54d9c94d043&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:dfd792e536bc16c4e88cad7a3cb8b0de20038ea4&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group0/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:44:17.056653Z",
+                "end_date_time": "2026-02-28T06:47:04.056653Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:68da87001ccfeccbf1e8906c22dde851d9900943&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:aaf02598b87d6c855205e35a7b87d6d6f9550461&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:68da87001ccfeccbf1e8906c22dde851d9900943&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:aaf02598b87d6c855205e35a7b87d6d6f9550461&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group1/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:47:26.744553Z",
+                "end_date_time": "2026-02-28T06:50:00.744553Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:984af8aa7ae31d1b7705ee8e5878e1ca70238911&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:94b5299ace55db29c02d5f18b5503caca07c7d54&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:984af8aa7ae31d1b7705ee8e5878e1ca70238911&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:94b5299ace55db29c02d5f18b5503caca07c7d54&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group2/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:47:34.049560Z",
+                "end_date_time": "2026-02-28T06:50:20.049560Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:257888df5194ea916219782c3feba00b04c06617&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:87df44c1ed1f03ba04253c75fe0eba5b10bf42e3&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:257888df5194ea916219782c3feba00b04c06617&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:87df44c1ed1f03ba04253c75fe0eba5b10bf42e3&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_recording1_group3/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:47:34.862315Z",
+                "end_date_time": "2026-02-28T06:50:00.862315Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3ede1d6bc9efbb5f05bfcf9a5014b6f41e4d4ac7&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group2&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8c7b5ae7e705473e601203fbba06d8f9ef4cbe91&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3ede1d6bc9efbb5f05bfcf9a5014b6f41e4d4ac7&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group2&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8c7b5ae7e705473e601203fbba06d8f9ef4cbe91&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeC_recording1_group2/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:48:31.161518Z",
+                "end_date_time": "2026-02-28T06:50:56.161518Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:93cb4f2a09007d7f6b49d7e132e6cf7570048747&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9fbed15efcf023735992993200bea12d9b005096&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:93cb4f2a09007d7f6b49d7e132e6cf7570048747&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9fbed15efcf023735992993200bea12d9b005096&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeC_recording1_group1/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:48:38.970135Z",
+                "end_date_time": "2026-02-28T06:50:52.970135Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:58b98ad3849d59f48284c4532d78c75cf9221115&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group0&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:ff760f08e05242ae6d6d2d8e10770723d0e4099f&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:58b98ad3849d59f48284c4532d78c75cf9221115&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group0&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:ff760f08e05242ae6d6d2d8e10770723d0e4099f&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeC_recording1_group0/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": null,
+                    "version": "1.0",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": "AIND Ephys Pipeline",
+                "start_date_time": "2026-02-28T06:48:39.325191Z",
+                "end_date_time": "2026-02-28T06:51:03.325191Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:a07b166ff12c4bbc8df5c6969343e64f32cafa1f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:7a2ba39e6aae1368b4d47e8dbd3baaefcae04488&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3/kilosort4/curation.json\"}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:a07b166ff12c4bbc8df5c6969343e64f32cafa1f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:7a2ba39e6aae1368b4d47e8dbd3baaefcae04488&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_recording1_group3/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            }
+        ],
+        "pipelines": [
+            {
+                "object_type": "Code",
+                "url": "https://github.com/AllenNeuralDynamics/aind-ephys-pipeline",
+                "name": "AIND Ephys Pipeline",
+                "version": "kilosort4_1.0.0",
+                "container": null,
+                "run_script": null,
+                "language": null,
+                "language_version": null,
+                "input_data": null,
+                "parameters": null,
+                "core_dependency": null
+            }
+        ],
+        "notes": "Processes were reordered by start_date_time",
+        "dependency_graph": {
+            "Other_1": [],
+            "Other_2": [
+                "Other_1"
+            ],
+            "Other_3": [
+                "Other_2"
+            ],
+            "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Other_3"
+            ],
+            "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys preprocessing - experiment4_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys preprocessing - experiment5_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys preprocessing - experiment6_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys preprocessing - experiment7_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3": [
+                "Ephys preprocessing - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0": [
+                "Ephys preprocessing - experiment3_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+            ],
+            "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3": [
+                "Ephys preprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+            ],
+            "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1": [
+                "Spike sorting - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+            ],
+            "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0": [
+                "Ephys postprocessing - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+            ],
+            "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3"
+            ],
+            "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys curation - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0": [
+                "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group0"
+            ],
+            "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys visualization - experiment3_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys visualization - experiment7_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1": [
+                "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1": [
+                "Ephys visualization - experiment4_Record Node 101#Neuropix-PXI-100.ProbeB_recording1"
+            ],
+            "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys visualization - experiment2_Record Node 101#Neuropix-PXI-100.ProbeA_recording1"
+            ],
+            "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeC_recording1": [
+                "Ephys visualization - experiment5_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1": [
+                "Ephys visualization - experiment6_Record Node 101#Neuropix-PXI-100.ProbeC_recording1"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group1"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group0"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group3"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group2"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group0"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group1"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group1"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeC_recording1_group2"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group2"
+            ],
+            "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeA_recording1_group3": [
+                "Ephys visualization - experiment1_Record Node 101#Neuropix-PXI-100.ProbeB_recording1_group3"
+            ]
+        }
+    },
+    "acquisition": null,
+    "instrument": null,
+    "quality_control": {
+        "object_type": "Quality control",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/quality_control.py",
+        "schema_version": "2.4.0",
+        "metrics": [
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeA_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:51:35.978289Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8d7ebfea35d4b91480179afc48d1c54d9c94d043&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_group0&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeA_group0/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeA_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:51:35.978289Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeA_group0/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeA_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:51:35.978289Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeA_group0/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeA_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:53:41.889694Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeA_group0/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeA_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:57:24.915775Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeA_group0/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeA_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:57:24.916824Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:dfd792e536bc16c4e88cad7a3cb8b0de20038ea4&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_group0/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeA_group0/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeA_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:57:24.916824Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeA_group0/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeA_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 1,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 9,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 11,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 17,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 22,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 30,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 35,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 52,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 68,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 85,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 98,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 114,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 121,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 130,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 135,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 140,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 141,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 142,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 150,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 165,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 170,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 177,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 186,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 189,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 194,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 195,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 202,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 205,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 209,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 215,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 216,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 218,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 233,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            1,
+                            9,
+                            11,
+                            17,
+                            22,
+                            30,
+                            35,
+                            52,
+                            68,
+                            85,
+                            98,
+                            114,
+                            121,
+                            130,
+                            135,
+                            140,
+                            141,
+                            142,
+                            150,
+                            165,
+                            170,
+                            177,
+                            186,
+                            189,
+                            194,
+                            195,
+                            202,
+                            205,
+                            209,
+                            215,
+                            216,
+                            218,
+                            233
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            95,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            104,
+                            105,
+                            106,
+                            107,
+                            108,
+                            109,
+                            111,
+                            112,
+                            113,
+                            114,
+                            115,
+                            116,
+                            117,
+                            118,
+                            119,
+                            120,
+                            121,
+                            122,
+                            123,
+                            124,
+                            125,
+                            126,
+                            127,
+                            128,
+                            129,
+                            130,
+                            131,
+                            132,
+                            133,
+                            135,
+                            136,
+                            137,
+                            138,
+                            139,
+                            140,
+                            141,
+                            142,
+                            143,
+                            144,
+                            145,
+                            146,
+                            147,
+                            148,
+                            149,
+                            150,
+                            151,
+                            152,
+                            153,
+                            154,
+                            155,
+                            156,
+                            157,
+                            158,
+                            159,
+                            160,
+                            161,
+                            162,
+                            163,
+                            164,
+                            165,
+                            166,
+                            167,
+                            168,
+                            169,
+                            170,
+                            171,
+                            172,
+                            173,
+                            174,
+                            175,
+                            176,
+                            177,
+                            178,
+                            179,
+                            180,
+                            181,
+                            182,
+                            183,
+                            184,
+                            185,
+                            186,
+                            187,
+                            188,
+                            189,
+                            190,
+                            191,
+                            192,
+                            193,
+                            194,
+                            195,
+                            196,
+                            197,
+                            198,
+                            199,
+                            200,
+                            201,
+                            202,
+                            203,
+                            204,
+                            205,
+                            206,
+                            207,
+                            208,
+                            209,
+                            210,
+                            211,
+                            212,
+                            213,
+                            214,
+                            215,
+                            216,
+                            217,
+                            218,
+                            219,
+                            220,
+                            221,
+                            222,
+                            223,
+                            224,
+                            225,
+                            226,
+                            227,
+                            228,
+                            229,
+                            230,
+                            231,
+                            232,
+                            233,
+                            234,
+                            235
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:57:24.916824Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group0.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group0"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T07:57:24.916824Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeA_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:03.802928Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:68da87001ccfeccbf1e8906c22dde851d9900943&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_group1&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeA_group1/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeA_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:03.802928Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeA_group1/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeA_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:03.802928Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeA_group1/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeA_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:36.523483Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeA_group1/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeA_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:58:23.489040Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeA_group1/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeA_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:58:23.490747Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:aaf02598b87d6c855205e35a7b87d6d6f9550461&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_group1/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeA_group1/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeA_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:58:23.490747Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeA_group1/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeA_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 1,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 2,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 8,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 9,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 12,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 17,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 22,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 25,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 28,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 30,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 39,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 40,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 52,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 56,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 62,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 73,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 74,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 75,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 76,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 82,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 83,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 91,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 93,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 95,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 98,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 104,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 105,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 109,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 114,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 116,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 117,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 118,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 119,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 122,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 124,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 126,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 129,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 132,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 133,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 137,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 138,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 142,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 148,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 152,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 154,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 157,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 172,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 179,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 180,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 195,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 201,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            1,
+                            2,
+                            8,
+                            9,
+                            12,
+                            17,
+                            22,
+                            25,
+                            28,
+                            30,
+                            39,
+                            40,
+                            52,
+                            56,
+                            62,
+                            73,
+                            74,
+                            75,
+                            76,
+                            82,
+                            83,
+                            91,
+                            93,
+                            95,
+                            98,
+                            104,
+                            105,
+                            109,
+                            114,
+                            116,
+                            117,
+                            118,
+                            119,
+                            122,
+                            124,
+                            126,
+                            129,
+                            132,
+                            133,
+                            137,
+                            138,
+                            142,
+                            148,
+                            152,
+                            154,
+                            157,
+                            172,
+                            179,
+                            180,
+                            195,
+                            201
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            39,
+                            40,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            95,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            104,
+                            105,
+                            106,
+                            107,
+                            108,
+                            109,
+                            110,
+                            111,
+                            112,
+                            113,
+                            114,
+                            115,
+                            116,
+                            117,
+                            118,
+                            119,
+                            120,
+                            121,
+                            122,
+                            123,
+                            124,
+                            125,
+                            126,
+                            127,
+                            128,
+                            129,
+                            130,
+                            131,
+                            132,
+                            133,
+                            134,
+                            135,
+                            136,
+                            137,
+                            138,
+                            139,
+                            140,
+                            141,
+                            142,
+                            143,
+                            144,
+                            145,
+                            146,
+                            147,
+                            148,
+                            149,
+                            150,
+                            151,
+                            152,
+                            153,
+                            154,
+                            155,
+                            156,
+                            157,
+                            158,
+                            159,
+                            160,
+                            161,
+                            162,
+                            163,
+                            164,
+                            165,
+                            166,
+                            167,
+                            168,
+                            169,
+                            170,
+                            171,
+                            172,
+                            173,
+                            174,
+                            175,
+                            176,
+                            177,
+                            178,
+                            179,
+                            180,
+                            181,
+                            182,
+                            183,
+                            184,
+                            185,
+                            186,
+                            187,
+                            188,
+                            189,
+                            190,
+                            191,
+                            192,
+                            193,
+                            194,
+                            195,
+                            196,
+                            197,
+                            198,
+                            199,
+                            200,
+                            201,
+                            202,
+                            203,
+                            204,
+                            205,
+                            206,
+                            207,
+                            208
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:58:23.490747Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group1"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T07:58:23.490747Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeA_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:50:20.228679Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:855d596602880bdb381c39690be81e608d4104a3&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_group2&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeA_group2/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeA_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:20.228679Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeA_group2/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeA_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:20.228679Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeA_group2/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeA_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:50:48.449606Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeA_group2/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeA_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:55:49.927925Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeA_group2/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeA_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:55:49.928942Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:bab5ddcb372bb7c40a4d39056fe4c895172a9a03&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_group2/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeA_group2/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeA_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:55:49.928942Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeA_group2/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeA_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 1,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 5,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 10,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 32,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 34,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 35,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 42,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 44,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 58,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 63,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 72,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 80,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 91,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 93,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 95,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 100,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 102,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 106,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 113,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 122,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 126,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 127,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 138,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 141,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 147,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 153,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 158,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 159,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 166,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 167,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 175,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 187,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 188,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 194,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 208,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 211,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 217,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 240,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            1,
+                            5,
+                            10,
+                            32,
+                            34,
+                            35,
+                            42,
+                            44,
+                            58,
+                            63,
+                            72,
+                            80,
+                            91,
+                            93,
+                            95,
+                            100,
+                            102,
+                            106,
+                            113,
+                            122,
+                            126,
+                            127,
+                            138,
+                            141,
+                            147,
+                            153,
+                            158,
+                            159,
+                            166,
+                            167,
+                            175,
+                            187,
+                            188,
+                            194,
+                            208,
+                            211,
+                            217,
+                            240
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            18,
+                            20,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            95,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            104,
+                            105,
+                            106,
+                            107,
+                            108,
+                            109,
+                            110,
+                            111,
+                            112,
+                            113,
+                            114,
+                            115,
+                            116,
+                            117,
+                            118,
+                            119,
+                            120,
+                            121,
+                            122,
+                            123,
+                            124,
+                            125,
+                            126,
+                            127,
+                            128,
+                            129,
+                            130,
+                            131,
+                            132,
+                            133,
+                            134,
+                            135,
+                            136,
+                            137,
+                            138,
+                            139,
+                            140,
+                            141,
+                            142,
+                            143,
+                            144,
+                            145,
+                            146,
+                            147,
+                            148,
+                            149,
+                            150,
+                            151,
+                            152,
+                            153,
+                            154,
+                            155,
+                            156,
+                            157,
+                            158,
+                            159,
+                            160,
+                            161,
+                            162,
+                            163,
+                            164,
+                            165,
+                            166,
+                            167,
+                            168,
+                            169,
+                            170,
+                            171,
+                            172,
+                            173,
+                            174,
+                            175,
+                            176,
+                            177,
+                            178,
+                            179,
+                            180,
+                            181,
+                            182,
+                            183,
+                            184,
+                            185,
+                            186,
+                            187,
+                            188,
+                            189,
+                            190,
+                            191,
+                            192,
+                            193,
+                            194,
+                            195,
+                            196,
+                            197,
+                            198,
+                            199,
+                            200,
+                            201,
+                            202,
+                            203,
+                            204,
+                            205,
+                            206,
+                            207,
+                            208,
+                            209,
+                            210,
+                            211,
+                            212,
+                            213,
+                            214,
+                            215,
+                            216,
+                            217,
+                            218,
+                            219,
+                            220,
+                            221,
+                            222,
+                            223,
+                            224,
+                            225,
+                            226,
+                            227,
+                            228,
+                            229,
+                            230,
+                            231,
+                            232,
+                            233,
+                            234,
+                            235,
+                            236,
+                            237,
+                            238,
+                            239,
+                            240,
+                            241
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:55:49.928942Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group2.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group2"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T07:55:49.928942Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeA_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:59:22.294258Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:257888df5194ea916219782c3feba00b04c06617&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_group3&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeA_group3/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeA_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:22.294258Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeA_group3/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeA_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:22.294258Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeA_group3/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeA_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:59:54.520458Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeA_group3/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeA_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:25.524140Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeA_group3/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeA_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:25.525601Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:87df44c1ed1f03ba04253c75fe0eba5b10bf42e3&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeA_group3/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeA_group3/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeA_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:25.525601Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeA_group3/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeA_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 0,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 1,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 2,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 5,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 9,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 11,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 13,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 17,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 23,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 25,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 27,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 35,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 41,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 45,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 48,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 50,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 57,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 64,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 65,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 69,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 71,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 79,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 82,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 83,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 85,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 92,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 98,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 100,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 101,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 102,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 105,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 106,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 117,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 119,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 122,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 126,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 128,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 142,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 148,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 152,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 157,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 164,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 168,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 169,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 174,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 175,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 177,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 183,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 184,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            0,
+                            1,
+                            2,
+                            5,
+                            9,
+                            11,
+                            13,
+                            17,
+                            23,
+                            25,
+                            27,
+                            35,
+                            41,
+                            45,
+                            48,
+                            50,
+                            57,
+                            64,
+                            65,
+                            69,
+                            71,
+                            79,
+                            82,
+                            83,
+                            85,
+                            92,
+                            98,
+                            100,
+                            101,
+                            102,
+                            105,
+                            106,
+                            117,
+                            119,
+                            122,
+                            126,
+                            128,
+                            142,
+                            148,
+                            152,
+                            157,
+                            164,
+                            168,
+                            169,
+                            174,
+                            175,
+                            177,
+                            183,
+                            184
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            95,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            104,
+                            105,
+                            106,
+                            107,
+                            108,
+                            109,
+                            110,
+                            111,
+                            112,
+                            113,
+                            114,
+                            115,
+                            116,
+                            117,
+                            118,
+                            119,
+                            120,
+                            121,
+                            122,
+                            123,
+                            124,
+                            125,
+                            126,
+                            127,
+                            128,
+                            129,
+                            130,
+                            131,
+                            132,
+                            133,
+                            134,
+                            135,
+                            136,
+                            137,
+                            138,
+                            139,
+                            140,
+                            141,
+                            142,
+                            143,
+                            144,
+                            145,
+                            146,
+                            147,
+                            148,
+                            149,
+                            150,
+                            151,
+                            152,
+                            153,
+                            154,
+                            155,
+                            156,
+                            157,
+                            158,
+                            159,
+                            160,
+                            161,
+                            162,
+                            163,
+                            164,
+                            165,
+                            166,
+                            167,
+                            168,
+                            169,
+                            170,
+                            171,
+                            172,
+                            173,
+                            174,
+                            175,
+                            176,
+                            177,
+                            178,
+                            179,
+                            180,
+                            181,
+                            182,
+                            183,
+                            184,
+                            185
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:13:25.525601Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA_recording1_group3.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeA.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeA_group3"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T08:13:25.525601Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeB_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:59:22.702155Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:368db50eb290aaf7e30c679813a5c6cf32a36039&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_group0&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeB_group0/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeB_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:22.702155Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeB_group0/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeB_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:22.702155Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeB_group0/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeB_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:54.239390Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeB_group0/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeB_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:33.658039Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeB_group0/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeB_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:33.659226Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:05977c33a69d95c37b1ec340e276c7b16f758ea4&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_group0/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeB_group0/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeB_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:33.659226Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeB_group0/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeB_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 1,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 3,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 7,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 8,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 12,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 25,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 33,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 41,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 44,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 52,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 56,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 57,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 61,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 69,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 70,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 72,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 75,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 76,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 78,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 90,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 91,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            1,
+                            3,
+                            7,
+                            8,
+                            12,
+                            25,
+                            33,
+                            41,
+                            44,
+                            52,
+                            56,
+                            57,
+                            61,
+                            69,
+                            70,
+                            72,
+                            75,
+                            76,
+                            78,
+                            90,
+                            91
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:13:33.659226Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group0.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group0"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T08:13:33.659226Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeB_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:59:17.437177Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:b73bf13856760d63a391c624820707463b0352e9&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_group1&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeB_group1/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeB_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:17.437177Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeB_group1/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeB_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:17.437177Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeB_group1/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeB_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:48.020791Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeB_group1/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeB_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:27.673039Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeB_group1/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeB_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:27.674339Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:49cc9ee71ebaf74a2bb1851de9718c79edc8742f&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_group1/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeB_group1/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeB_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:27.674339Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeB_group1/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeB_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 0,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 1,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 5,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 9,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 13,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 17,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 31,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 33,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 34,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 35,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 36,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 38,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 41,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 42,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 43,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 47,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 52,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 63,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 66,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 71,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 74,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 76,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 77,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 80,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 83,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 87,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            0,
+                            1,
+                            5,
+                            9,
+                            13,
+                            17,
+                            31,
+                            33,
+                            34,
+                            35,
+                            36,
+                            38,
+                            41,
+                            42,
+                            43,
+                            47,
+                            52,
+                            63,
+                            66,
+                            71,
+                            74,
+                            76,
+                            77,
+                            80,
+                            83,
+                            87
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:13:27.674339Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group1"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T08:13:27.674339Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeB_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:59:21.014754Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:984af8aa7ae31d1b7705ee8e5878e1ca70238911&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_group2&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeB_group2/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeB_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:21.014754Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeB_group2/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeB_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:21.014754Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeB_group2/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeB_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:52.311440Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeB_group2/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeB_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:31.392066Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeB_group2/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeB_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:31.393380Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:94b5299ace55db29c02d5f18b5503caca07c7d54&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_group2/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeB_group2/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeB_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:31.393380Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeB_group2/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeB_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 0,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 5,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 7,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 13,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 16,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 17,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 22,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 31,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 34,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 44,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 46,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 49,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 50,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 54,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 56,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 58,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 61,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 63,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 68,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 69,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 75,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 80,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 85,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 91,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 93,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 96,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 97,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 99,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 100,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 101,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            0,
+                            5,
+                            7,
+                            13,
+                            16,
+                            17,
+                            22,
+                            31,
+                            34,
+                            44,
+                            46,
+                            49,
+                            50,
+                            54,
+                            56,
+                            58,
+                            61,
+                            63,
+                            68,
+                            69,
+                            75,
+                            80,
+                            85,
+                            91,
+                            93,
+                            96,
+                            97,
+                            99,
+                            100,
+                            101
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            95,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            104,
+                            105
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:13:31.393380Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group2.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group2"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T08:13:31.393380Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeB_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:01:40.148507Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:a07b166ff12c4bbc8df5c6969343e64f32cafa1f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_group3&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeB_group3/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeB_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:40.148507Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeB_group3/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeB_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:40.148507Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeB_group3/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeB_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:02:15.478936Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeB_group3/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeB_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:05:51.054239Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeB_group3/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeB_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:05:51.055385Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:7a2ba39e6aae1368b4d47e8dbd3baaefcae04488&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeB_group3/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeB_group3/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeB_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:05:51.055385Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeB_group3/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeB_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 0,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 1,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 3,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 4,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 5,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 6,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 7,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 8,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 9,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 11,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 12,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 13,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 14,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 18,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 24,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 30,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 31,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 35,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 36,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 41,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 44,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 45,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 48,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 54,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 56,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 58,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 60,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 62,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 67,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 68,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 72,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 73,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 76,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 79,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 80,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 82,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 84,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 86,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 90,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 91,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 93,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 97,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 105,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 106,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 107,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 113,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 114,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 117,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            0,
+                            1,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            11,
+                            12,
+                            13,
+                            14,
+                            18,
+                            24,
+                            30,
+                            31,
+                            35,
+                            36,
+                            41,
+                            44,
+                            45,
+                            48,
+                            54,
+                            56,
+                            58,
+                            60,
+                            62,
+                            67,
+                            68,
+                            72,
+                            73,
+                            76,
+                            79,
+                            80,
+                            82,
+                            84,
+                            86,
+                            90,
+                            91,
+                            93,
+                            97,
+                            105,
+                            106,
+                            107,
+                            113,
+                            114,
+                            117
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            24,
+                            25,
+                            27,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            95,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            105,
+                            106,
+                            107,
+                            108,
+                            110,
+                            112,
+                            113,
+                            114,
+                            115,
+                            116,
+                            117,
+                            118
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:05:51.055385Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB_recording1_group3.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeB.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeB_group3"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T08:05:51.055385Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeC_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:59:23.961351Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:58b98ad3849d59f48284c4532d78c75cf9221115&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_group0&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeC_group0/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeC_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:23.961351Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeC_group0/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeC_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:23.961351Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeC_group0/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeC_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:50.407201Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeC_group0/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeC_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:21.870994Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeC_group0/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeC_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:21.872686Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:ff760f08e05242ae6d6d2d8e10770723d0e4099f&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeC_group0/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_group0%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeC_group0/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeC_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:21.872686Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeC_group0/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group0"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeC_group0",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 3,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 4,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 5,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 12,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 16,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 19,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 27,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 29,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 39,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 42,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 50,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 60,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 63,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 73,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 80,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 84,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 86,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 97,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 101,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 103,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 105,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            3,
+                            4,
+                            5,
+                            12,
+                            16,
+                            19,
+                            27,
+                            29,
+                            39,
+                            42,
+                            50,
+                            60,
+                            63,
+                            73,
+                            80,
+                            84,
+                            86,
+                            97,
+                            101,
+                            103,
+                            105
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            95,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            104,
+                            105,
+                            106,
+                            107,
+                            108,
+                            109,
+                            110,
+                            111,
+                            112,
+                            113,
+                            114,
+                            115,
+                            116,
+                            117,
+                            118,
+                            119,
+                            120,
+                            121
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:13:21.872686Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group0.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group0"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T08:13:21.872686Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeC_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:59:23.941241Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:93cb4f2a09007d7f6b49d7e132e6cf7570048747&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_group1&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeC_group1/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeC_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:23.941241Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeC_group1/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeC_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:23.941241Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeC_group1/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeC_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:59:50.835156Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeC_group1/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeC_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:17.500834Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeC_group1/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeC_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:17.502734Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9fbed15efcf023735992993200bea12d9b005096&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeC_group1/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_group1%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeC_group1/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeC_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:13:17.502734Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeC_group1/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group1"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeC_group1",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 4,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 6,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 19,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 24,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 49,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 54,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 57,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 58,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 62,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 72,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 83,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 85,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 87,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 103,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 110,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 130,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 137,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 142,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 143,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 145,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 148,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            4,
+                            6,
+                            19,
+                            24,
+                            49,
+                            54,
+                            57,
+                            58,
+                            62,
+                            72,
+                            83,
+                            85,
+                            87,
+                            103,
+                            110,
+                            130,
+                            137,
+                            142,
+                            143,
+                            145,
+                            148
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            105,
+                            106,
+                            107,
+                            108,
+                            109,
+                            110,
+                            111,
+                            112,
+                            113,
+                            114,
+                            115,
+                            116,
+                            117,
+                            118,
+                            119,
+                            120,
+                            121,
+                            122,
+                            123,
+                            124,
+                            125,
+                            126,
+                            127,
+                            128,
+                            129,
+                            130,
+                            131,
+                            132,
+                            133,
+                            134,
+                            135,
+                            136,
+                            137,
+                            138,
+                            139,
+                            140,
+                            141,
+                            142,
+                            143,
+                            144,
+                            145,
+                            146,
+                            147,
+                            148,
+                            149
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:13:17.502734Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group1.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group1"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T08:13:17.502734Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeC_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:50:30.991332Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3ede1d6bc9efbb5f05bfcf9a5014b6f41e4d4ac7&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_group2&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeC_group2/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeC_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:30.991332Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeC_group2/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeC_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:30.991332Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeC_group2/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeC_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:55.922618Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeC_group2/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeC_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:01.729128Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeC_group2/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeC_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:01.732078Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8c7b5ae7e705473e601203fbba06d8f9ef4cbe91&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeC_group2/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_group2%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeC_group2/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeC_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:01.732078Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeC_group2/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group2"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeC_group2",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 0,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 2,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 4,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 7,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 12,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 14,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 17,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 19,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 23,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 26,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 27,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 32,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 38,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 40,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 46,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 48,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 53,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 56,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 59,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 68,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 73,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 78,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 85,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 103,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 119,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            0,
+                            2,
+                            4,
+                            7,
+                            12,
+                            14,
+                            17,
+                            19,
+                            23,
+                            26,
+                            27,
+                            32,
+                            38,
+                            40,
+                            46,
+                            48,
+                            53,
+                            56,
+                            59,
+                            68,
+                            73,
+                            78,
+                            85,
+                            103,
+                            119
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86,
+                            87,
+                            88,
+                            89,
+                            90,
+                            91,
+                            92,
+                            93,
+                            94,
+                            95,
+                            96,
+                            97,
+                            98,
+                            99,
+                            100,
+                            101,
+                            102,
+                            103,
+                            104,
+                            105,
+                            106,
+                            107,
+                            108,
+                            109,
+                            110,
+                            111,
+                            112,
+                            113,
+                            114,
+                            115,
+                            116,
+                            117,
+                            118,
+                            119,
+                            120,
+                            121,
+                            122,
+                            123,
+                            124
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:01.732078Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group2.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group2"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T07:54:01.732078Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment1_ProbeC_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:50:55.692846Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:618cbd4912014bba13a47b89e51d126d6824addc&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_group3&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeC_group3/traces_raw.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment1_ProbeC_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:55.692846Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment1_ProbeC_group3/psd.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment1_ProbeC_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:55.692846Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment1_ProbeC_group3/rms.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment1_ProbeC_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:51:28.655165Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment1_ProbeC_group3/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Probe Drift - experiment1_ProbeC_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "High drift",
+                        "Bad drift estimation"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:56:01.439604Z"
+                    }
+                ],
+                "description": "This metric shows a rastermap of the recording with overlaid estimated motion. Use this metric to spot high drifts or bad drift estimation.",
+                "reference": "quality_control/experiment1_ProbeC_group3/drift_map.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Unit Metrics Yield - experiment1_ProbeC_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Low Yield",
+                        "High Noise"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:56:01.440706Z"
+                    }
+                ],
+                "description": "This metric displays a summary of spike sorted units, including distributions of key features and number of units with different labels. Use this metric to report a low yield of units or a disproportionate high number of bad units with respect to good units. The sorting summary can also be viewed in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:76ef0613f3af380188c85686e640e3c23cb9d05c&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_834198_2026-02-26_15-05-56/experiment1_Record Node 101%23Neuropix-PXI-100.ProbeC_group3/kilosort4/curation.json%22}&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_group3%20-%20kilosort4%20-%20Sorting%20Summary&zone=aind)",
+                "reference": "quality_control/experiment1_ProbeC_group3/unit_yield.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Firing rate - experiment1_ProbeC_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "No problems detected",
+                        "Seizure",
+                        "Firing Rate Gap"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:56:01.440706Z"
+                    }
+                ],
+                "description": "This metric shows the population firing rate across the entire recording. Use this metric to spot abnormal seizure-like activity or firing rate gaps, which could result from hardware failures diring acquisition.",
+                "reference": "quality_control/experiment1_ProbeC_group3/firing_rate.png",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group3"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "Curation metric",
+                "name": "Sorting Curation - experiment1_ProbeC_group3",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Processing",
+                "value": [
+                    {
+                        "format_version": "2",
+                        "label_definitions": {
+                            "quality": {
+                                "label_options": [
+                                    "good",
+                                    "MUA",
+                                    "noise"
+                                ],
+                                "exclusive": true
+                            }
+                        },
+                        "manual_labels": [
+                            {
+                                "unit_id": 0,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 1,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 7,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 8,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 9,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 10,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 11,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 14,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 18,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 20,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 25,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 29,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 34,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 40,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 43,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 44,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 47,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 52,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 54,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 61,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 62,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 63,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 64,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 71,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 73,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 78,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 81,
+                                "quality": [
+                                    "noise"
+                                ]
+                            },
+                            {
+                                "unit_id": 85,
+                                "quality": [
+                                    "noise"
+                                ]
+                            }
+                        ],
+                        "removed": [
+                            0,
+                            1,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            14,
+                            18,
+                            20,
+                            25,
+                            29,
+                            34,
+                            40,
+                            43,
+                            44,
+                            47,
+                            52,
+                            54,
+                            61,
+                            62,
+                            63,
+                            64,
+                            71,
+                            73,
+                            78,
+                            81,
+                            85
+                        ],
+                        "merges": [],
+                        "splits": [],
+                        "unit_ids": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4,
+                            5,
+                            6,
+                            7,
+                            8,
+                            9,
+                            10,
+                            11,
+                            12,
+                            13,
+                            14,
+                            15,
+                            16,
+                            17,
+                            18,
+                            19,
+                            20,
+                            21,
+                            22,
+                            23,
+                            24,
+                            25,
+                            26,
+                            27,
+                            28,
+                            29,
+                            30,
+                            31,
+                            32,
+                            33,
+                            34,
+                            35,
+                            36,
+                            37,
+                            38,
+                            39,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            45,
+                            46,
+                            47,
+                            48,
+                            49,
+                            50,
+                            51,
+                            52,
+                            53,
+                            54,
+                            55,
+                            56,
+                            57,
+                            58,
+                            59,
+                            60,
+                            61,
+                            62,
+                            63,
+                            64,
+                            65,
+                            66,
+                            67,
+                            68,
+                            69,
+                            70,
+                            71,
+                            72,
+                            73,
+                            74,
+                            75,
+                            76,
+                            77,
+                            78,
+                            79,
+                            80,
+                            81,
+                            82,
+                            83,
+                            84,
+                            85,
+                            86
+                        ]
+                    }
+                ],
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:56:01.440706Z"
+                    }
+                ],
+                "description": "This metric renders the SpikeInterface GUI through the AIND ephys portal. You can use the GUI to curate spike sorting results (label, remove, merge, split). Use the 'Submit to parent' button to submit the curation data to the QC Portal.",
+                "reference": "https%3A//ephys.allenneuraldynamics.org/ephys_gui_app%3Fanalyzer_path%3D%7Bderived_asset_location%7D/postprocessed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC_recording1_group3.zarr%26recording_path%3D%7Braw_asset_location%7D/ecephys/ecephys_compressed/experiment1_Record%20Node%20101%23Neuropix-PXI-100.ProbeC.zarr",
+                "tags": {
+                    "probe": "experiment1_ProbeC_group3"
+                },
+                "evaluated_assets": null,
+                "type": "Spike sorting curation",
+                "curation_history": [
+                    {
+                        "object_type": "Curation history",
+                        "curator": "Ephys pipeline",
+                        "timestamp": "2026-02-28T07:56:01.440706Z"
+                    }
+                ]
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment2_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:50:17.872678Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:2fb473fd770fd8b1e3c39c0c46687d859bed4392&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeA&zone=aind)",
+                "reference": "quality_control/experiment2_ProbeA/traces_raw.png",
+                "tags": {
+                    "probe": "experiment2_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment2_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:17.872678Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment2_ProbeA/psd.png",
+                "tags": {
+                    "probe": "experiment2_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment2_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:17.872678Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment2_ProbeA/rms.png",
+                "tags": {
+                    "probe": "experiment2_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment2_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:35.559632Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment2_ProbeA/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment2_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment2_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:01.592631Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:7dc69fcf0833755641a32b675e208f9f4de2e69e&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeB&zone=aind)",
+                "reference": "quality_control/experiment2_ProbeB/traces_raw.png",
+                "tags": {
+                    "probe": "experiment2_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment2_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:01.592631Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment2_ProbeB/psd.png",
+                "tags": {
+                    "probe": "experiment2_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment2_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:01.592631Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment2_ProbeB/rms.png",
+                "tags": {
+                    "probe": "experiment2_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment2_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:28.664480Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment2_ProbeB/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment2_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment2_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:53:48.261656Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:3c81c29c6fa36dbeaee67a092ccf7cf141ac5852&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment2_Record%20Node%20101%23Neuropix-PXI-100.ProbeC&zone=aind)",
+                "reference": "quality_control/experiment2_ProbeC/traces_raw.png",
+                "tags": {
+                    "probe": "experiment2_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment2_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:53:48.261656Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment2_ProbeC/psd.png",
+                "tags": {
+                    "probe": "experiment2_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment2_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:53:48.261656Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment2_ProbeC/rms.png",
+                "tags": {
+                    "probe": "experiment2_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment2_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:13.815640Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment2_ProbeC/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment2_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment3_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:53:06.007682Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:628cbdbe4f1b68655fbfa52a42a1aea99588fcec&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeA&zone=aind)",
+                "reference": "quality_control/experiment3_ProbeA/traces_raw.png",
+                "tags": {
+                    "probe": "experiment3_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment3_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:53:06.007682Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment3_ProbeA/psd.png",
+                "tags": {
+                    "probe": "experiment3_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment3_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:53:06.007682Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment3_ProbeA/rms.png",
+                "tags": {
+                    "probe": "experiment3_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment3_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:53:47.106849Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment3_ProbeA/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment3_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment3_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:05.599029Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8a2bf933c00aab42a73fda7dbe78de1718b47228&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeB&zone=aind)",
+                "reference": "quality_control/experiment3_ProbeB/traces_raw.png",
+                "tags": {
+                    "probe": "experiment3_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment3_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:05.599029Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment3_ProbeB/psd.png",
+                "tags": {
+                    "probe": "experiment3_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment3_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:05.599029Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment3_ProbeB/rms.png",
+                "tags": {
+                    "probe": "experiment3_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment3_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:33.813804Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment3_ProbeB/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment3_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment3_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:08.522230Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9aaead9f76137b5e55151a1d554597d04498f65d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment3_Record%20Node%20101%23Neuropix-PXI-100.ProbeC&zone=aind)",
+                "reference": "quality_control/experiment3_ProbeC/traces_raw.png",
+                "tags": {
+                    "probe": "experiment3_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment3_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:08.522230Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment3_ProbeC/psd.png",
+                "tags": {
+                    "probe": "experiment3_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment3_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:54:08.522230Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment3_ProbeC/rms.png",
+                "tags": {
+                    "probe": "experiment3_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment3_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:54:36.142347Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment3_ProbeC/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment3_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment4_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:53:27.334766Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:ec64a3ff9e6e43d169fd8db122cf2d84239dc589&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeA&zone=aind)",
+                "reference": "quality_control/experiment4_ProbeA/traces_raw.png",
+                "tags": {
+                    "probe": "experiment4_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment4_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:53:27.334766Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment4_ProbeA/psd.png",
+                "tags": {
+                    "probe": "experiment4_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment4_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:53:27.334766Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment4_ProbeA/rms.png",
+                "tags": {
+                    "probe": "experiment4_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment4_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:53:50.729198Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment4_ProbeA/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment4_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment4_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:50:18.718778Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:f78e25474c8f1228566d0b1e7cd4322324ef659f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeB&zone=aind)",
+                "reference": "quality_control/experiment4_ProbeB/traces_raw.png",
+                "tags": {
+                    "probe": "experiment4_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment4_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:18.718778Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment4_ProbeB/psd.png",
+                "tags": {
+                    "probe": "experiment4_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment4_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:18.718778Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment4_ProbeB/rms.png",
+                "tags": {
+                    "probe": "experiment4_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment4_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:42.290458Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment4_ProbeB/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment4_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment4_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:50:51.852168Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:8c8e19473f8f73803acf96cb3d6bfab5477849b8&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment4_Record%20Node%20101%23Neuropix-PXI-100.ProbeC&zone=aind)",
+                "reference": "quality_control/experiment4_ProbeC/traces_raw.png",
+                "tags": {
+                    "probe": "experiment4_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment4_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:51.852168Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment4_ProbeC/psd.png",
+                "tags": {
+                    "probe": "experiment4_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment4_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:51.852168Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment4_ProbeC/rms.png",
+                "tags": {
+                    "probe": "experiment4_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment4_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:51:08.765992Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment4_ProbeC/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment4_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment5_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:51:00.086745Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:883b86035ec4cebbcdafb7ae384d455f295e8956&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeA&zone=aind)",
+                "reference": "quality_control/experiment5_ProbeA/traces_raw.png",
+                "tags": {
+                    "probe": "experiment5_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment5_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:51:00.086745Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment5_ProbeA/psd.png",
+                "tags": {
+                    "probe": "experiment5_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment5_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:51:00.086745Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment5_ProbeA/rms.png",
+                "tags": {
+                    "probe": "experiment5_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment5_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:51:18.596421Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment5_ProbeA/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment5_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment5_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T07:50:54.105927Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:085faaddcd20d9a5ae82409cd545543172527389&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeB&zone=aind)",
+                "reference": "quality_control/experiment5_ProbeB/traces_raw.png",
+                "tags": {
+                    "probe": "experiment5_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment5_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:54.105927Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment5_ProbeB/psd.png",
+                "tags": {
+                    "probe": "experiment5_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment5_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:50:54.105927Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment5_ProbeB/rms.png",
+                "tags": {
+                    "probe": "experiment5_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment5_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T07:51:11.573919Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment5_ProbeB/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment5_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment5_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:01:38.977779Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9b91d84782cfe1875dfa4ca19c6bed0cca5b4b04&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment5_Record%20Node%20101%23Neuropix-PXI-100.ProbeC&zone=aind)",
+                "reference": "quality_control/experiment5_ProbeC/traces_raw.png",
+                "tags": {
+                    "probe": "experiment5_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment5_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:38.977779Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment5_ProbeC/psd.png",
+                "tags": {
+                    "probe": "experiment5_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment5_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:38.977779Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment5_ProbeC/rms.png",
+                "tags": {
+                    "probe": "experiment5_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment5_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:02:07.415628Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment5_ProbeC/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment5_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment6_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:01:39.255439Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:9b570bac1d82f1069a60d798c437f0e108d3d0b8&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeA&zone=aind)",
+                "reference": "quality_control/experiment6_ProbeA/traces_raw.png",
+                "tags": {
+                    "probe": "experiment6_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment6_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:39.255439Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment6_ProbeA/psd.png",
+                "tags": {
+                    "probe": "experiment6_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment6_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:39.255439Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment6_ProbeA/rms.png",
+                "tags": {
+                    "probe": "experiment6_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment6_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:02:07.073957Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment6_ProbeA/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment6_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment6_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:01:34.371284Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:32db6e0e8ccad39af443269d959741d4bd73179d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeB&zone=aind)",
+                "reference": "quality_control/experiment6_ProbeB/traces_raw.png",
+                "tags": {
+                    "probe": "experiment6_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment6_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:34.371284Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment6_ProbeB/psd.png",
+                "tags": {
+                    "probe": "experiment6_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment6_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:34.371284Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment6_ProbeB/rms.png",
+                "tags": {
+                    "probe": "experiment6_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment6_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:02:02.655931Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment6_ProbeB/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment6_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment6_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:01:34.113878Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:e86c45e754a25279230080f9ff250662ce065e8d&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment6_Record%20Node%20101%23Neuropix-PXI-100.ProbeC&zone=aind)",
+                "reference": "quality_control/experiment6_ProbeC/traces_raw.png",
+                "tags": {
+                    "probe": "experiment6_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment6_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:34.113878Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment6_ProbeC/psd.png",
+                "tags": {
+                    "probe": "experiment6_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment6_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:34.113878Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment6_ProbeC/rms.png",
+                "tags": {
+                    "probe": "experiment6_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment6_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:02:03.157902Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment6_ProbeC/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment6_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment7_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:01:34.212053Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:83d168fcd176e3aabc870d09c4e4c1a2d60e94fe&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeA&zone=aind)",
+                "reference": "quality_control/experiment7_ProbeA/traces_raw.png",
+                "tags": {
+                    "probe": "experiment7_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment7_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:34.212053Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment7_ProbeA/psd.png",
+                "tags": {
+                    "probe": "experiment7_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment7_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:34.212053Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment7_ProbeA/rms.png",
+                "tags": {
+                    "probe": "experiment7_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment7_ProbeA",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:02:02.687013Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment7_ProbeA/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment7_ProbeA"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment7_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:01:35.551246Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:40609168baa3d3b345f521006d165319dca95447&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeB&zone=aind)",
+                "reference": "quality_control/experiment7_ProbeB/traces_raw.png",
+                "tags": {
+                    "probe": "experiment7_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment7_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:35.551246Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment7_ProbeB/psd.png",
+                "tags": {
+                    "probe": "experiment7_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment7_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:35.551246Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment7_ProbeB/rms.png",
+                "tags": {
+                    "probe": "experiment7_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment7_ProbeB",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "Pass"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:02:03.180870Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment7_ProbeB/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment7_ProbeB"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Raw data experiment7_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Normal",
+                        "No spikes",
+                        "Noisy"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:01:37.276676Z"
+                    }
+                ],
+                "description": "This metric displays raw data snippets for both for AP and LFP streams. Check out the snippets for abnormal noise or lack of spikes.Raw data can also be visualized in [Sortingview](https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=kachery:aind:sha1:40686b4fd98d0d2323fcce312319f81681f2472f&label=ecephys_834198_2026-02-26_15-05-56%20-%20experiment7_Record%20Node%20101%23Neuropix-PXI-100.ProbeC&zone=aind)",
+                "reference": "quality_control/experiment7_ProbeC/traces_raw.png",
+                "tags": {
+                    "probe": "experiment7_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "PSD experiment7_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": null,
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:37.276676Z"
+                    }
+                ],
+                "description": "This metric displays the power spectral density (PSD) of raw data. PDSs are computed by channel and shown as lines or map (by channel depth). Use the plots to spot contamination from high-frequency or line noise sources.",
+                "reference": "quality_control/experiment7_ProbeC/psd.png",
+                "tags": {
+                    "probe": "experiment7_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "RMS experiment7_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "No out channels detected"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pass",
+                        "timestamp": "2026-02-28T08:01:37.276676Z"
+                    }
+                ],
+                "description": "This metric shows the noise levels (RMS) by depth for each channel, computed from the raw and preprocessed data. It also includes a summary of channel labels (after bad channel detection). Use this metric to check if out-of-brain channels are visible (lower RMS values at the top of the probe), but not labeled as 'out'.",
+                "reference": "quality_control/experiment7_ProbeC/rms.png",
+                "tags": {
+                    "probe": "experiment7_ProbeC"
+                },
+                "evaluated_assets": null
+            },
+            {
+                "object_type": "QC metric",
+                "name": "Saturation events timeline experiment7_ProbeC",
+                "modality": {
+                    "name": "Extracellular electrophysiology",
+                    "abbreviation": "ecephys"
+                },
+                "stage": "Raw data",
+                "value": {
+                    "value": "",
+                    "options": [
+                        "Good",
+                        "Too many saturation events"
+                    ],
+                    "status": [
+                        "Pass",
+                        "Fail"
+                    ],
+                    "type": "dropdown"
+                },
+                "status_history": [
+                    {
+                        "object_type": "QC status",
+                        "evaluator": "",
+                        "status": "Pending",
+                        "timestamp": "2026-02-28T08:02:05.120347Z"
+                    }
+                ],
+                "description": "This metric shows a scatter plot of saturation events, with red and blue markers for positive and negative events, respectively. Use this metric to spot an abnormal number of saturation events.",
+                "reference": "quality_control/experiment7_ProbeC/saturation_timeline.png",
+                "tags": {
+                    "probe": "experiment7_ProbeC"
+                },
+                "evaluated_assets": null
+            }
+        ],
+        "key_experimenters": null,
+        "notes": null,
+        "default_grouping": [
+            "probe",
+            "stage"
+        ],
+        "allow_tag_failures": [
+            "experiment2_ProbeA",
+            "experiment2_ProbeB",
+            "experiment2_ProbeC",
+            "experiment3_ProbeA",
+            "experiment3_ProbeB",
+            "experiment3_ProbeC",
+            "experiment4_ProbeA",
+            "experiment4_ProbeB",
+            "experiment4_ProbeC",
+            "experiment5_ProbeA",
+            "experiment5_ProbeB",
+            "experiment5_ProbeC",
+            "experiment6_ProbeA",
+            "experiment6_ProbeB",
+            "experiment6_ProbeC",
+            "experiment7_ProbeA",
+            "experiment7_ProbeB",
+            "experiment7_ProbeC"
+        ],
+        "status": {
+            "probe:experiment7_ProbeC": "Pending",
+            "probe:experiment1_ProbeA_group0": "Pending",
+            "probe:experiment1_ProbeB_group2": "Pending",
+            "probe:experiment1_ProbeC_group3": "Pending",
+            "probe:experiment6_ProbeA": "Pending",
+            "probe:experiment5_ProbeB": "Pending",
+            "probe:experiment6_ProbeC": "Pending",
+            "probe:experiment2_ProbeC": "Pending",
+            "probe:experiment7_ProbeA": "Pending",
+            "probe:experiment3_ProbeC": "Pending",
+            "probe:experiment1_ProbeB_group1": "Pending",
+            "probe:experiment2_ProbeA": "Pending",
+            "probe:experiment4_ProbeC": "Pending",
+            "probe:experiment3_ProbeB": "Pending",
+            "probe:experiment2_ProbeB": "Pending",
+            "probe:experiment5_ProbeC": "Pending",
+            "probe:experiment3_ProbeA": "Pending",
+            "probe:experiment1_ProbeC_group1": "Pending",
+            "probe:experiment1_ProbeA_group3": "Pending",
+            "probe:experiment7_ProbeB": "Pending",
+            "probe:experiment4_ProbeA": "Pending",
+            "probe:experiment1_ProbeC_group2": "Pending",
+            "probe:experiment6_ProbeB": "Pending",
+            "probe:experiment1_ProbeB_group3": "Pending",
+            "probe:experiment1_ProbeA_group2": "Pending",
+            "probe:experiment5_ProbeA": "Pending",
+            "probe:experiment1_ProbeA_group1": "Pending",
+            "probe:experiment4_ProbeB": "Pending",
+            "probe:experiment1_ProbeC_group0": "Pending",
+            "probe:experiment1_ProbeB_group0": "Pending",
+            "ecephys": "Pending",
+            "Processing": "Pending",
+            "Raw data": "Pending"
+        }
+    }
+}


### PR DESCRIPTION
Adds code to upgrade a laser power calibration that I missed. Includes a test record that has one of these in it.