### PR TITLE
fix: support multiple detectors mapping to multiple channels

### DIFF
--- a/src/aind_metadata_upgrader/session/v1v2.py
+++ b/src/aind_metadata_upgrader/session/v1v2.py
@@ -465,37 +465,72 @@ class SessionV1V2(CoreUpgrader):
         else:
             return [], []
 
+    def _get_emission_wavelengths_from_rig_filters(self) -> Dict:
+        """Build a color->wavelength map from rig band-pass filters, falling back to None if not found."""
+        wavelengths = {"green": None, "red": None}
+        for f in getattr(self, "_rig_filters", []):
+            if f.get("filter_type", "").lower() != "band pass":
+                continue
+            name_lower = f.get("name", "").lower()
+            center = f.get("center_wavelength")
+            if center is None:
+                continue
+            if "green" in name_lower:
+                wavelengths["green"] = center
+            elif "red" in name_lower:
+                wavelengths["red"] = center
+        return wavelengths
+
     def _create_ophys_fov_components(self, stream: Dict, light_sources: List, detectors: List) -> tuple:
         """Create channels and PlanarImage objects from ophys_fovs"""
         channels = []
         images = []
 
-        if len(detectors) > 1:
-            raise ValueError("Multiple detectors are not yet supported in ophys upgrade")
+        if len(detectors) > 2:
+            raise ValueError("More than two detectors are not supported in ophys upgrade")
 
-        channel = Channel(
-            channel_name="Ophys Channel",
-            detector=(
-                self._upgrade_detector_config(detectors[0])
-                if detectors
-                else DetectorConfig(
-                    device_name="Unknown Detector",
-                    exposure_time=1.0,
-                    exposure_time_unit=TimeUnit.MS,
-                    trigger_type=TriggerType.INTERNAL,
+        if len(detectors) == 2:
+            green_detectors = [d for d in detectors if "green" in d.get("name", "").lower()]
+            red_detectors = [d for d in detectors if "red" in d.get("name", "").lower()]
+            if len(green_detectors) != 1 or len(red_detectors) != 1:
+                raise ValueError(
+                    "When two detectors are present, expected exactly one green and one red detector, "
+                    f"got: {[d.get('name') for d in detectors]}"
                 )
-            ),
-            light_sources=[self._upgrade_light_source_config(ls) for ls in light_sources],
-        ).model_dump()
-        channels.append(channel)
-
-        for i, fov in enumerate(stream.get("ophys_fovs", [])):
-            # Create plane and image
-            plane = self._upgrade_ophys_fov_to_plane(fov)
-            image = PlanarImage(
-                planes=[plane], image_to_acquisition_transform=[], channel_name=channel["channel_name"]
+            color_wavelengths = self._get_emission_wavelengths_from_rig_filters()
+            for color, det in [("green", green_detectors[0]), ("red", red_detectors[0])]:
+                channel = Channel(
+                    channel_name=f"{color.capitalize()} Channel",
+                    detector=self._upgrade_detector_config(det),
+                    light_sources=[self._upgrade_light_source_config(ls) for ls in light_sources],
+                    emission_wavelength=color_wavelengths[color],
+                    emission_wavelength_unit=SizeUnit.NM if color_wavelengths[color] is not None else None,
+                ).model_dump()
+                channels.append(channel)
+        else:
+            channel = Channel(
+                channel_name="Ophys Channel",
+                detector=(
+                    self._upgrade_detector_config(detectors[0])
+                    if detectors
+                    else DetectorConfig(
+                        device_name="Unknown Detector",
+                        exposure_time=1.0,
+                        exposure_time_unit=TimeUnit.MS,
+                        trigger_type=TriggerType.INTERNAL,
+                    )
+                ),
+                light_sources=[self._upgrade_light_source_config(ls) for ls in light_sources],
             ).model_dump()
-            images.append(image)
+            channels.append(channel)
+
+        for fov in stream.get("ophys_fovs", []):
+            plane = self._upgrade_ophys_fov_to_plane(fov)
+            for channel in channels:
+                image = PlanarImage(
+                    planes=[plane], image_to_acquisition_transform=[], channel_name=channel["channel_name"]
+                ).model_dump()
+                images.append(image)
 
         return channels, images
 
@@ -940,6 +975,13 @@ class SessionV1V2(CoreUpgrader):
         mouse_platform_name = session_data.get("mouse_platform_name") or "unknown"
         reward_consumed_total = session_data.get("reward_consumed_total")
         reward_consumed_unit = session_data.get("reward_consumed_unit", "milliliter")
+
+        # Store rig filters for emission wavelength lookup during stream upgrade
+        self._rig_filters = []
+        if metadata and isinstance(metadata, dict):
+            rig = metadata.get("rig", {})
+            if isinstance(rig, dict):
+                self._rig_filters = rig.get("filters", []) or []
 
         # Upgrade experimenter names to Person objects
         experimenters = self._upgrade_experimenter_names(experimenter_full_name)

--- a/tests/records/v1/17e48fd5-9424-4a5d-a184-29f1b1e5696e.json
+++ b/tests/records/v1/17e48fd5-9424-4a5d-a184-29f1b1e5696e.json
@@ -1,0 +1,1779 @@
+{
+    "_id": "17e48fd5-9424-4a5d-a184-29f1b1e5696e",
+    "acquisition": null,
+    "created": "2025-06-23T22:36:51.612641",
+    "data_description": {
+        "creation_time": "2025-06-23T09:24:00-07:00",
+        "data_level": "raw",
+        "data_summary": null,
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "funding_source": [
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "AI",
+                    "name": "Allen Institute",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null
+            }
+        ],
+        "group": null,
+        "institution": {
+            "abbreviation": "AIND",
+            "name": "Allen Institute for Neural Dynamics",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "investigators": [
+            {
+                "abbreviation": null,
+                "name": "Kayvon Daie",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Marton Rozsa",
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "label": null,
+        "license": "CC-BY-4.0",
+        "modality": [
+            {
+                "abbreviation": "pophys",
+                "name": "Planar optical physiology"
+            },
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            }
+        ],
+        "name": "single-plane-ophys_776628_2025-06-23_09-24-00",
+        "platform": {
+            "abbreviation": "single-plane-ophys",
+            "name": "Single-plane optical physiology platform"
+        },
+        "project_name": "Brain Computer Interface",
+        "related_data": [],
+        "restrictions": null,
+        "schema_version": "1.0.3",
+        "subject_id": "776628"
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "eea6acc9-766b-4b8f-b949-dab79dd4bfe2"
+        ]
+    },
+    "instrument": null,
+    "last_modified": "2025-07-31T02:44:23.671Z",
+    "location": "s3://aind-private-data-prod-o5171v/single-plane-ophys_776628_2025-06-23_09-24-00",
+    "metadata_status": "Missing",
+    "name": "single-plane-ophys_776628_2025-06-23_09-24-00",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.1.3",
+        "specimen_procedures": [],
+        "subject_id": "776628",
+        "subject_procedures": [
+            {
+                "anaesthesia": {
+                    "duration": null,
+                    "duration_unit": "minute",
+                    "level": null,
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": null,
+                "animal_weight_prior": null,
+                "experimenter_full_name": "NSB",
+                "iacuc_protocol": null,
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "craniotomy_hemisphere": null,
+                        "craniotomy_type": "3 mm",
+                        "dura_removed": null,
+                        "implant_part_number": "3mm stacked coverslip",
+                        "procedure_type": "Craniotomy",
+                        "protective_material": null,
+                        "recovery_time": null,
+                        "recovery_time_unit": "minute"
+                    },
+                    {
+                        "headframe_material": null,
+                        "headframe_part_number": "0160-100-51",
+                        "headframe_type": "Motor Ctx",
+                        "procedure_type": "Headframe",
+                        "well_part_number": null,
+                        "well_type": "Motor Ctx SLAP2 well"
+                    },
+                    {
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": null,
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": null,
+                        "injection_coordinate_depth": [
+                            "0.4"
+                        ],
+                        "injection_coordinate_ml": null,
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Left",
+                        "injection_materials": [],
+                        "injection_volume": [
+                            "100.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "instrument_id": null,
+                        "procedure_type": "Nanoject injection",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4",
+                        "recovery_time": null,
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    },
+                    {
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": null,
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": null,
+                        "injection_coordinate_depth": [
+                            "0.4"
+                        ],
+                        "injection_coordinate_ml": null,
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Left",
+                        "injection_materials": [],
+                        "injection_volume": [
+                            "50.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "instrument_id": null,
+                        "procedure_type": "Nanoject injection",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4",
+                        "recovery_time": null,
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    }
+                ],
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2",
+                "start_date": "2025-01-28",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 8"
+            },
+            {
+                "baseline_weight": "31.4",
+                "end_date": null,
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "procedure_type": "Water restriction",
+                "start_date": "2025-03-13",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "weight_unit": "gram"
+            }
+        ]
+    },
+    "processing": {
+        "analyses": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "notes": null,
+        "processing_pipeline": {
+            "data_processes": [],
+            "note": null,
+            "pipeline_url": null,
+            "pipeline_version": null,
+            "processor_full_name": "AIND Scientific Computing"
+        },
+        "schema_version": "1.1.3"
+    },
+    "quality_control": null,
+    "rig": {
+        "additional_devices": [],
+        "calibrations": [
+            {
+                "calibration_date": "2022-01-04T00:00:00Z",
+                "description": "Laser Power Calibration",
+                "device_name": "Monaco Laser",
+                "input": {
+                    "power_setting": []
+                },
+                "notes": "Calibration of the laser power output at different settings",
+                "output": {
+                    "power_output": []
+                }
+            },
+            {
+                "calibration_date": "2022-01-04T00:00:00Z",
+                "description": "Laser Power Calibration",
+                "device_name": "Chameleon Laser",
+                "input": {
+                    "power_setting": [
+                        0,
+                        5,
+                        10,
+                        15,
+                        20,
+                        40,
+                        60,
+                        80,
+                        100
+                    ]
+                },
+                "notes": "Calibration of the laser power output at different settings",
+                "output": {
+                    "power_output": [
+                        1,
+                        13,
+                        30,
+                        50,
+                        67,
+                        140,
+                        213,
+                        280,
+                        340
+                    ]
+                }
+            }
+        ],
+        "cameras": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "Additive",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "",
+                    "cooling": "Air",
+                    "crop_height": 500,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": 900,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-16S2M",
+                    "name": "Side Face Camera",
+                    "notes": "",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": {
+                        "name": "pyBpod",
+                        "parameters": {},
+                        "url": "https://github.com/rozmar/pySpinCapture",
+                        "version": "26140c2"
+                    },
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "sensor_height": 1080,
+                    "sensor_width": 1440,
+                    "serial_number": "19414825",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Side",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": null,
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": null,
+                    "description": "850 nm shortpass filter",
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Short pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Thorlabs",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04gsnvb07"
+                    },
+                    "model": null,
+                    "name": "LP filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Other",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": "f/1.2",
+                    "model": "Tamron 12VM412ASIR",
+                    "name": "Side Camera Lens",
+                    "notes": "Focal Length 4-12mm 1/2\" IR F/1.2",
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "unknown",
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Side Face Camera Assembly",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "Additive",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "",
+                    "cooling": "Air",
+                    "crop_height": 500,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": 900,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-16S2M",
+                    "name": "Bottom Face Camera",
+                    "notes": "",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": {
+                        "name": "pyBpod",
+                        "parameters": {},
+                        "url": "https://github.com/rozmar/pySpinCapture",
+                        "version": "26140c2"
+                    },
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "sensor_height": 1080,
+                    "sensor_width": 1440,
+                    "serial_number": "1944074",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Bottom",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Other",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": "f/1.2",
+                    "model": "Tamron 12VM412ASIR",
+                    "name": "Bottom Camera Lens",
+                    "notes": "FocFF562-Di03-25x36al Length 4-12mm 1/2\" IR F/1.2",
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "unknown",
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Bottom Face Camera Assembly",
+                "position": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "daqs": [
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "2p_PC",
+                "data_interface": "PXI",
+                "device_type": "DAQ Device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "National Instruments",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "026exqw73"
+                },
+                "model": null,
+                "name": "PXI",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "detectors": [
+            {
+                "additional_settings": {},
+                "bin_height": null,
+                "bin_mode": "None",
+                "bin_unit": "pixel",
+                "bin_width": null,
+                "bit_depth": null,
+                "chroma": null,
+                "computer_name": null,
+                "cooling": "Air",
+                "crop_height": null,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": null,
+                "data_interface": "PXI",
+                "detector_type": "Photomultiplier Tube",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": null,
+                "immersion": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "PMT2101",
+                "name": "Red PMT",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "AF7695",
+                "size_unit": "pixel"
+            },
+            {
+                "additional_settings": {},
+                "bin_height": null,
+                "bin_mode": "None",
+                "bin_unit": "pixel",
+                "bin_width": null,
+                "bit_depth": null,
+                "chroma": null,
+                "computer_name": null,
+                "cooling": "Air",
+                "crop_height": null,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": null,
+                "data_interface": "PXI",
+                "detector_type": "Photomultiplier Tube",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": null,
+                "immersion": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "PMT2101",
+                "name": "Green PMT",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "AF7690",
+                "size_unit": "pixel"
+            }
+        ],
+        "digital_micromirror_devices": [],
+        "enclosure": null,
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "filters": [
+            {
+                "additional_settings": {},
+                "center_wavelength": 525,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF03-525/50-25",
+                "name": "Green emission filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 620,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Chroma",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "ET620/60m",
+                "name": "Red emission filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": 562,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Dichroic",
+                "filter_wheel_index": null,
+                "height": "25",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF562-Di03-25x36",
+                "name": "Emission dichroic",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "36"
+            }
+        ],
+        "laser_assemblies": [],
+        "lenses": [],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "coupling": "Free-space",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Coherent Scientific",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "maximum_power": "40000",
+                "model": "Monaco",
+                "name": "Monaco Laser",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "0918012925",
+                "wavelength": 1035,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Free-space",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Coherent Scientific",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "maximum_power": "1500",
+                "model": "Chameleon",
+                "name": "Chameleon Laser",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "GDP.1185374.8460",
+                "wavelength": 920,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "pophys",
+                "name": "Planar optical physiology"
+            }
+        ],
+        "modification_date": "2022-01-01",
+        "mouse_platform": {
+            "additional_settings": {},
+            "date_surface_replaced": null,
+            "device_type": "Tube",
+            "diameter": "3.0",
+            "diameter_unit": "centimeter",
+            "manufacturer": null,
+            "model": null,
+            "name": "Standard Mouse Tube",
+            "notes": "Mouse sits in a plastic tube",
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "surface_material": null
+        },
+        "notes": null,
+        "objectives": [
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "water",
+                "magnification": "16",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Nikon",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "0280y9h11"
+                },
+                "model": "N16XLWD-PF - 16X Nikon CFI LWD Plan Fluorite Objective",
+                "name": "16x Objective",
+                "notes": "3.0 mm WD",
+                "numerical_aperture": "0.8",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "none"
+            }
+        ],
+        "origin": null,
+        "patch_cords": [],
+        "pockels_cells": [],
+        "polygonal_scanners": [],
+        "rig_axes": null,
+        "rig_id": "Bergamo_2p-photostim-room442_20241021",
+        "schema_version": "1.0.1",
+        "stick_microscopes": [],
+        "stimulus_devices": [
+            {
+                "additional_settings": {},
+                "device_type": "Speaker",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": null,
+                "name": "speaker",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "serial_number": null
+            },
+            {
+                "device_type": "Reward delivery",
+                "reward_spouts": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Lick detector",
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Janelia_Lick_Detector",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": null,
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Lickport",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Center",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid",
+                            "manufacturer": null,
+                            "model": null,
+                            "name": "Solenoid",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.3",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    }
+                ],
+                "stage_type": null
+            }
+        ]
+    },
+    "schema_version": "1.1.1",
+    "session": {
+        "active_mouse_platform": false,
+        "anaesthesia": null,
+        "animal_weight_post": null,
+        "animal_weight_prior": null,
+        "calibrations": [],
+        "data_streams": [
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "PXI",
+                    "PXI"
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "name": "Green PMT",
+                        "trigger_type": "Internal"
+                    },
+                    {
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "name": "Red PMT",
+                        "trigger_type": "Internal"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": "13.0",
+                        "excitation_power_unit": "percent",
+                        "name": "Chameleon Laser",
+                        "wavelength": 920,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "tiff_stem:red_green_two_channels",
+                "ophys_fovs": [
+                    {
+                        "coupled_fov_index": null,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 256,
+                        "fov_reference": "there is no reference",
+                        "fov_scale_factor": "2.44140625",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "58.2659",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 112,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 0,
+                        "magnification": "1.6",
+                        "notes": null,
+                        "power": null,
+                        "power_ratio": null,
+                        "power_unit": "percent",
+                        "scanfield_z": null,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": null,
+                        "targeted_structure": "Primary Motor Cortex"
+                    }
+                ],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-06-23T09:49:57.257326-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "pophys",
+                        "name": "Planar optical physiology"
+                    }
+                ],
+                "stream_start_time": "2025-06-23T09:48:12.785000-07:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "PXI"
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "name": "Green PMT",
+                        "trigger_type": "Internal"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": "13.0",
+                        "excitation_power_unit": "percent",
+                        "name": "Chameleon Laser",
+                        "wavelength": 920,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "tiff_stem:spont22",
+                "ophys_fovs": [
+                    {
+                        "coupled_fov_index": null,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 256,
+                        "fov_reference": "there is no reference",
+                        "fov_scale_factor": "2.44140625",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "58.2659",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 112,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 0,
+                        "magnification": "1.6",
+                        "notes": null,
+                        "power": null,
+                        "power_ratio": null,
+                        "power_unit": "percent",
+                        "scanfield_z": null,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": null,
+                        "targeted_structure": "Primary Motor Cortex"
+                    }
+                ],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-06-23T09:31:16.393270-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "pophys",
+                        "name": "Planar optical physiology"
+                    }
+                ],
+                "stream_start_time": "2025-06-23T09:29:15.750999-07:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "PXI"
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "name": "Green PMT",
+                        "trigger_type": "Internal"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": "13.0",
+                        "excitation_power_unit": "percent",
+                        "name": "Chameleon Laser",
+                        "wavelength": 920,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "tiff_stem:spontPost",
+                "ophys_fovs": [
+                    {
+                        "coupled_fov_index": null,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 256,
+                        "fov_reference": "there is no reference",
+                        "fov_scale_factor": "2.44140625",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "58.2659",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 112,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 0,
+                        "magnification": "1.6",
+                        "notes": null,
+                        "power": null,
+                        "power_ratio": null,
+                        "power_unit": "percent",
+                        "scanfield_z": null,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": null,
+                        "targeted_structure": "Primary Motor Cortex"
+                    }
+                ],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-06-23T09:47:57.150562-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "pophys",
+                        "name": "Planar optical physiology"
+                    }
+                ],
+                "stream_start_time": "2025-06-23T09:45:21.004999-07:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "PXI"
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "name": "Green PMT",
+                        "trigger_type": "Internal"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": "13.0",
+                        "excitation_power_unit": "percent",
+                        "name": "Chameleon Laser",
+                        "wavelength": 920,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "tiff_stem:spont",
+                "ophys_fovs": [
+                    {
+                        "coupled_fov_index": null,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 256,
+                        "fov_reference": "there is no reference",
+                        "fov_scale_factor": "2.44140625",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "58.2659",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 112,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 0,
+                        "magnification": "1.6",
+                        "notes": null,
+                        "power": null,
+                        "power_ratio": null,
+                        "power_unit": "percent",
+                        "scanfield_z": null,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": null,
+                        "targeted_structure": "Primary Motor Cortex"
+                    }
+                ],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-06-23T09:24:40.044738-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "pophys",
+                        "name": "Planar optical physiology"
+                    }
+                ],
+                "stream_start_time": "2025-06-23T09:24:00.069000-07:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "PXI"
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "name": "Green PMT",
+                        "trigger_type": "Internal"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": "13.0",
+                        "excitation_power_unit": "percent",
+                        "name": "Chameleon Laser",
+                        "wavelength": 920,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "tiff_stem:spont_pre2",
+                "ophys_fovs": [
+                    {
+                        "coupled_fov_index": null,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 256,
+                        "fov_reference": "there is no reference",
+                        "fov_scale_factor": "2.44140625",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "58.2659",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 112,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 0,
+                        "magnification": "1.6",
+                        "notes": null,
+                        "power": null,
+                        "power_ratio": null,
+                        "power_unit": "percent",
+                        "scanfield_z": null,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": null,
+                        "targeted_structure": "Primary Motor Cortex"
+                    }
+                ],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-06-23T09:28:21.037377-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "pophys",
+                        "name": "Planar optical physiology"
+                    }
+                ],
+                "stream_start_time": "2025-06-23T09:27:33.274000-07:00"
+            },
+            {
+                "camera_names": [],
+                "daq_names": [
+                    "PXI"
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "name": "Green PMT",
+                        "trigger_type": "Internal"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": "13.0",
+                        "excitation_power_unit": "percent",
+                        "name": "Chameleon Laser",
+                        "wavelength": 920,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "tiff_stem:spont_pre",
+                "ophys_fovs": [
+                    {
+                        "coupled_fov_index": null,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 256,
+                        "fov_reference": "there is no reference",
+                        "fov_scale_factor": "2.44140625",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "58.2659",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 112,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 0,
+                        "magnification": "1.6",
+                        "notes": null,
+                        "power": null,
+                        "power_ratio": null,
+                        "power_unit": "percent",
+                        "scanfield_z": null,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": null,
+                        "targeted_structure": "Primary Motor Cortex"
+                    }
+                ],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-06-23T09:25:56.348293-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "pophys",
+                        "name": "Planar optical physiology"
+                    }
+                ],
+                "stream_start_time": "2025-06-23T09:25:50.201999-07:00"
+            },
+            {
+                "camera_names": [
+                    "Side Face Camera",
+                    "Bottom Face Camera"
+                ],
+                "daq_names": [
+                    "PXI"
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": null,
+                        "exposure_time_unit": "millisecond",
+                        "name": "Green PMT",
+                        "trigger_type": "Internal"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": "13.0",
+                        "excitation_power_unit": "percent",
+                        "name": "Chameleon Laser",
+                        "wavelength": 920,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "tiff_stem:BCI",
+                "ophys_fovs": [
+                    {
+                        "coupled_fov_index": null,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 256,
+                        "fov_reference": "there is no reference",
+                        "fov_scale_factor": "2.44140625",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "58.2659",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 112,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 0,
+                        "magnification": "1.6",
+                        "notes": null,
+                        "power": null,
+                        "power_ratio": null,
+                        "power_unit": "percent",
+                        "scanfield_z": null,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": null,
+                        "targeted_structure": "Primary Motor Cortex"
+                    }
+                ],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-06-23T09:45:06.692895-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "pophys",
+                        "name": "Planar optical physiology"
+                    },
+                    {
+                        "abbreviation": "behavior",
+                        "name": "Behavior"
+                    },
+                    {
+                        "abbreviation": "behavior-videos",
+                        "name": "Behavior videos"
+                    }
+                ],
+                "stream_start_time": "2025-06-23T09:32:20.617999-07:00"
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "experimenter_full_name": [
+            "Kayvon Daie"
+        ],
+        "headframe_registration": null,
+        "iacuc_protocol": "2109",
+        "maintenance": [],
+        "mouse_platform_name": "Standard Mouse Tube",
+        "notes": "dense expression, no learning",
+        "protocol_id": [],
+        "reward_consumed_total": null,
+        "reward_consumed_unit": "milliliter",
+        "reward_delivery": {
+            "notes": null,
+            "reward_solution": "Water",
+            "reward_spouts": [
+                {
+                    "side": "Center",
+                    "starting_position": {
+                        "device_axes": [
+                            {
+                                "direction": "lateral motion",
+                                "name": "X"
+                            },
+                            {
+                                "direction": "rostro-caudal motion positive is towards mouse, negative is away",
+                                "name": "Y"
+                            },
+                            {
+                                "direction": "up/down",
+                                "name": "Z"
+                            }
+                        ],
+                        "device_origin": "tip of the lickspout",
+                        "device_position_transformations": [
+                            {
+                                "translation": [
+                                    "0.0",
+                                    "-6.0",
+                                    "0.0"
+                                ],
+                                "type": "translation"
+                            },
+                            {
+                                "rotation": [
+                                    "0",
+                                    "0",
+                                    "0",
+                                    "0",
+                                    "0",
+                                    "0",
+                                    "0",
+                                    "0",
+                                    "0"
+                                ],
+                                "type": "rotation"
+                            }
+                        ],
+                        "notes": null
+                    },
+                    "variable_position": true
+                }
+            ]
+        },
+        "rig_id": "442_Bergamo_2p_photostim",
+        "schema_version": "1.0.1",
+        "session_end_time": "2025-06-23T09:49:57.257326-07:00",
+        "session_start_time": "2025-06-23T09:24:00.069000-07:00",
+        "session_type": "BCI",
+        "stimulus_epochs": [
+            {
+                "light_source_config": [],
+                "notes": "absence of any kind of stimulus",
+                "output_parameters": {
+                    "tiff_files": [
+                        "red_green_two_channels_00001.tif",
+                        "red_green_two_channels_00002.tif"
+                    ],
+                    "tiff_stem": "red_green_two_channels"
+                },
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-06-23T09:49:57.257326-07:00",
+                "stimulus_modalities": [
+                    "None"
+                ],
+                "stimulus_name": "spontaneous activity",
+                "stimulus_parameters": null,
+                "stimulus_start_time": "2025-06-23T09:48:12.785000-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": "absence of any kind of stimulus",
+                "output_parameters": {
+                    "tiff_files": [
+                        "spont22_00001.tif",
+                        "spont22_00002.tif"
+                    ],
+                    "tiff_stem": "spont22"
+                },
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-06-23T09:31:16.393270-07:00",
+                "stimulus_modalities": [
+                    "None"
+                ],
+                "stimulus_name": "spontaneous activity",
+                "stimulus_parameters": null,
+                "stimulus_start_time": "2025-06-23T09:29:15.750999-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": "absence of any kind of stimulus",
+                "output_parameters": {
+                    "tiff_files": [
+                        "spontPost_00001.tif",
+                        "spontPost_00002.tif",
+                        "spontPost_00003.tif"
+                    ],
+                    "tiff_stem": "spontPost"
+                },
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-06-23T09:47:57.150562-07:00",
+                "stimulus_modalities": [
+                    "None"
+                ],
+                "stimulus_name": "spontaneous activity",
+                "stimulus_parameters": null,
+                "stimulus_start_time": "2025-06-23T09:45:21.004999-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": "absence of any kind of stimulus",
+                "output_parameters": {
+                    "tiff_files": [
+                        "spont_00001.tif"
+                    ],
+                    "tiff_stem": "spont"
+                },
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-06-23T09:24:40.044738-07:00",
+                "stimulus_modalities": [
+                    "None"
+                ],
+                "stimulus_name": "spontaneous activity",
+                "stimulus_parameters": null,
+                "stimulus_start_time": "2025-06-23T09:24:00.069000-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": "absence of any kind of stimulus",
+                "output_parameters": {
+                    "tiff_files": [
+                        "spont_pre2_00001.tif"
+                    ],
+                    "tiff_stem": "spont_pre2"
+                },
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-06-23T09:28:21.037377-07:00",
+                "stimulus_modalities": [
+                    "None"
+                ],
+                "stimulus_name": "spontaneous activity",
+                "stimulus_parameters": null,
+                "stimulus_start_time": "2025-06-23T09:27:33.274000-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": "absence of any kind of stimulus",
+                "output_parameters": {
+                    "tiff_files": [
+                        "spont_pre_00001.tif"
+                    ],
+                    "tiff_stem": "spont_pre"
+                },
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-06-23T09:25:56.348293-07:00",
+                "stimulus_modalities": [
+                    "None"
+                ],
+                "stimulus_name": "spontaneous activity",
+                "stimulus_parameters": null,
+                "stimulus_start_time": "2025-06-23T09:25:50.201999-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": null,
+                "output_parameters": {
+                    "average_hit_rate": 0.6865671641791045,
+                    "hit_rate_trials_0_10": 1,
+                    "hit_rate_trials_20_40": 0.7,
+                    "tiff_files": [
+                        "BCI_00001.tif",
+                        "BCI_00002.tif",
+                        "BCI_00003.tif",
+                        "BCI_00004.tif",
+                        "BCI_00005.tif",
+                        "BCI_00006.tif",
+                        "BCI_00007.tif",
+                        "BCI_00008.tif",
+                        "BCI_00009.tif",
+                        "BCI_00010.tif",
+                        "BCI_00011.tif",
+                        "BCI_00012.tif",
+                        "BCI_00013.tif",
+                        "BCI_00014.tif",
+                        "BCI_00015.tif",
+                        "BCI_00016.tif",
+                        "BCI_00017.tif",
+                        "BCI_00018.tif",
+                        "BCI_00019.tif",
+                        "BCI_00020.tif",
+                        "BCI_00021.tif",
+                        "BCI_00022.tif",
+                        "BCI_00023.tif",
+                        "BCI_00024.tif",
+                        "BCI_00025.tif",
+                        "BCI_00026.tif",
+                        "BCI_00027.tif",
+                        "BCI_00028.tif",
+                        "BCI_00029.tif",
+                        "BCI_00030.tif",
+                        "BCI_00031.tif",
+                        "BCI_00032.tif",
+                        "BCI_00033.tif",
+                        "BCI_00034.tif",
+                        "BCI_00035.tif",
+                        "BCI_00036.tif",
+                        "BCI_00037.tif",
+                        "BCI_00038.tif",
+                        "BCI_00039.tif",
+                        "BCI_00040.tif",
+                        "BCI_00041.tif",
+                        "BCI_00042.tif",
+                        "BCI_00043.tif",
+                        "BCI_00044.tif",
+                        "BCI_00045.tif",
+                        "BCI_00046.tif",
+                        "BCI_00047.tif",
+                        "BCI_00048.tif",
+                        "BCI_00049.tif",
+                        "BCI_00050.tif",
+                        "BCI_00051.tif",
+                        "BCI_00052.tif",
+                        "BCI_00053.tif",
+                        "BCI_00054.tif",
+                        "BCI_00055.tif",
+                        "BCI_00056.tif",
+                        "BCI_00057.tif",
+                        "BCI_00058.tif",
+                        "BCI_00059.tif",
+                        "BCI_00060.tif",
+                        "BCI_00061.tif",
+                        "BCI_00062.tif",
+                        "BCI_00063.tif",
+                        "BCI_00064.tif",
+                        "BCI_00065.tif",
+                        "BCI_00066.tif",
+                        "BCI_00067.tif"
+                    ],
+                    "tiff_stem": "BCI",
+                    "total_hits": 46
+                },
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "pybpod_basic.py",
+                    "parameters": {},
+                    "url": "https://github.com/rozmar/BCI-motor-control/blob/main/BCI-pybpod-protocols/bci_basic.py",
+                    "version": "2d77d15"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "pyBpod",
+                        "parameters": {},
+                        "url": "https://github.com/pybpod/pybpod",
+                        "version": "1.8.2"
+                    }
+                ],
+                "speaker_config": null,
+                "stimulus_device_names": [
+                    "speaker",
+                    "lickport"
+                ],
+                "stimulus_end_time": "2025-06-23T09:45:06.692895-07:00",
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_name": "single neuron BCI conditioning",
+                "stimulus_parameters": [],
+                "stimulus_start_time": "2025-06-23T09:32:20.617999-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": 67
+            }
+        ],
+        "subject_id": "776628",
+        "weight_unit": "gram"
+    },
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Oi8(H11-CAG-Cas9)(BWT-ND)",
+            "maternal_genotype": "Oi8(H11-CAG-Cas9)/Oi8(H11-CAG-Cas9)",
+            "maternal_id": "758829",
+            "paternal_genotype": "Oi8(H11-CAG-Cas9)/Oi8(H11-CAG-Cas9)",
+            "paternal_id": "756856"
+        },
+        "date_of_birth": "2024-11-09",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "Oi8(H11-CAG-Cas9)/Oi8(H11-CAG-Cas9)",
+        "housing": {
+            "cage_id": "8287237",
+            "cohoused_subjects": [],
+            "home_cage_enrichment": [],
+            "light_cycle": null,
+            "room_id": "221"
+        },
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.2",
+        "sex": "Male",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "776628",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
This PR adds support in the session upgraded to allow multiple detectors to be used to construct multiple channels based on the available emission paths. It is narrowly constructed for the BCI data, if other assets use this pattern we'll have to construct an upgrader path for them.

To avoid hard-coding the emission wavelengths (even though that's probably safe since this is all for BCI) I pull them in advance and store them in the SessionV1V2 upgrader. Then they get pulled back out during the actual FOV construction.

An example asset is included that relies on this new code.