### PR TITLE
refactor: add a new timezone repair that runs at Metadata validation

### DIFF
--- a/src/aind_metadata_upgrader/utils/v1v2_metadata_utils.py
+++ b/src/aind_metadata_upgrader/utils/v1v2_metadata_utils.py
@@ -1,6 +1,6 @@
 """Metadata level utilities"""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from aind_data_schema.core.procedures import Procedures
 from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.components.devices import Device
@@ -151,6 +151,155 @@ def repair_creation_time(data: dict) -> dict:
     return data
 
 
+def repair_acquisition_timezone(data: dict) -> dict:
+    """If acquisition_start_time has a non-UTC timezone, try reinterpreting all UTC-labeled
+    acquisition_end_time and data stream / stimulus epoch times as that same timezone.
+
+    The fix is only applied if, after the reinterpretation, every stream and epoch time
+    is properly contained within the acquisition_start_time / acquisition_end_time window.
+    This guards against incorrectly patching records where UTC is genuinely correct.
+
+    Handles both string and datetime values (strings from raw v1 JSON; datetime objects
+    from model_dump() output of upgraded records).
+    """
+    if "acquisition" not in data:
+        return data
+
+    acquisition = data["acquisition"]
+    start_time_raw = acquisition.get("acquisition_start_time")
+
+    if not start_time_raw:
+        return data
+
+    def _to_dt(v):
+        """Normalise a raw string or datetime to an aware datetime, or return None."""
+        if v is None:
+            return None
+        if isinstance(v, datetime):
+            return v
+        if isinstance(v, str):
+            return datetime.fromisoformat(v.replace("Z", "+00:00"))
+        return None
+
+    start_time = _to_dt(start_time_raw)
+    if start_time is None:
+        return data
+
+    # Only proceed if start_time has a non-UTC timezone
+    if start_time.tzinfo is None or start_time.utcoffset() == timedelta(0):
+        return data
+
+    start_tz = start_time.tzinfo
+
+    def _fix_if_utc(v):
+        """Reinterpret a UTC value as start_tz; leave non-UTC values as-is.
+        Returns a datetime object."""
+        dt = _to_dt(v)
+        if dt is None:
+            return v
+        if dt.tzinfo is not None and dt.utcoffset() == timedelta(0):
+            return dt.replace(tzinfo=start_tz)
+        return dt
+
+    # Build candidate end time
+    end_time_raw = acquisition.get("acquisition_end_time")
+    candidate_end = _fix_if_utc(end_time_raw) if end_time_raw is not None else None
+
+    # Build candidate stream times
+    candidate_streams = []
+    for stream in acquisition.get("data_streams", []):
+        ss = _fix_if_utc(stream.get("stream_start_time")) if stream.get("stream_start_time") is not None else None
+        se = _fix_if_utc(stream.get("stream_end_time")) if stream.get("stream_end_time") is not None else None
+        candidate_streams.append((ss, se))
+
+    # Build candidate stimulus epoch times
+    candidate_epochs = []
+    for epoch in acquisition.get("stimulus_epochs", []):
+        es = _fix_if_utc(epoch.get("stimulus_start_time")) if epoch.get("stimulus_start_time") is not None else None
+        ee = _fix_if_utc(epoch.get("stimulus_end_time")) if epoch.get("stimulus_end_time") is not None else None
+        candidate_epochs.append((es, ee))
+
+    # Validate: all streams and epochs must be within [start_time, candidate_end]
+    acq_start = start_time
+    acq_end = _to_dt(candidate_end) if not isinstance(candidate_end, datetime) else candidate_end
+
+    def _within(t):
+        if t is None or not isinstance(t, datetime):
+            return True
+        if acq_start and t.tzinfo and t < acq_start:
+            return False
+        if acq_end and t.tzinfo and t > acq_end:
+            return False
+        return True
+
+    all_valid = all(_within(t) for pair in candidate_streams + candidate_epochs for t in pair)
+
+    if not all_valid:
+        return data
+
+    # Apply the fix
+    if end_time_raw is not None:
+        data["acquisition"]["acquisition_end_time"] = candidate_end
+
+    for stream, (ss, se) in zip(acquisition.get("data_streams", []), candidate_streams):
+        if stream.get("stream_start_time") is not None:
+            stream["stream_start_time"] = ss
+        if stream.get("stream_end_time") is not None:
+            stream["stream_end_time"] = se
+
+    for epoch, (es, ee) in zip(acquisition.get("stimulus_epochs", []), candidate_epochs):
+        if epoch.get("stimulus_start_time") is not None:
+            epoch["stimulus_start_time"] = es
+        if epoch.get("stimulus_end_time") is not None:
+            epoch["stimulus_end_time"] = ee
+
+    return data
+
+
+def repair_naive_acquisition_times(data: dict) -> dict:
+    """Assign Pacific timezone to any acquisition timestamps that are still naive (no timezone info).
+
+    This is the final fallback after repair_acquisition_timezone has run: if any times still
+    lack a timezone, attach America/Los_Angeles as the safest default for AIND data.
+    """
+    from zoneinfo import ZoneInfo
+
+    pacific = ZoneInfo("America/Los_Angeles")
+
+    if "acquisition" not in data:
+        return data
+
+    acquisition = data["acquisition"]
+
+    def _ensure(v):
+        if v is None:
+            return v
+        if isinstance(v, datetime) and v.tzinfo is None:
+            return v.replace(tzinfo=pacific)
+        if isinstance(v, str):
+            dt = datetime.fromisoformat(v.replace("Z", "+00:00"))
+            if dt.tzinfo is None:
+                return dt.replace(tzinfo=pacific)
+            return dt
+        return v
+
+    for field in ("acquisition_start_time", "acquisition_end_time"):
+        if acquisition.get(field) is not None:
+            acquisition[field] = _ensure(acquisition[field])
+
+    for stream in acquisition.get("data_streams", []):
+        for field in ("stream_start_time", "stream_end_time"):
+            if stream.get(field) is not None:
+                stream[field] = _ensure(stream[field])
+
+    for epoch in acquisition.get("stimulus_epochs", []):
+        for field in ("stimulus_start_time", "stimulus_end_time"):
+            if epoch.get(field) is not None:
+                epoch[field] = _ensure(epoch[field])
+
+    return data
+
+
 def repair_metadata(data: dict) -> dict:
     """Repair the full metadata record, checking for common issues"""
 
@@ -158,5 +307,7 @@ def repair_metadata(data: dict) -> dict:
     data = repair_missing_active_devices(data)
     data = repair_connection_devices(data)
     data = repair_creation_time(data)
+    data = repair_acquisition_timezone(data)
+    data = repair_naive_acquisition_times(data)
 
     return data

--- a/src/aind_metadata_upgrader/utils/v1v2_metadata_utils.py
+++ b/src/aind_metadata_upgrader/utils/v1v2_metadata_utils.py
@@ -1,6 +1,7 @@
 """Metadata level utilities"""
 
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from aind_data_schema.core.procedures import Procedures
 from aind_data_schema.core.instrument import Instrument
 from aind_data_schema.components.devices import Device
@@ -151,6 +152,73 @@ def repair_creation_time(data: dict) -> dict:
     return data
 
 
+def _parse_dt(v):
+    """Normalise a string or datetime to a datetime object, or return None."""
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v
+    if isinstance(v, str):
+        return datetime.fromisoformat(v.replace("Z", "+00:00"))
+    return None
+
+
+def _reinterpret_utc_as(v, tz):
+    """If v parses to a UTC-aware datetime, replace its tzinfo with tz (reinterpret, not convert).
+    Otherwise return the parsed datetime unchanged."""
+    dt = _parse_dt(v)
+    if dt is None:
+        return v
+    if dt.tzinfo is not None and dt.utcoffset() == timedelta(0):
+        return dt.replace(tzinfo=tz)
+    return dt
+
+
+def _within_bounds(t, acq_start, acq_end):
+    """Return True if t (datetime or None) lies within [acq_start, acq_end]."""
+    if t is None or not isinstance(t, datetime):
+        return True
+    if acq_start and t.tzinfo and t < acq_start:
+        return False
+    if acq_end and t.tzinfo and t > acq_end:
+        return False
+    return True
+
+
+def _ensure_tz(v, tz):
+    """Parse v to a datetime and attach tz if it is naive; aware datetimes pass through."""
+    if v is None:
+        return v
+    dt = _parse_dt(v)
+    if dt is None:
+        return v
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=tz)
+    return dt
+
+
+def _reinterpret_pair(obj, fields, tz):
+    """Return a tuple of reinterpreted values for the two fields in obj."""
+    return tuple(_reinterpret_utc_as(obj.get(f), tz) for f in fields)
+
+
+def _apply_pair(obj, fields, values):
+    """Write back non-None candidate values into obj for the given fields."""
+    for field, value in zip(fields, values):
+        if obj.get(field) is not None:
+            obj[field] = value
+
+
+def _non_utc_tz(start_raw):
+    """Return the tzinfo from start_raw if it is a non-UTC aware datetime, else None."""
+    start_time = _parse_dt(start_raw)
+    if start_time is None:
+        return None
+    if start_time.tzinfo is None or start_time.utcoffset() == timedelta(0):
+        return None
+    return start_time.tzinfo, start_time
+
+
 def repair_acquisition_timezone(data: dict) -> dict:
     """If acquisition_start_time has a non-UTC timezone, try reinterpreting all UTC-labeled
     acquisition_end_time and data stream / stimulus epoch times as that same timezone.
@@ -166,94 +234,37 @@ def repair_acquisition_timezone(data: dict) -> dict:
         return data
 
     acquisition = data["acquisition"]
-    start_time_raw = acquisition.get("acquisition_start_time")
-
-    if not start_time_raw:
+    result = _non_utc_tz(acquisition.get("acquisition_start_time"))
+    if result is None:
         return data
+    start_tz, start_time = result
 
-    def _to_dt(v):
-        """Normalise a raw string or datetime to an aware datetime, or return None."""
-        if v is None:
-            return None
-        if isinstance(v, datetime):
-            return v
-        if isinstance(v, str):
-            return datetime.fromisoformat(v.replace("Z", "+00:00"))
-        return None
+    candidate_end = _reinterpret_utc_as(acquisition.get("acquisition_end_time"), start_tz)
+    candidate_streams = [_reinterpret_pair(s, _STREAM_FIELDS, start_tz) for s in acquisition.get("data_streams", [])]
+    candidate_epochs = [_reinterpret_pair(e, _EPOCH_FIELDS, start_tz) for e in acquisition.get("stimulus_epochs", [])]
 
-    start_time = _to_dt(start_time_raw)
-    if start_time is None:
-        return data
-
-    # Only proceed if start_time has a non-UTC timezone
-    if start_time.tzinfo is None or start_time.utcoffset() == timedelta(0):
-        return data
-
-    start_tz = start_time.tzinfo
-
-    def _fix_if_utc(v):
-        """Reinterpret a UTC value as start_tz; leave non-UTC values as-is.
-        Returns a datetime object."""
-        dt = _to_dt(v)
-        if dt is None:
-            return v
-        if dt.tzinfo is not None and dt.utcoffset() == timedelta(0):
-            return dt.replace(tzinfo=start_tz)
-        return dt
-
-    # Build candidate end time
-    end_time_raw = acquisition.get("acquisition_end_time")
-    candidate_end = _fix_if_utc(end_time_raw) if end_time_raw is not None else None
-
-    # Build candidate stream times
-    candidate_streams = []
-    for stream in acquisition.get("data_streams", []):
-        ss = _fix_if_utc(stream.get("stream_start_time")) if stream.get("stream_start_time") is not None else None
-        se = _fix_if_utc(stream.get("stream_end_time")) if stream.get("stream_end_time") is not None else None
-        candidate_streams.append((ss, se))
-
-    # Build candidate stimulus epoch times
-    candidate_epochs = []
-    for epoch in acquisition.get("stimulus_epochs", []):
-        es = _fix_if_utc(epoch.get("stimulus_start_time")) if epoch.get("stimulus_start_time") is not None else None
-        ee = _fix_if_utc(epoch.get("stimulus_end_time")) if epoch.get("stimulus_end_time") is not None else None
-        candidate_epochs.append((es, ee))
-
-    # Validate: all streams and epochs must be within [start_time, candidate_end]
-    acq_start = start_time
-    acq_end = _to_dt(candidate_end) if not isinstance(candidate_end, datetime) else candidate_end
-
-    def _within(t):
-        if t is None or not isinstance(t, datetime):
-            return True
-        if acq_start and t.tzinfo and t < acq_start:
-            return False
-        if acq_end and t.tzinfo and t > acq_end:
-            return False
-        return True
-
-    all_valid = all(_within(t) for pair in candidate_streams + candidate_epochs for t in pair)
-
+    acq_end = _parse_dt(candidate_end)
+    all_valid = all(
+        _within_bounds(t, start_time, acq_end)
+        for pair in candidate_streams + candidate_epochs
+        for t in pair
+    )
     if not all_valid:
         return data
 
-    # Apply the fix
-    if end_time_raw is not None:
-        data["acquisition"]["acquisition_end_time"] = candidate_end
-
-    for stream, (ss, se) in zip(acquisition.get("data_streams", []), candidate_streams):
-        if stream.get("stream_start_time") is not None:
-            stream["stream_start_time"] = ss
-        if stream.get("stream_end_time") is not None:
-            stream["stream_end_time"] = se
-
-    for epoch, (es, ee) in zip(acquisition.get("stimulus_epochs", []), candidate_epochs):
-        if epoch.get("stimulus_start_time") is not None:
-            epoch["stimulus_start_time"] = es
-        if epoch.get("stimulus_end_time") is not None:
-            epoch["stimulus_end_time"] = ee
+    _apply_pair(acquisition, ("acquisition_end_time",), (candidate_end,))
+    for stream, pair in zip(acquisition.get("data_streams", []), candidate_streams):
+        _apply_pair(stream, _STREAM_FIELDS, pair)
+    for epoch, pair in zip(acquisition.get("stimulus_epochs", []), candidate_epochs):
+        _apply_pair(epoch, _EPOCH_FIELDS, pair)
 
     return data
+
+
+_PACIFIC = ZoneInfo("America/Los_Angeles")
+_ACQ_TOP_FIELDS = ("acquisition_start_time", "acquisition_end_time")
+_STREAM_FIELDS = ("stream_start_time", "stream_end_time")
+_EPOCH_FIELDS = ("stimulus_start_time", "stimulus_end_time")
 
 
 def repair_naive_acquisition_times(data: dict) -> dict:
@@ -262,40 +273,24 @@ def repair_naive_acquisition_times(data: dict) -> dict:
     This is the final fallback after repair_acquisition_timezone has run: if any times still
     lack a timezone, attach America/Los_Angeles as the safest default for AIND data.
     """
-    from zoneinfo import ZoneInfo
-
-    pacific = ZoneInfo("America/Los_Angeles")
-
     if "acquisition" not in data:
         return data
 
     acquisition = data["acquisition"]
 
-    def _ensure(v):
-        if v is None:
-            return v
-        if isinstance(v, datetime) and v.tzinfo is None:
-            return v.replace(tzinfo=pacific)
-        if isinstance(v, str):
-            dt = datetime.fromisoformat(v.replace("Z", "+00:00"))
-            if dt.tzinfo is None:
-                return dt.replace(tzinfo=pacific)
-            return dt
-        return v
-
-    for field in ("acquisition_start_time", "acquisition_end_time"):
+    for field in _ACQ_TOP_FIELDS:
         if acquisition.get(field) is not None:
-            acquisition[field] = _ensure(acquisition[field])
+            acquisition[field] = _ensure_tz(acquisition[field], _PACIFIC)
 
     for stream in acquisition.get("data_streams", []):
-        for field in ("stream_start_time", "stream_end_time"):
+        for field in _STREAM_FIELDS:
             if stream.get(field) is not None:
-                stream[field] = _ensure(stream[field])
+                stream[field] = _ensure_tz(stream[field], _PACIFIC)
 
     for epoch in acquisition.get("stimulus_epochs", []):
-        for field in ("stimulus_start_time", "stimulus_end_time"):
+        for field in _EPOCH_FIELDS:
             if epoch.get(field) is not None:
-                epoch[field] = _ensure(epoch[field])
+                epoch[field] = _ensure_tz(epoch[field], _PACIFIC)
 
     return data
 

--- a/tests/records/v1/18e5edd1-8836-4ee1-88c0-bbb6bc5f2691.json
+++ b/tests/records/v1/18e5edd1-8836-4ee1-88c0-bbb6bc5f2691.json
@@ -1,0 +1,7905 @@
+{
+    "_id": "18e5edd1-8836-4ee1-88c0-bbb6bc5f2691",
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "schema_version": "1.2.1",
+    "name": "ecephys_668755_2023-08-31_12-33-31_nwb_2026-05-01_13-19-39",
+    "created": "2026-05-01T23:21:02.104311Z",
+    "last_modified": "2026-05-01T23:21:02.524Z",
+    "location": "s3://codeocean-s3datasetsbucket-1u41qdg42ur9/917a448b-8aa8-4188-9337-1b6f9d9618c3",
+    "metadata_status": "Invalid",
+    "external_links": {
+        "Code Ocean": [
+            "917a448b-8aa8-4188-9337-1b6f9d9618c3"
+        ]
+    },
+    "subject": {
+        "background_strain": null,
+        "breeding_group": "C57BL6J(NP)",
+        "date_of_birth": "2023-02-06",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/subject.py",
+        "genotype": "wt/wt",
+        "housing": null,
+        "maternal_genotype": "wt/wt",
+        "maternal_id": "651824",
+        "mgi_allele_ids": null,
+        "notes": null,
+        "paternal_genotype": "wt/wt",
+        "paternal_id": "647460",
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "0.4.1",
+        "sex": "Male",
+        "source": null,
+        "species": {
+            "abbreviation": null,
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "10090"
+        },
+        "subject_id": "668755",
+        "wellness_reports": null
+    },
+    "data_description": {
+        "object_type": "Data description",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "2.3.0",
+        "license": "CC-BY-4.0",
+        "subject_id": "668755",
+        "creation_time": "2026-05-01T13:19:39-07:00",
+        "tags": [
+            "prod",
+            "first_block_vis",
+            "late_autorewards"
+        ],
+        "name": "ecephys_668755_2023-08-31_12-33-31_nwb_2026-05-01_13-19-39",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": "Research Organization Registry (ROR)",
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "object_type": "Funding",
+                "funder": {
+                    "name": "Allen Institute",
+                    "abbreviation": "AI",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null,
+                "fundee": null
+            }
+        ],
+        "data_level": "derived",
+        "group": "ephys",
+        "investigators": [
+            {
+                "object_type": "Person",
+                "name": "Shawn Olsen",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": "0000-0002-9568-7057"
+            },
+            {
+                "object_type": "Person",
+                "name": "Corbett Bennett",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": "0009-0001-2847-7754"
+            }
+        ],
+        "project_name": "Dynamic Routing",
+        "restrictions": null,
+        "modalities": [
+            {
+                "name": "Extracellular electrophysiology",
+                "abbreviation": "ecephys"
+            },
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            }
+        ],
+        "source_data": null,
+        "data_summary": "visual-auditory task-switching behavior experiment"
+    },
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "0.13.14",
+        "specimen_procedures": [],
+        "subject_id": "668755",
+        "subject_procedures": [
+            {
+                "anaesthesia": null,
+                "animal_weight_post": null,
+                "animal_weight_prior": null,
+                "experimenter_full_name": "26888",
+                "iacuc_protocol": "2104",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "output_specimen_ids": [
+                            "668755"
+                        ],
+                        "procedure_type": "Perfusion",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bg5vjy66"
+                    }
+                ],
+                "protocol_id": "unknown",
+                "start_date": "2023-09-01",
+                "weight_unit": "gram",
+                "workstation_id": null
+            },
+            {
+                "anaesthesia": {
+                    "duration": "165.0",
+                    "duration_unit": "minute",
+                    "level": "1.5",
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": "29.4",
+                "animal_weight_prior": "26.0",
+                "experimenter_full_name": "NSB-187",
+                "iacuc_protocol": "2104",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "bregma_to_lambda_distance": "4.535",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "craniotomy_hemisphere": null,
+                        "craniotomy_type": "Whole hemisphere craniotomy",
+                        "dura_removed": null,
+                        "implant_part_number": null,
+                        "procedure_type": "Craniotomy",
+                        "protective_material": null,
+                        "protocol_id": "unknown",
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute"
+                    }
+                ],
+                "protocol_id": "unknown",
+                "start_date": "2023-04-04",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 5"
+            }
+        ]
+    },
+    "session": null,
+    "rig": null,
+    "processing": {
+        "object_type": "Processing",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "schema_version": "2.2.0",
+        "data_processes": [
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-data-transfer",
+                    "name": "Ephys preprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "modality": {
+                            "name": "Extracellular electrophysiology",
+                            "abbreviation": "ecephys"
+                        },
+                        "source": "\\\\allen\\programs\\mindscope\\workgroups\\np-exp\\codeocean\\DRpilot_668755_20230831\\ephys",
+                        "compress_raw_data": true,
+                        "extra_configs": null
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2023-09-02T01:54:20.538959Z",
+                "end_date_time": "2023-09-02T04:50:59.447379Z",
+                "output_path": "s3:/aind-ephys-data/ecephys_668755_2023-08-31_12-33-31",
+                "output_parameters": {},
+                "notes": null,
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": "Ephys preprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeD-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-03-31T18:46:54.110396Z",
+                "end_date_time": "2024-04-01T02:34:56.110396Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": "Ephys preprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeA-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-03-31T18:46:54.145767Z",
+                "end_date_time": "2024-04-01T02:38:55.145767Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": "Ephys preprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeB-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-03-31T18:46:54.305806Z",
+                "end_date_time": "2024-04-01T02:34:10.305806Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": "Ephys preprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeF-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-03-31T18:46:54.408083Z",
+                "end_date_time": "2024-04-01T02:41:42.408083Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "noise",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 3 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": "Ephys preprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeE-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-03-31T18:46:54.415500Z",
+                "end_date_time": "2024-04-01T02:41:22.415500Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys preprocessing",
+                "name": "Ephys preprocessing_7",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-preprocessing",
+                    "name": "Ephys preprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "denoising_strategy": "cmr",
+                        "min_preprocessing_duration": 120,
+                        "highpass_filter": {
+                            "freq_min": 300,
+                            "margin_ms": 5
+                        },
+                        "phase_shift": {
+                            "margin_ms": 100
+                        },
+                        "detect_bad_channels": {
+                            "method": "coherence+psd",
+                            "dead_channel_threshold": -0.5,
+                            "noisy_channel_threshold": 1,
+                            "outside_channel_threshold": -0.3,
+                            "outside_channels_location": "top",
+                            "n_neighbors": 11,
+                            "seed": 0
+                        },
+                        "remove_out_channels": true,
+                        "remove_bad_channels": true,
+                        "max_bad_channel_fraction": 0.5,
+                        "common_reference": {
+                            "reference": "global",
+                            "operator": "median"
+                        },
+                        "highpass_spatial_filter": {
+                            "n_channel_pad": 60,
+                            "n_channel_taper": null,
+                            "direction": "y",
+                            "apply_agc": true,
+                            "agc_window_length_s": 0.01,
+                            "highpass_butter_order": 3,
+                            "highpass_butter_wn": 0.01
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeC-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-03-31T18:46:54.426178Z",
+                "end_date_time": "2024-04-01T02:43:02.426178Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "channel_labels": [
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "dead",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good",
+                        "good"
+                    ]
+                },
+                "notes": "\n- Removed 0 outside of the brain.\n- Removed 1 bad channels after preprocessing.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort25",
+                    "name": "Spike sorting",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort2_5",
+                        "sorter_params": {
+                            "detect_threshold": 6,
+                            "projection_threshold": [
+                                10,
+                                4
+                            ],
+                            "preclust_threshold": 8,
+                            "momentum": [
+                                20,
+                                400
+                            ],
+                            "car": true,
+                            "minFR": 0.1,
+                            "minfr_goodchannels": 0.1,
+                            "nblocks": 5,
+                            "sig": 20,
+                            "freq_min": 150,
+                            "sigmaMask": 30,
+                            "lam": 10,
+                            "nPCs": 3,
+                            "ntbuff": 64,
+                            "nfilt_factor": 4,
+                            "NT": 65600,
+                            "AUCsplit": 0.9,
+                            "do_correction": true,
+                            "wave_length": 61,
+                            "keep_good_only": false,
+                            "skip_kilosort_preprocessing": false,
+                            "scaleproc": null,
+                            "save_rez_to_mat": false,
+                            "delete_tmp_files": [
+                                "matlab_files"
+                            ],
+                            "delete_recording_dat": false,
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_process": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T03:10:16.506684Z",
+                "end_date_time": "2024-04-01T04:54:33.506684Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS2.5 found 419 units, 419 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort25",
+                    "name": "Spike sorting",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort2_5",
+                        "sorter_params": {
+                            "detect_threshold": 6,
+                            "projection_threshold": [
+                                10,
+                                4
+                            ],
+                            "preclust_threshold": 8,
+                            "momentum": [
+                                20,
+                                400
+                            ],
+                            "car": true,
+                            "minFR": 0.1,
+                            "minfr_goodchannels": 0.1,
+                            "nblocks": 5,
+                            "sig": 20,
+                            "freq_min": 150,
+                            "sigmaMask": 30,
+                            "lam": 10,
+                            "nPCs": 3,
+                            "ntbuff": 64,
+                            "nfilt_factor": 4,
+                            "NT": 65600,
+                            "AUCsplit": 0.9,
+                            "do_correction": true,
+                            "wave_length": 61,
+                            "keep_good_only": false,
+                            "skip_kilosort_preprocessing": false,
+                            "scaleproc": null,
+                            "save_rez_to_mat": false,
+                            "delete_tmp_files": [
+                                "matlab_files"
+                            ],
+                            "delete_recording_dat": false,
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_process": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T03:10:17.031590Z",
+                "end_date_time": "2024-04-01T04:40:49.031590Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS2.5 found 505 units, 505 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort25",
+                    "name": "Spike sorting",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort2_5",
+                        "sorter_params": {
+                            "detect_threshold": 6,
+                            "projection_threshold": [
+                                10,
+                                4
+                            ],
+                            "preclust_threshold": 8,
+                            "momentum": [
+                                20,
+                                400
+                            ],
+                            "car": true,
+                            "minFR": 0.1,
+                            "minfr_goodchannels": 0.1,
+                            "nblocks": 5,
+                            "sig": 20,
+                            "freq_min": 150,
+                            "sigmaMask": 30,
+                            "lam": 10,
+                            "nPCs": 3,
+                            "ntbuff": 64,
+                            "nfilt_factor": 4,
+                            "NT": 65600,
+                            "AUCsplit": 0.9,
+                            "do_correction": true,
+                            "wave_length": 61,
+                            "keep_good_only": false,
+                            "skip_kilosort_preprocessing": false,
+                            "scaleproc": null,
+                            "save_rez_to_mat": false,
+                            "delete_tmp_files": [
+                                "matlab_files"
+                            ],
+                            "delete_recording_dat": false,
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_process": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T03:12:24.613533Z",
+                "end_date_time": "2024-04-01T04:59:29.613533Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS2.5 found 712 units, 712 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort25",
+                    "name": "Spike sorting",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort2_5",
+                        "sorter_params": {
+                            "detect_threshold": 6,
+                            "projection_threshold": [
+                                10,
+                                4
+                            ],
+                            "preclust_threshold": 8,
+                            "momentum": [
+                                20,
+                                400
+                            ],
+                            "car": true,
+                            "minFR": 0.1,
+                            "minfr_goodchannels": 0.1,
+                            "nblocks": 5,
+                            "sig": 20,
+                            "freq_min": 150,
+                            "sigmaMask": 30,
+                            "lam": 10,
+                            "nPCs": 3,
+                            "ntbuff": 64,
+                            "nfilt_factor": 4,
+                            "NT": 65600,
+                            "AUCsplit": 0.9,
+                            "do_correction": true,
+                            "wave_length": 61,
+                            "keep_good_only": false,
+                            "skip_kilosort_preprocessing": false,
+                            "scaleproc": null,
+                            "save_rez_to_mat": false,
+                            "delete_tmp_files": [
+                                "matlab_files"
+                            ],
+                            "delete_recording_dat": false,
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_process": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T03:15:04.946458Z",
+                "end_date_time": "2024-04-01T04:50:27.946458Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS2.5 found 289 units, 289 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort25",
+                    "name": "Spike sorting",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort2_5",
+                        "sorter_params": {
+                            "detect_threshold": 6,
+                            "projection_threshold": [
+                                10,
+                                4
+                            ],
+                            "preclust_threshold": 8,
+                            "momentum": [
+                                20,
+                                400
+                            ],
+                            "car": true,
+                            "minFR": 0.1,
+                            "minfr_goodchannels": 0.1,
+                            "nblocks": 5,
+                            "sig": 20,
+                            "freq_min": 150,
+                            "sigmaMask": 30,
+                            "lam": 10,
+                            "nPCs": 3,
+                            "ntbuff": 64,
+                            "nfilt_factor": 4,
+                            "NT": 65600,
+                            "AUCsplit": 0.9,
+                            "do_correction": true,
+                            "wave_length": 61,
+                            "keep_good_only": false,
+                            "skip_kilosort_preprocessing": false,
+                            "scaleproc": null,
+                            "save_rez_to_mat": false,
+                            "delete_tmp_files": [
+                                "matlab_files"
+                            ],
+                            "delete_recording_dat": false,
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_process": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T03:16:57.383490Z",
+                "end_date_time": "2024-04-01T04:50:03.383490Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS2.5 found 325 units, 325 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Spike sorting",
+                "name": "Spike sorting_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-spikesort-kilosort25",
+                    "name": "Spike sorting",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "sorter_name": "kilosort2_5",
+                        "sorter_params": {
+                            "detect_threshold": 6,
+                            "projection_threshold": [
+                                10,
+                                4
+                            ],
+                            "preclust_threshold": 8,
+                            "momentum": [
+                                20,
+                                400
+                            ],
+                            "car": true,
+                            "minFR": 0.1,
+                            "minfr_goodchannels": 0.1,
+                            "nblocks": 5,
+                            "sig": 20,
+                            "freq_min": 150,
+                            "sigmaMask": 30,
+                            "lam": 10,
+                            "nPCs": 3,
+                            "ntbuff": 64,
+                            "nfilt_factor": 4,
+                            "NT": 65600,
+                            "AUCsplit": 0.9,
+                            "do_correction": true,
+                            "wave_length": 61,
+                            "keep_good_only": false,
+                            "skip_kilosort_preprocessing": false,
+                            "scaleproc": null,
+                            "save_rez_to_mat": false,
+                            "delete_tmp_files": [
+                                "matlab_files"
+                            ],
+                            "delete_recording_dat": false,
+                            "n_jobs": 16,
+                            "chunk_duration": "1s",
+                            "progress_bar": false,
+                            "mp_context": null,
+                            "max_threads_per_process": 1
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T03:19:04.810643Z",
+                "end_date_time": "2024-04-01T05:21:05.810643Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "empty_units": 0
+                },
+                "notes": "\n- KS2.5 found 666 units, 666 after removing empty templates.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": "Ephys postprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "waveforms_deduplicate": {
+                            "ms_before": 0.5,
+                            "ms_after": 1.5,
+                            "max_spikes_per_unit": 100,
+                            "return_scaled": false,
+                            "dtype": null,
+                            "sparse": false,
+                            "precompute_template": [
+                                "average"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "max_spikes_per_unit": 500,
+                            "return_scaled": true,
+                            "dtype": null,
+                            "precompute_template": [
+                                "average",
+                                "std"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "spike_amplitudes": {
+                            "peak_sign": "neg",
+                            "return_scaled": true,
+                            "outputs": "concatenated"
+                        },
+                        "similarity": {
+                            "method": "cosine_similarity"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isis": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeC-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T05:45:43.910416Z",
+                "end_date_time": "2024-04-01T06:57:39.910416Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 3
+                },
+                "notes": "\n- Removed 3 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": "Ephys postprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "waveforms_deduplicate": {
+                            "ms_before": 0.5,
+                            "ms_after": 1.5,
+                            "max_spikes_per_unit": 100,
+                            "return_scaled": false,
+                            "dtype": null,
+                            "sparse": false,
+                            "precompute_template": [
+                                "average"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "max_spikes_per_unit": 500,
+                            "return_scaled": true,
+                            "dtype": null,
+                            "precompute_template": [
+                                "average",
+                                "std"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "spike_amplitudes": {
+                            "peak_sign": "neg",
+                            "return_scaled": true,
+                            "outputs": "concatenated"
+                        },
+                        "similarity": {
+                            "method": "cosine_similarity"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isis": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeF-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T05:46:55.199792Z",
+                "end_date_time": "2024-04-01T06:12:10.199792Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 1
+                },
+                "notes": "\n- Removed 1 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": "Ephys postprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "waveforms_deduplicate": {
+                            "ms_before": 0.5,
+                            "ms_after": 1.5,
+                            "max_spikes_per_unit": 100,
+                            "return_scaled": false,
+                            "dtype": null,
+                            "sparse": false,
+                            "precompute_template": [
+                                "average"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "max_spikes_per_unit": 500,
+                            "return_scaled": true,
+                            "dtype": null,
+                            "precompute_template": [
+                                "average",
+                                "std"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "spike_amplitudes": {
+                            "peak_sign": "neg",
+                            "return_scaled": true,
+                            "outputs": "concatenated"
+                        },
+                        "similarity": {
+                            "method": "cosine_similarity"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isis": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeD-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T05:48:44.733223Z",
+                "end_date_time": "2024-04-01T06:41:48.733223Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 1
+                },
+                "notes": "\n- Removed 1 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": "Ephys postprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "waveforms_deduplicate": {
+                            "ms_before": 0.5,
+                            "ms_after": 1.5,
+                            "max_spikes_per_unit": 100,
+                            "return_scaled": false,
+                            "dtype": null,
+                            "sparse": false,
+                            "precompute_template": [
+                                "average"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "max_spikes_per_unit": 500,
+                            "return_scaled": true,
+                            "dtype": null,
+                            "precompute_template": [
+                                "average",
+                                "std"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "spike_amplitudes": {
+                            "peak_sign": "neg",
+                            "return_scaled": true,
+                            "outputs": "concatenated"
+                        },
+                        "similarity": {
+                            "method": "cosine_similarity"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isis": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeA-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T05:56:33.091772Z",
+                "end_date_time": "2024-04-01T07:43:06.091772Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 21
+                },
+                "notes": "\n- Removed 21 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": "Ephys postprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "waveforms_deduplicate": {
+                            "ms_before": 0.5,
+                            "ms_after": 1.5,
+                            "max_spikes_per_unit": 100,
+                            "return_scaled": false,
+                            "dtype": null,
+                            "sparse": false,
+                            "precompute_template": [
+                                "average"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "max_spikes_per_unit": 500,
+                            "return_scaled": true,
+                            "dtype": null,
+                            "precompute_template": [
+                                "average",
+                                "std"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "spike_amplitudes": {
+                            "peak_sign": "neg",
+                            "return_scaled": true,
+                            "outputs": "concatenated"
+                        },
+                        "similarity": {
+                            "method": "cosine_similarity"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isis": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeB-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T05:58:16.834785Z",
+                "end_date_time": "2024-04-01T06:40:59.834785Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 10
+                },
+                "notes": "\n- Removed 10 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys postprocessing",
+                "name": "Ephys postprocessing_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-postprocessing",
+                    "name": "Ephys postprocessing",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "duplicate_threshold": 0.9,
+                        "waveforms_deduplicate": {
+                            "ms_before": 0.5,
+                            "ms_after": 1.5,
+                            "max_spikes_per_unit": 100,
+                            "return_scaled": false,
+                            "dtype": null,
+                            "sparse": false,
+                            "precompute_template": [
+                                "average"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "waveforms": {
+                            "ms_before": 3,
+                            "ms_after": 4,
+                            "max_spikes_per_unit": 500,
+                            "return_scaled": true,
+                            "dtype": null,
+                            "precompute_template": [
+                                "average",
+                                "std"
+                            ],
+                            "use_relative_path": true
+                        },
+                        "spike_amplitudes": {
+                            "peak_sign": "neg",
+                            "return_scaled": true,
+                            "outputs": "concatenated"
+                        },
+                        "similarity": {
+                            "method": "cosine_similarity"
+                        },
+                        "correlograms": {
+                            "window_ms": 50,
+                            "bin_ms": 1
+                        },
+                        "isis": {
+                            "window_ms": 100,
+                            "bin_ms": 5
+                        },
+                        "unit_locations": {
+                            "method": "monopolar_triangulation"
+                        },
+                        "spike_locations": {
+                            "method": "grid_convolution"
+                        },
+                        "template_metrics": {
+                            "upsampling_factor": 10,
+                            "sparsity": null,
+                            "include_multi_channel_metrics": true
+                        },
+                        "principal_components": {
+                            "n_components": 5,
+                            "mode": "by_channel_local",
+                            "whiten": true
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeE-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:02:21.230044Z",
+                "end_date_time": "2024-04-01T06:46:57.230044Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "duplicated_units": 2
+                },
+                "notes": "\n- Removed 2 duplicated units.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_7",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-unit-classifier",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "unit_classifier_model": "unit_classifier_models_v1.0",
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeF-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:14:25.409048Z",
+                "end_date_time": "2024-04-01T06:14:25.409048Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 324,
+                    "noise_units": 7,
+                    "neuronal_units": 317,
+                    "sua_units": 153,
+                    "mua_units": 164
+                },
+                "notes": "NOISE: 7 / 324\nSUA: 153 / 324\nMUA: 164 / 324\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "isi_violations_ratio_threshold": 0.5,
+                        "presence_ratio_threshold": 0.8,
+                        "amplitude_cutoff_threshold": 0.1,
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeF-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:14:53.981746Z",
+                "end_date_time": "2024-04-01T06:14:55.981746Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 324,
+                    "passing_qc": 133,
+                    "failing_qc": 191
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\n133/324 passing default QC.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "isi_violations_ratio_threshold": 0.5,
+                        "presence_ratio_threshold": 0.8,
+                        "amplitude_cutoff_threshold": 0.1,
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeB-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:43:08.844063Z",
+                "end_date_time": "2024-04-01T06:43:09.844063Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 495,
+                    "passing_qc": 215,
+                    "failing_qc": 280
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\n215/495 passing default QC.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_8",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-unit-classifier",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "unit_classifier_model": "unit_classifier_models_v1.0",
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeB-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:43:11.415210Z",
+                "end_date_time": "2024-04-01T06:43:12.415210Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 495,
+                    "noise_units": 62,
+                    "neuronal_units": 433,
+                    "sua_units": 271,
+                    "mua_units": 162
+                },
+                "notes": "NOISE: 62 / 495\nSUA: 271 / 495\nMUA: 162 / 495\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "isi_violations_ratio_threshold": 0.5,
+                        "presence_ratio_threshold": 0.8,
+                        "amplitude_cutoff_threshold": 0.1,
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeD-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:44:27.734566Z",
+                "end_date_time": "2024-04-01T06:44:28.734566Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 418,
+                    "passing_qc": 237,
+                    "failing_qc": 181
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\n237/418 passing default QC.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_9",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-unit-classifier",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "unit_classifier_model": "unit_classifier_models_v1.0",
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeD-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:45:22.071755Z",
+                "end_date_time": "2024-04-01T06:45:22.071755Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 418,
+                    "noise_units": 19,
+                    "neuronal_units": 399,
+                    "sua_units": 255,
+                    "mua_units": 144
+                },
+                "notes": "NOISE: 19 / 418\nSUA: 255 / 418\nMUA: 144 / 418\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "isi_violations_ratio_threshold": 0.5,
+                        "presence_ratio_threshold": 0.8,
+                        "amplitude_cutoff_threshold": 0.1,
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeE-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:49:07.371251Z",
+                "end_date_time": "2024-04-01T06:49:08.371251Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 287,
+                    "passing_qc": 198,
+                    "failing_qc": 89
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\n198/287 passing default QC.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_10",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-unit-classifier",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "unit_classifier_model": "unit_classifier_models_v1.0",
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeE-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T06:49:11.996936Z",
+                "end_date_time": "2024-04-01T06:49:20.996936Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 287,
+                    "noise_units": 19,
+                    "neuronal_units": 268,
+                    "sua_units": 216,
+                    "mua_units": 52
+                },
+                "notes": "NOISE: 19 / 287\nSUA: 216 / 287\nMUA: 52 / 287\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_11",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-unit-classifier",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "unit_classifier_model": "unit_classifier_models_v1.0",
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeC-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T07:00:26.717710Z",
+                "end_date_time": "2024-04-01T07:00:42.717710Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 663,
+                    "noise_units": 22,
+                    "neuronal_units": 641,
+                    "sua_units": 465,
+                    "mua_units": 176
+                },
+                "notes": "NOISE: 22 / 663\nSUA: 465 / 663\nMUA: 176 / 663\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "isi_violations_ratio_threshold": 0.5,
+                        "presence_ratio_threshold": 0.8,
+                        "amplitude_cutoff_threshold": 0.1,
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeC-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T07:01:27.564477Z",
+                "end_date_time": "2024-04-01T07:02:01.564477Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 663,
+                    "passing_qc": 444,
+                    "failing_qc": 219
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\n444/663 passing default QC.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-curation",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "isi_violations_ratio_threshold": 0.5,
+                        "presence_ratio_threshold": 0.8,
+                        "amplitude_cutoff_threshold": 0.1,
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeA-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T07:46:46.887739Z",
+                "end_date_time": "2024-04-01T07:47:06.887739Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 691,
+                    "passing_qc": 367,
+                    "failing_qc": 324
+                },
+                "notes": "Curation query: isi_violations_ratio < 0.5 and presence_ratio > 0.8 and amplitude_cutoff < 0.1\n367/691 passing default QC.\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys curation",
+                "name": "Ephys curation_12",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-unit-classifier",
+                    "name": "Ephys curation",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "unit_classifier_model": "unit_classifier_models_v1.0",
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeA-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T07:46:50.021350Z",
+                "end_date_time": "2024-04-01T07:46:50.021350Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "total_units": 691,
+                    "noise_units": 30,
+                    "neuronal_units": 661,
+                    "sua_units": 435,
+                    "mua_units": 226
+                },
+                "notes": "NOISE: 30 / 691\nSUA: 435 / 691\nMUA: 226 / 691\n",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": "Ephys visualization",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5,
+                            "skip": false
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeE-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T08:35:02.481323Z",
+                "end_date_time": "2024-04-01T08:41:20.481323Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://6c9f8d715948e4d06af7746815f5c3430ccf00f4&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeE-AP_recording1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://b123cacb2b2243559c381a954bc3fd13272f18ad&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 103#Neuropix-PXI-100.ProbeE-AP_recording1/kilosort2_5/curation.json\"}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeE-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://6c9f8d715948e4d06af7746815f5c3430ccf00f4&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeE-AP_recording1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://b123cacb2b2243559c381a954bc3fd13272f18ad&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 103%23Neuropix-PXI-100.ProbeE-AP_recording1/kilosort2_5/curation.json%22}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeE-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_3",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": "Ephys visualization",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5,
+                            "skip": false
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeA-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T08:35:02.754621Z",
+                "end_date_time": "2024-04-01T08:43:00.754621Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://d86fa853ae3658ea02fd8adefd842f579b2037fa&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeA-AP_recording1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://abaceb36ba668c79a71e5080b7f044e91adc4c20&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 102#Neuropix-PXI-100.ProbeA-AP_recording1/kilosort2_5/curation.json\"}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeA-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://d86fa853ae3658ea02fd8adefd842f579b2037fa&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeA-AP_recording1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://abaceb36ba668c79a71e5080b7f044e91adc4c20&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 102%23Neuropix-PXI-100.ProbeA-AP_recording1/kilosort2_5/curation.json%22}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeA-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_2",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": "Ephys visualization",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5,
+                            "skip": false
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeD-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T08:35:02.899469Z",
+                "end_date_time": "2024-04-01T08:41:50.899469Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://8c83d36799cb7c216601ee8257d0628fe4b0a22b&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeD-AP_recording1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://055919db9a1e4e3705f78a15056fbf56399a3eb7&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 103#Neuropix-PXI-100.ProbeD-AP_recording1/kilosort2_5/curation.json\"}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeD-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://8c83d36799cb7c216601ee8257d0628fe4b0a22b&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeD-AP_recording1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://055919db9a1e4e3705f78a15056fbf56399a3eb7&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 103%23Neuropix-PXI-100.ProbeD-AP_recording1/kilosort2_5/curation.json%22}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeD-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_4",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": "Ephys visualization",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5,
+                            "skip": false
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 103#Neuropix-PXI-100.ProbeF-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T08:49:50.731703Z",
+                "end_date_time": "2024-04-01T08:56:47.731703Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://abebac00b554cfb08f1d3a6b832181f62157a7aa&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeF-AP_recording1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://e511e9445873e5dc6899f7d1e0578cf336264c52&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 103#Neuropix-PXI-100.ProbeF-AP_recording1/kilosort2_5/curation.json\"}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeF-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://abebac00b554cfb08f1d3a6b832181f62157a7aa&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeF-AP_recording1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://e511e9445873e5dc6899f7d1e0578cf336264c52&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 103%23Neuropix-PXI-100.ProbeF-AP_recording1/kilosort2_5/curation.json%22}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20103%23Neuropix-PXI-100.ProbeF-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_5",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": "Ephys visualization",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5,
+                            "skip": false
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeC-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T08:49:50.734769Z",
+                "end_date_time": "2024-04-01T08:59:49.734769Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://a4158ccd310acd0ff1235900af94702c84aff19c&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeC-AP_recording1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://cdb68c53935338f9e3eccda996aeb351a8f37833&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 102#Neuropix-PXI-100.ProbeC-AP_recording1/kilosort2_5/curation.json\"}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeC-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://a4158ccd310acd0ff1235900af94702c84aff19c&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeC-AP_recording1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://cdb68c53935338f9e3eccda996aeb351a8f37833&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 102%23Neuropix-PXI-100.ProbeC-AP_recording1/kilosort2_5/curation.json%22}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeC-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Ephys visualization",
+                "name": "Ephys visualization_6",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/aind-ephys-visualization",
+                    "name": "Ephys visualization",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "timeseries": {
+                            "n_snippets_per_segment": 2,
+                            "snippet_duration_s": 0.5,
+                            "skip": false
+                        },
+                        "drift": {
+                            "detection": {
+                                "peak_sign": "neg",
+                                "detect_threshold": 5,
+                                "exclude_sweep_ms": 0.1
+                            },
+                            "localization": {
+                                "ms_before": 0.1,
+                                "ms_after": 0.3,
+                                "radius_um": 100
+                            },
+                            "n_skip": 30,
+                            "alpha": 0.15,
+                            "vmin": -200,
+                            "vmax": 0,
+                            "cmap": "Greys_r",
+                            "figsize": [
+                                10,
+                                10
+                            ]
+                        },
+                        "motion": {
+                            "cmap": "Greys_r",
+                            "scatter_decimate": 15,
+                            "figsize": [
+                                15,
+                                10
+                            ]
+                        },
+                        "recording_name": "experiment2_Record Node 102#Neuropix-PXI-100.ProbeB-AP_recording1"
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Alessio Buccino"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2024-04-01T09:07:14.989782Z",
+                "end_date_time": "2024-04-01T09:12:17.989782Z",
+                "output_path": "../results",
+                "output_parameters": {
+                    "timeseries": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://652fb7d3c2426033288e8097d130f4f47109c55e&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeB-AP_recording1&zone=aind",
+                    "sorting_summary": "https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://016b34b5751f8c840528ebddbef5a2c6e19c40e7&s={\"sortingCuration\":\"gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 102#Neuropix-PXI-100.ProbeB-AP_recording1/kilosort2_5/curation.json\"}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeB-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind"
+                },
+                "notes": "{\n    \"timeseries\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://652fb7d3c2426033288e8097d130f4f47109c55e&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeB-AP_recording1&zone=aind\",\n    \"sorting_summary\": \"https://figurl.org/f?v=npm://@fi-sci/figurl-sortingview@12/dist&d=sha1://016b34b5751f8c840528ebddbef5a2c6e19c40e7&s={%22sortingCuration%22:%22gh://AllenNeuralDynamics/ephys-sorting-manual-curation/main/ecephys_668755_2023-08-31_12-33-31/experiment2_Record Node 102%23Neuropix-PXI-100.ProbeB-AP_recording1/kilosort2_5/curation.json%22}&label=ecephys_668755_2023-08-31_12-33-31%20-%20experiment2_Record%20Node%20102%23Neuropix-PXI-100.ProbeB-AP_recording1%20-%20kilosort2_5%20-%20Sorting%20Summary&zone=aind\"\n}",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "Other",
+                "name": "Other_1",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenNeuralDynamics/lightning_pose_CO_capsule",
+                    "name": "Other",
+                    "version": null,
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": {
+                        "face camera parameters": {
+                            "callbacks": {
+                                "anneal_weight": {
+                                    "attr_name": "total_unsupervised_importance",
+                                    "final_val": 1,
+                                    "freeze_until_epoch": 0,
+                                    "increase_factor": 0.01,
+                                    "init_val": 0
+                                }
+                            },
+                            "dali": {
+                                "base": {
+                                    "predict": {
+                                        "sequence_length": 96
+                                    },
+                                    "train": {
+                                        "sequence_length": 32
+                                    }
+                                },
+                                "context": {
+                                    "predict": {
+                                        "sequence_length": 96
+                                    },
+                                    "train": {
+                                        "batch_size": 16
+                                    }
+                                },
+                                "general": {
+                                    "seed": 123456
+                                }
+                            },
+                            "data": {
+                                "columns_for_singleview_pca": [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    9,
+                                    10
+                                ],
+                                "csv_file": "/root/capsule/results/CollectedData.masked.csv",
+                                "data_dir": "/root/capsule/results",
+                                "detector": {
+                                    "downsample_factor": 2,
+                                    "image_resize_dims": {
+                                        "height": null,
+                                        "width": null
+                                    },
+                                    "keypoint_names": null,
+                                    "keypoints_for_crop": null,
+                                    "num_keypoints": null
+                                },
+                                "downsample_factor": 2,
+                                "dynamic_crop": false,
+                                "image_resize_dims": {
+                                    "height": 384,
+                                    "width": 384
+                                },
+                                "keypoint_names": null,
+                                "mirrored_column_matches": null,
+                                "num_keypoints": 11,
+                                "num_max_instances": 1,
+                                "video_dir": "/root/capsule/results/videos/"
+                            },
+                            "eval": {
+                                "confidence_thresh_for_vid": 0.9,
+                                "fiftyone": {
+                                    "address": "127.0.0.1",
+                                    "dataset_name": "test",
+                                    "launch_app_from_script": false,
+                                    "model_display_names": [
+                                        "test_model"
+                                    ],
+                                    "port": 5151,
+                                    "remote": true
+                                },
+                                "hydra_paths": [
+                                    " "
+                                ],
+                                "pred_csv_files_to_plot": [
+                                    " "
+                                ],
+                                "predict_vids_after_training": true,
+                                "save_vids_after_training": false,
+                                "saved_vid_preds_dir": null,
+                                "test_videos_directory": "/root/capsule/results/videos/",
+                                "video_file_to_plot": null
+                            },
+                            "hydra": {
+                                "run": {
+                                    "dir": "outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}"
+                                },
+                                "sweep": {
+                                    "dir": "multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}",
+                                    "subdir": "${hydra.job.num}"
+                                }
+                            },
+                            "losses": {
+                                "pca_multiview": {
+                                    "components_to_keep": 3,
+                                    "epsilon": null,
+                                    "log_weight": 5
+                                },
+                                "pca_singleview": {
+                                    "components_to_keep": 0.99,
+                                    "epsilon": null,
+                                    "log_weight": 5
+                                },
+                                "temporal": {
+                                    "epsilon": 20,
+                                    "log_weight": 5,
+                                    "prob_threshold": 0.05
+                                }
+                            },
+                            "model": {
+                                "backbone": "resnet50_animal_ap10k",
+                                "heatmap_loss_type": "mse",
+                                "losses_to_use": [
+                                    "pca_singleview",
+                                    "temporal"
+                                ],
+                                "model_name": "test",
+                                "model_type": "heatmap"
+                            },
+                            "training": {
+                                "check_val_every_n_epoch": 5,
+                                "early_stop_patience": 3,
+                                "gpu_id": 0,
+                                "imgaug": "dlc",
+                                "log_every_n_steps": 10,
+                                "lr_scheduler": "multisteplr",
+                                "lr_scheduler_params": {
+                                    "multisteplr": {
+                                        "gamma": 0.5,
+                                        "milestones": [
+                                            150,
+                                            200,
+                                            250
+                                        ]
+                                    }
+                                },
+                                "max_epochs": 300,
+                                "min_epochs": 300,
+                                "num_gpus": 1,
+                                "num_workers": 4,
+                                "rng_seed_data_pt": 0,
+                                "rng_seed_model_pt": 0,
+                                "test_batch_size": 32,
+                                "train_batch_size": 16,
+                                "train_frames": 1,
+                                "train_prob": 0.8,
+                                "unfreezing_epoch": 20,
+                                "uniform_heatmaps_for_nan_keypoints": true,
+                                "val_batch_size": 32,
+                                "val_prob": 0.1
+                            }
+                        },
+                        "side camera parameters": {
+                            "callbacks": {
+                                "anneal_weight": {
+                                    "attr_name": "total_unsupervised_importance",
+                                    "final_val": 1,
+                                    "freeze_until_epoch": 0,
+                                    "increase_factor": 0.01,
+                                    "init_val": 0
+                                }
+                            },
+                            "dali": {
+                                "base": {
+                                    "predict": {
+                                        "sequence_length": 96
+                                    },
+                                    "train": {
+                                        "sequence_length": 32
+                                    }
+                                },
+                                "context": {
+                                    "predict": {
+                                        "sequence_length": 96
+                                    },
+                                    "train": {
+                                        "batch_size": 16
+                                    }
+                                },
+                                "general": {
+                                    "seed": 123456
+                                }
+                            },
+                            "data": {
+                                "columns_for_singleview_pca": [
+                                    0,
+                                    1,
+                                    2,
+                                    3,
+                                    4,
+                                    5,
+                                    6,
+                                    7,
+                                    9,
+                                    10
+                                ],
+                                "csv_file": "/root/capsule/results/CollectedData.masked.csv",
+                                "data_dir": "/root/capsule/results",
+                                "detector": {
+                                    "downsample_factor": 2,
+                                    "image_resize_dims": {
+                                        "height": null,
+                                        "width": null
+                                    },
+                                    "keypoint_names": null,
+                                    "keypoints_for_crop": null,
+                                    "num_keypoints": null
+                                },
+                                "downsample_factor": 2,
+                                "dynamic_crop": false,
+                                "image_resize_dims": {
+                                    "height": 384,
+                                    "width": 384
+                                },
+                                "keypoint_names": null,
+                                "mirrored_column_matches": null,
+                                "num_keypoints": 11,
+                                "num_max_instances": 1,
+                                "video_dir": "/root/capsule/results/videos/"
+                            },
+                            "eval": {
+                                "confidence_thresh_for_vid": 0.9,
+                                "fiftyone": {
+                                    "address": "127.0.0.1",
+                                    "dataset_name": "test",
+                                    "launch_app_from_script": false,
+                                    "model_display_names": [
+                                        "test_model"
+                                    ],
+                                    "port": 5151,
+                                    "remote": true
+                                },
+                                "hydra_paths": [
+                                    " "
+                                ],
+                                "pred_csv_files_to_plot": [
+                                    " "
+                                ],
+                                "predict_vids_after_training": true,
+                                "save_vids_after_training": false,
+                                "saved_vid_preds_dir": null,
+                                "test_videos_directory": "/root/capsule/results/videos/",
+                                "video_file_to_plot": null
+                            },
+                            "hydra": {
+                                "run": {
+                                    "dir": "outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}"
+                                },
+                                "sweep": {
+                                    "dir": "multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}",
+                                    "subdir": "${hydra.job.num}"
+                                }
+                            },
+                            "losses": {
+                                "pca_multiview": {
+                                    "components_to_keep": 3,
+                                    "epsilon": null,
+                                    "log_weight": 5
+                                },
+                                "pca_singleview": {
+                                    "components_to_keep": 0.99,
+                                    "epsilon": null,
+                                    "log_weight": 5
+                                },
+                                "temporal": {
+                                    "epsilon": 20,
+                                    "log_weight": 5,
+                                    "prob_threshold": 0.05
+                                }
+                            },
+                            "model": {
+                                "backbone": "resnet50_animal_ap10k",
+                                "heatmap_loss_type": "mse",
+                                "losses_to_use": [
+                                    "pca_singleview",
+                                    "temporal"
+                                ],
+                                "model_name": "test",
+                                "model_type": "heatmap"
+                            },
+                            "training": {
+                                "check_val_every_n_epoch": 5,
+                                "early_stop_patience": 3,
+                                "gpu_id": 0,
+                                "imgaug": "dlc",
+                                "log_every_n_steps": 10,
+                                "lr_scheduler": "multisteplr",
+                                "lr_scheduler_params": {
+                                    "multisteplr": {
+                                        "gamma": 0.5,
+                                        "milestones": [
+                                            150,
+                                            200,
+                                            250
+                                        ]
+                                    }
+                                },
+                                "max_epochs": 300,
+                                "min_epochs": 300,
+                                "num_gpus": 1,
+                                "num_workers": 4,
+                                "rng_seed_data_pt": 0,
+                                "rng_seed_model_pt": 0,
+                                "test_batch_size": 32,
+                                "train_batch_size": 16,
+                                "train_frames": 1,
+                                "train_prob": 0.8,
+                                "unfreezing_epoch": 20,
+                                "uniform_heatmaps_for_nan_keypoints": true,
+                                "val_batch_size": 32,
+                                "val_prob": 0.1
+                            }
+                        }
+                    },
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Shailaja Akella"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2025-01-18T16:53:00.421345Z",
+                "end_date_time": "2025-01-18T17:39:41.380248Z",
+                "output_path": "/results",
+                "output_parameters": {},
+                "notes": "Lightning Pose Posture Tracking",
+                "resources": null
+            },
+            {
+                "object_type": "Data process",
+                "process_type": "File format conversion",
+                "name": "File format conversion",
+                "stage": "Processing",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://github.com/AllenInstitute/npc_sessions",
+                    "name": null,
+                    "version": "0.0.280",
+                    "container": null,
+                    "run_script": null,
+                    "language": null,
+                    "language_version": null,
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": null
+                },
+                "experimenters": [
+                    "Ben Hardcastle"
+                ],
+                "pipeline_name": null,
+                "start_date_time": "2026-05-01T13:05:01-07:00",
+                "end_date_time": "2026-05-01T13:19:39-07:00",
+                "output_path": null,
+                "output_parameters": null,
+                "notes": null,
+                "resources": null
+            }
+        ],
+        "pipelines": null,
+        "notes": "Processes were reordered by start_date_time; Processes were reordered by start_date_time",
+        "dependency_graph": {
+            "Other_1": [],
+            "Ephys preprocessing_1": [
+                "Other_1"
+            ],
+            "Ephys preprocessing_2": [
+                "Ephys preprocessing_1"
+            ],
+            "Ephys preprocessing_3": [
+                "Ephys preprocessing_2"
+            ],
+            "Ephys preprocessing_4": [
+                "Ephys preprocessing_3"
+            ],
+            "Ephys preprocessing_5": [
+                "Ephys preprocessing_4"
+            ],
+            "Ephys preprocessing_6": [
+                "Ephys preprocessing_5"
+            ],
+            "Ephys preprocessing_7": [
+                "Ephys preprocessing_6"
+            ],
+            "Spike sorting_1": [
+                "Ephys preprocessing_7"
+            ],
+            "Spike sorting_2": [
+                "Spike sorting_1"
+            ],
+            "Spike sorting_3": [
+                "Spike sorting_2"
+            ],
+            "Spike sorting_4": [
+                "Spike sorting_3"
+            ],
+            "Spike sorting_5": [
+                "Spike sorting_4"
+            ],
+            "Spike sorting_6": [
+                "Spike sorting_5"
+            ],
+            "Ephys postprocessing_1": [
+                "Spike sorting_6"
+            ],
+            "Ephys postprocessing_2": [
+                "Ephys postprocessing_1"
+            ],
+            "Ephys postprocessing_3": [
+                "Ephys postprocessing_2"
+            ],
+            "Ephys postprocessing_4": [
+                "Ephys postprocessing_3"
+            ],
+            "Ephys postprocessing_5": [
+                "Ephys postprocessing_4"
+            ],
+            "Ephys postprocessing_6": [
+                "Ephys postprocessing_5"
+            ],
+            "Ephys curation_1": [
+                "Ephys postprocessing_6"
+            ],
+            "Ephys curation_2": [
+                "Ephys curation_1"
+            ],
+            "Ephys curation_3": [
+                "Ephys curation_2"
+            ],
+            "Ephys curation_4": [
+                "Ephys curation_3"
+            ],
+            "Ephys curation_5": [
+                "Ephys curation_4"
+            ],
+            "Ephys curation_6": [
+                "Ephys curation_5"
+            ],
+            "Ephys curation_7": [
+                "Ephys curation_6"
+            ],
+            "Ephys curation_8": [
+                "Ephys curation_7"
+            ],
+            "Ephys curation_9": [
+                "Ephys curation_8"
+            ],
+            "Ephys curation_10": [
+                "Ephys curation_9"
+            ],
+            "Ephys curation_11": [
+                "Ephys curation_10"
+            ],
+            "Ephys curation_12": [
+                "Ephys curation_11"
+            ],
+            "Ephys visualization_1": [
+                "Ephys curation_12"
+            ],
+            "Ephys visualization_2": [
+                "Ephys visualization_1"
+            ],
+            "Ephys visualization_3": [
+                "Ephys visualization_2"
+            ],
+            "Ephys visualization_4": [
+                "Ephys visualization_3"
+            ],
+            "Ephys visualization_5": [
+                "Ephys visualization_4"
+            ],
+            "Ephys visualization_6": [
+                "Ephys visualization_5"
+            ],
+            "File format conversion": [
+                "Ephys visualization_6"
+            ]
+        }
+    },
+    "acquisition": {
+        "object_type": "Acquisition",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
+        "schema_version": "2.2.3",
+        "subject_id": "668755",
+        "specimen_id": null,
+        "acquisition_start_time": "2023-08-31T12:33:31-07:00",
+        "acquisition_end_time": "2023-08-31T14:29:44.718331Z",
+        "experimenters": [
+            "Hannah Cabasco"
+        ],
+        "protocol_id": null,
+        "ethics_review_id": [
+            "2403"
+        ],
+        "instrument_id": "NP3",
+        "acquisition_type": "brainwide survey",
+        "notes": null,
+        "coordinate_system": null,
+        "calibrations": [],
+        "maintenance": [],
+        "data_streams": [
+            {
+                "object_type": "Data stream",
+                "stream_start_time": "2023-08-31T12:33:31.218331Z",
+                "stream_end_time": "2023-08-31T14:29:44.497900-07:00",
+                "modalities": [
+                    {
+                        "name": "Behavior",
+                        "abbreviation": "behavior"
+                    },
+                    {
+                        "name": "Behavior videos",
+                        "abbreviation": "behavior-videos"
+                    },
+                    {
+                        "name": "Extracellular electrophysiology",
+                        "abbreviation": "ecephys"
+                    }
+                ],
+                "code": [
+                    {
+                        "object_type": "Code",
+                        "url": "https://github.com/AllenInstitute/np_services/blob/main/src/np_services/open_ephys.py",
+                        "name": null,
+                        "version": null,
+                        "container": null,
+                        "run_script": null,
+                        "language": "Python",
+                        "language_version": "3.9",
+                        "input_data": null,
+                        "parameters": null,
+                        "core_dependency": {
+                            "object_type": "Software",
+                            "name": "Open Ephys GUI",
+                            "version": "0.6.4"
+                        }
+                    },
+                    {
+                        "object_type": "Code",
+                        "url": "https://github.com/AllenInstitute/np_services/blob/main/src/np_services/proxies.py",
+                        "name": null,
+                        "version": null,
+                        "container": null,
+                        "run_script": null,
+                        "language": "Python",
+                        "language_version": "3.9",
+                        "input_data": null,
+                        "parameters": null,
+                        "core_dependency": {
+                            "object_type": "Software",
+                            "name": "nidaqmx",
+                            "version": "0.6.2"
+                        }
+                    },
+                    {
+                        "object_type": "Code",
+                        "url": "https://github.com/AllenInstitute/np_services/blob/main/src/np_services/proxies.py",
+                        "name": null,
+                        "version": null,
+                        "container": null,
+                        "run_script": null,
+                        "language": "Python",
+                        "language_version": "3.9",
+                        "input_data": null,
+                        "parameters": null,
+                        "core_dependency": {
+                            "object_type": "Software",
+                            "name": "PsychoPy",
+                            "version": "2022.1.2"
+                        }
+                    },
+                    {
+                        "object_type": "Code",
+                        "url": "https://github.com/AllenInstitute/np_services/blob/main/src/np_services/proxies.py",
+                        "name": null,
+                        "version": null,
+                        "container": null,
+                        "run_script": null,
+                        "language": "Python",
+                        "language_version": "3.9",
+                        "input_data": null,
+                        "parameters": null,
+                        "core_dependency": {
+                            "object_type": "Software",
+                            "name": "MultiVideoRecorder",
+                            "version": "1.1.5+gdbb75c4.b150844"
+                        }
+                    }
+                ],
+                "notes": null,
+                "active_devices": [
+                    "Camstim DAQ",
+                    "Eye camera",
+                    "Front camera",
+                    "Nose camera",
+                    "Opto DAQ",
+                    "Opto laser #1",
+                    "Opto laser #2",
+                    "Opto laser galvo X",
+                    "Opto laser galvo Y",
+                    "Side camera",
+                    "Stimulus microphone",
+                    "Stimulus monitor",
+                    "Stimulus photodiode",
+                    "Stimulus speaker",
+                    "Sync DAQ",
+                    "Sync DAQ",
+                    "TaskControl DAQ",
+                    "probeA",
+                    "probeB",
+                    "probeC",
+                    "probeD",
+                    "probeE",
+                    "probeF"
+                ],
+                "configurations": [
+                    {
+                        "object_type": "Ephys assembly config",
+                        "device_name": "A",
+                        "manipulator": {
+                            "object_type": "Manipulator config",
+                            "device_name": "A",
+                            "coordinate_system": {
+                                "object_type": "Coordinate system",
+                                "name": "probeA XYZ",
+                                "origin": "Tip",
+                                "axes": [
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "X",
+                                        "direction": "Left_to_right"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Y",
+                                        "direction": "Back_to_front"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Z",
+                                        "direction": "Superior_to_inferior"
+                                    }
+                                ],
+                                "axis_unit": "micrometer"
+                            },
+                            "local_axis_positions": {
+                                "object_type": "Translation",
+                                "translation": [
+                                    6505,
+                                    6822.5,
+                                    11067
+                                ]
+                            }
+                        },
+                        "probes": [
+                            {
+                                "object_type": "Probe config",
+                                "device_name": "probeA",
+                                "primary_targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Primary motor area",
+                                    "acronym": "MOp",
+                                    "id": "985"
+                                },
+                                "other_targeted_structure": null,
+                                "atlas_coordinate": null,
+                                "coordinate_system": {
+                                    "object_type": "Coordinate system",
+                                    "name": "probeA XYZ",
+                                    "origin": "Tip",
+                                    "axes": [
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "X",
+                                            "direction": "Left_to_right"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Y",
+                                            "direction": "Back_to_front"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Z",
+                                            "direction": "Superior_to_inferior"
+                                        }
+                                    ],
+                                    "axis_unit": "micrometer"
+                                },
+                                "transform": [
+                                    {
+                                        "object_type": "Translation",
+                                        "translation": [
+                                            6505,
+                                            6822.5,
+                                            11067
+                                        ]
+                                    }
+                                ],
+                                "dye": "DiO",
+                                "notes": null
+                            }
+                        ],
+                        "modules": null
+                    },
+                    {
+                        "object_type": "Ephys assembly config",
+                        "device_name": "B",
+                        "manipulator": {
+                            "object_type": "Manipulator config",
+                            "device_name": "B",
+                            "coordinate_system": {
+                                "object_type": "Coordinate system",
+                                "name": "probeB XYZ",
+                                "origin": "Tip",
+                                "axes": [
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "X",
+                                        "direction": "Left_to_right"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Y",
+                                        "direction": "Back_to_front"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Z",
+                                        "direction": "Superior_to_inferior"
+                                    }
+                                ],
+                                "axis_unit": "micrometer"
+                            },
+                            "local_axis_positions": {
+                                "object_type": "Translation",
+                                "translation": [
+                                    5313.5,
+                                    5524,
+                                    8138.5
+                                ]
+                            }
+                        },
+                        "probes": [
+                            {
+                                "object_type": "Probe config",
+                                "device_name": "probeB",
+                                "primary_targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Secondary motor area",
+                                    "acronym": "MOs",
+                                    "id": "993"
+                                },
+                                "other_targeted_structure": null,
+                                "atlas_coordinate": null,
+                                "coordinate_system": {
+                                    "object_type": "Coordinate system",
+                                    "name": "probeB XYZ",
+                                    "origin": "Tip",
+                                    "axes": [
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "X",
+                                            "direction": "Left_to_right"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Y",
+                                            "direction": "Back_to_front"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Z",
+                                            "direction": "Superior_to_inferior"
+                                        }
+                                    ],
+                                    "axis_unit": "micrometer"
+                                },
+                                "transform": [
+                                    {
+                                        "object_type": "Translation",
+                                        "translation": [
+                                            5313.5,
+                                            5524,
+                                            8138.5
+                                        ]
+                                    }
+                                ],
+                                "dye": "DiO",
+                                "notes": null
+                            }
+                        ],
+                        "modules": null
+                    },
+                    {
+                        "object_type": "Ephys assembly config",
+                        "device_name": "C",
+                        "manipulator": {
+                            "object_type": "Manipulator config",
+                            "device_name": "C",
+                            "coordinate_system": {
+                                "object_type": "Coordinate system",
+                                "name": "probeC XYZ",
+                                "origin": "Tip",
+                                "axes": [
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "X",
+                                        "direction": "Left_to_right"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Y",
+                                        "direction": "Back_to_front"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Z",
+                                        "direction": "Superior_to_inferior"
+                                    }
+                                ],
+                                "axis_unit": "micrometer"
+                            },
+                            "local_axis_positions": {
+                                "object_type": "Translation",
+                                "translation": [
+                                    5288.5,
+                                    10739.5,
+                                    7298
+                                ]
+                            }
+                        },
+                        "probes": [
+                            {
+                                "object_type": "Probe config",
+                                "device_name": "probeC",
+                                "primary_targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Anterior cingulate area, ventral part",
+                                    "acronym": "ACAv",
+                                    "id": "48"
+                                },
+                                "other_targeted_structure": null,
+                                "atlas_coordinate": null,
+                                "coordinate_system": {
+                                    "object_type": "Coordinate system",
+                                    "name": "probeC XYZ",
+                                    "origin": "Tip",
+                                    "axes": [
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "X",
+                                            "direction": "Left_to_right"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Y",
+                                            "direction": "Back_to_front"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Z",
+                                            "direction": "Superior_to_inferior"
+                                        }
+                                    ],
+                                    "axis_unit": "micrometer"
+                                },
+                                "transform": [
+                                    {
+                                        "object_type": "Translation",
+                                        "translation": [
+                                            5288.5,
+                                            10739.5,
+                                            7298
+                                        ]
+                                    }
+                                ],
+                                "dye": "DiO",
+                                "notes": null
+                            }
+                        ],
+                        "modules": null
+                    },
+                    {
+                        "object_type": "Ephys assembly config",
+                        "device_name": "D",
+                        "manipulator": {
+                            "object_type": "Manipulator config",
+                            "device_name": "D",
+                            "coordinate_system": {
+                                "object_type": "Coordinate system",
+                                "name": "probeD XYZ",
+                                "origin": "Tip",
+                                "axes": [
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "X",
+                                        "direction": "Left_to_right"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Y",
+                                        "direction": "Back_to_front"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Z",
+                                        "direction": "Superior_to_inferior"
+                                    }
+                                ],
+                                "axis_unit": "micrometer"
+                            },
+                            "local_axis_positions": {
+                                "object_type": "Translation",
+                                "translation": [
+                                    4037,
+                                    6280.5,
+                                    7500.5
+                                ]
+                            }
+                        },
+                        "probes": [
+                            {
+                                "object_type": "Probe config",
+                                "device_name": "probeD",
+                                "primary_targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Primary visual area",
+                                    "acronym": "VISp",
+                                    "id": "385"
+                                },
+                                "other_targeted_structure": null,
+                                "atlas_coordinate": null,
+                                "coordinate_system": {
+                                    "object_type": "Coordinate system",
+                                    "name": "probeD XYZ",
+                                    "origin": "Tip",
+                                    "axes": [
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "X",
+                                            "direction": "Left_to_right"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Y",
+                                            "direction": "Back_to_front"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Z",
+                                            "direction": "Superior_to_inferior"
+                                        }
+                                    ],
+                                    "axis_unit": "micrometer"
+                                },
+                                "transform": [
+                                    {
+                                        "object_type": "Translation",
+                                        "translation": [
+                                            4037,
+                                            6280.5,
+                                            7500.5
+                                        ]
+                                    }
+                                ],
+                                "dye": "DiO",
+                                "notes": null
+                            }
+                        ],
+                        "modules": null
+                    },
+                    {
+                        "object_type": "Ephys assembly config",
+                        "device_name": "E",
+                        "manipulator": {
+                            "object_type": "Manipulator config",
+                            "device_name": "E",
+                            "coordinate_system": {
+                                "object_type": "Coordinate system",
+                                "name": "probeE XYZ",
+                                "origin": "Tip",
+                                "axes": [
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "X",
+                                        "direction": "Left_to_right"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Y",
+                                        "direction": "Back_to_front"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Z",
+                                        "direction": "Superior_to_inferior"
+                                    }
+                                ],
+                                "axis_unit": "micrometer"
+                            },
+                            "local_axis_positions": {
+                                "object_type": "Translation",
+                                "translation": [
+                                    4827.5,
+                                    9094.5,
+                                    8062.5
+                                ]
+                            }
+                        },
+                        "probes": [
+                            {
+                                "object_type": "Probe config",
+                                "device_name": "probeE",
+                                "primary_targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Anteromedial visual area",
+                                    "acronym": "VISam",
+                                    "id": "394"
+                                },
+                                "other_targeted_structure": null,
+                                "atlas_coordinate": null,
+                                "coordinate_system": {
+                                    "object_type": "Coordinate system",
+                                    "name": "probeE XYZ",
+                                    "origin": "Tip",
+                                    "axes": [
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "X",
+                                            "direction": "Left_to_right"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Y",
+                                            "direction": "Back_to_front"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Z",
+                                            "direction": "Superior_to_inferior"
+                                        }
+                                    ],
+                                    "axis_unit": "micrometer"
+                                },
+                                "transform": [
+                                    {
+                                        "object_type": "Translation",
+                                        "translation": [
+                                            4827.5,
+                                            9094.5,
+                                            8062.5
+                                        ]
+                                    }
+                                ],
+                                "dye": "DiO",
+                                "notes": null
+                            }
+                        ],
+                        "modules": null
+                    },
+                    {
+                        "object_type": "Ephys assembly config",
+                        "device_name": "F",
+                        "manipulator": {
+                            "object_type": "Manipulator config",
+                            "device_name": "F",
+                            "coordinate_system": {
+                                "object_type": "Coordinate system",
+                                "name": "probeF XYZ",
+                                "origin": "Tip",
+                                "axes": [
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "X",
+                                        "direction": "Left_to_right"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Y",
+                                        "direction": "Back_to_front"
+                                    },
+                                    {
+                                        "object_type": "Axis",
+                                        "name": "Z",
+                                        "direction": "Superior_to_inferior"
+                                    }
+                                ],
+                                "axis_unit": "micrometer"
+                            },
+                            "local_axis_positions": {
+                                "object_type": "Translation",
+                                "translation": [
+                                    4964,
+                                    9904,
+                                    9299.5
+                                ]
+                            }
+                        },
+                        "probes": [
+                            {
+                                "object_type": "Probe config",
+                                "device_name": "probeF",
+                                "primary_targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Primary somatosensory area",
+                                    "acronym": "SSp",
+                                    "id": "322"
+                                },
+                                "other_targeted_structure": null,
+                                "atlas_coordinate": null,
+                                "coordinate_system": {
+                                    "object_type": "Coordinate system",
+                                    "name": "probeF XYZ",
+                                    "origin": "Tip",
+                                    "axes": [
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "X",
+                                            "direction": "Left_to_right"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Y",
+                                            "direction": "Back_to_front"
+                                        },
+                                        {
+                                            "object_type": "Axis",
+                                            "name": "Z",
+                                            "direction": "Superior_to_inferior"
+                                        }
+                                    ],
+                                    "axis_unit": "micrometer"
+                                },
+                                "transform": [
+                                    {
+                                        "object_type": "Translation",
+                                        "translation": [
+                                            4964,
+                                            9904,
+                                            9299.5
+                                        ]
+                                    }
+                                ],
+                                "dye": "DiO",
+                                "notes": null
+                            }
+                        ],
+                        "modules": null
+                    }
+                ],
+                "connections": []
+            }
+        ],
+        "stimulus_epochs": [
+            {
+                "object_type": "Stimulus epoch",
+                "stimulus_start_time": "2023-08-31T12:34:31.296490-07:00",
+                "stimulus_end_time": "2023-08-31T12:48:51.417470-07:00",
+                "stimulus_name": "RFMapping",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://raw.githubusercontent.com/samgale/DynamicRoutingTask/5112923a6f7145cf5b800a6a662b01de5e5f6364/RFMapping.py",
+                    "name": null,
+                    "version": "5112923a6f7145cf5b800a6a662b01de5e5f6364",
+                    "container": null,
+                    "run_script": null,
+                    "language": "Python",
+                    "language_version": "3.9",
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": {
+                        "object_type": "Software",
+                        "name": "PsychoPy",
+                        "version": "2022.1.2"
+                    }
+                },
+                "stimulus_modalities": [
+                    "Visual",
+                    "Auditory"
+                ],
+                "performance_metrics": null,
+                "notes": "",
+                "active_devices": [
+                    "Camstim DAQ",
+                    "Stimulus microphone",
+                    "Stimulus monitor",
+                    "Stimulus photodiode",
+                    "Stimulus speaker",
+                    "Sync DAQ",
+                    "TaskControl DAQ"
+                ],
+                "configurations": [
+                    {
+                        "object_type": "Speaker config",
+                        "device_name": "Speaker",
+                        "volume": 68,
+                        "volume_unit": "decibels"
+                    }
+                ],
+                "training_protocol_name": null,
+                "curriculum_status": null
+            },
+            {
+                "object_type": "Stimulus epoch",
+                "stimulus_start_time": "2023-08-31T12:49:08.048220-07:00",
+                "stimulus_end_time": "2023-08-31T12:52:55.605565-07:00",
+                "stimulus_name": "OptoTagging",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://raw.githubusercontent.com/samgale/DynamicRoutingTask/5112923a6f7145cf5b800a6a662b01de5e5f6364/OptoTagging.py",
+                    "name": null,
+                    "version": "5112923a6f7145cf5b800a6a662b01de5e5f6364",
+                    "container": null,
+                    "run_script": null,
+                    "language": "Python",
+                    "language_version": "3.9",
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": {
+                        "object_type": "Software",
+                        "name": "PsychoPy",
+                        "version": "2022.1.2"
+                    }
+                },
+                "stimulus_modalities": [
+                    "Optogenetics"
+                ],
+                "performance_metrics": null,
+                "notes": "",
+                "active_devices": [
+                    "Camstim DAQ",
+                    "Opto DAQ",
+                    "Opto laser #1",
+                    "Opto laser #2",
+                    "Opto laser galvo X",
+                    "Opto laser galvo Y",
+                    "Sync DAQ",
+                    "TaskControl DAQ"
+                ],
+                "configurations": [
+                    {
+                        "object_type": "Laser config",
+                        "device_name": "Opto laser #1",
+                        "wavelength": 488,
+                        "wavelength_unit": "nanometer",
+                        "power": 5,
+                        "power_unit": "milliwatt",
+                        "power_measured_at": "Brain surface"
+                    },
+                    {
+                        "object_type": "Laser config",
+                        "device_name": "Opto laser #2",
+                        "wavelength": 633,
+                        "wavelength_unit": "nanometer",
+                        "power": 5,
+                        "power_unit": "milliwatt",
+                        "power_measured_at": "Brain surface"
+                    }
+                ],
+                "training_protocol_name": null,
+                "curriculum_status": null
+            },
+            {
+                "object_type": "Stimulus epoch",
+                "stimulus_start_time": "2023-08-31T12:53:10.267940-07:00",
+                "stimulus_end_time": "2023-08-31T13:03:12.956435-07:00",
+                "stimulus_name": "Spontaneous",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://raw.githubusercontent.com/samgale/DynamicRoutingTask/5112923a6f7145cf5b800a6a662b01de5e5f6364/TaskControl.py",
+                    "name": null,
+                    "version": "5112923a6f7145cf5b800a6a662b01de5e5f6364",
+                    "container": null,
+                    "run_script": null,
+                    "language": "Python",
+                    "language_version": "3.9",
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": {
+                        "object_type": "Software",
+                        "name": "PsychoPy",
+                        "version": "2022.1.2"
+                    }
+                },
+                "stimulus_modalities": [
+                    "Visual"
+                ],
+                "performance_metrics": null,
+                "notes": "",
+                "active_devices": [
+                    "Camstim DAQ",
+                    "Stimulus monitor",
+                    "Stimulus photodiode",
+                    "Sync DAQ",
+                    "TaskControl DAQ"
+                ],
+                "configurations": [],
+                "training_protocol_name": null,
+                "curriculum_status": null
+            },
+            {
+                "object_type": "Stimulus epoch",
+                "stimulus_start_time": "2023-08-31T13:04:07.435510-07:00",
+                "stimulus_end_time": "2023-08-31T13:14:07.922935-07:00",
+                "stimulus_name": "SpontaneousRewards",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://raw.githubusercontent.com/samgale/DynamicRoutingTask/5112923a6f7145cf5b800a6a662b01de5e5f6364/TaskControl.py",
+                    "name": null,
+                    "version": "5112923a6f7145cf5b800a6a662b01de5e5f6364",
+                    "container": null,
+                    "run_script": null,
+                    "language": "Python",
+                    "language_version": "3.9",
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": {
+                        "object_type": "Software",
+                        "name": "PsychoPy",
+                        "version": "2022.1.2"
+                    }
+                },
+                "stimulus_modalities": [
+                    "Visual"
+                ],
+                "performance_metrics": null,
+                "notes": "",
+                "active_devices": [
+                    "Camstim DAQ",
+                    "Stimulus monitor",
+                    "Stimulus photodiode",
+                    "Sync DAQ",
+                    "TaskControl DAQ"
+                ],
+                "configurations": [],
+                "training_protocol_name": null,
+                "curriculum_status": null
+            },
+            {
+                "object_type": "Stimulus epoch",
+                "stimulus_start_time": "2023-08-31T13:14:22.867360-07:00",
+                "stimulus_end_time": "2023-08-31T14:15:09.958600-07:00",
+                "stimulus_name": "DynamicRouting1",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://raw.githubusercontent.com/samgale/DynamicRoutingTask/5112923a6f7145cf5b800a6a662b01de5e5f6364/DynamicRouting1.py",
+                    "name": null,
+                    "version": "5112923a6f7145cf5b800a6a662b01de5e5f6364",
+                    "container": null,
+                    "run_script": null,
+                    "language": "Python",
+                    "language_version": "3.9",
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": {
+                        "object_type": "Software",
+                        "name": "PsychoPy",
+                        "version": "2022.1.2"
+                    }
+                },
+                "stimulus_modalities": [
+                    "Visual",
+                    "Auditory"
+                ],
+                "performance_metrics": {
+                    "object_type": "Performance metrics",
+                    "output_parameters": {
+                        "block_metrics": {
+                            "0": {
+                                "block_index": 0,
+                                "block_stim_rewarded": "vis1",
+                                "hit_count": 18,
+                                "dprime_same_modal": 3.829011650111114,
+                                "dprime_other_modal_go": 1.1929835410732137
+                            },
+                            "1": {
+                                "block_index": 1,
+                                "block_stim_rewarded": "sound1",
+                                "hit_count": 15,
+                                "dprime_same_modal": 2.3753097209450025,
+                                "dprime_other_modal_go": 1.4565226919873606
+                            },
+                            "2": {
+                                "block_index": 2,
+                                "block_stim_rewarded": "vis1",
+                                "hit_count": 20,
+                                "dprime_same_modal": 3.897895495392883,
+                                "dprime_other_modal_go": 2.3906912838355114
+                            },
+                            "3": {
+                                "block_index": 3,
+                                "block_stim_rewarded": "sound1",
+                                "hit_count": 17,
+                                "dprime_same_modal": 3.0763413930892485,
+                                "dprime_other_modal_go": 1.88950996033343
+                            },
+                            "4": {
+                                "block_index": 4,
+                                "block_stim_rewarded": "vis1",
+                                "hit_count": 19,
+                                "dprime_same_modal": 3.21948307639743,
+                                "dprime_other_modal_go": 1.68458440771703
+                            },
+                            "5": {
+                                "block_index": 5,
+                                "block_stim_rewarded": "sound1",
+                                "hit_count": 20,
+                                "dprime_same_modal": 2.4394696378710043,
+                                "dprime_other_modal_go": 2.484364497248095
+                            }
+                        },
+                        "task_version": "stage 5 ori AMN moving"
+                    },
+                    "reward_consumed_during_epoch": "4.17",
+                    "reward_consumed_unit": "milliliter",
+                    "trials_total": 524,
+                    "trials_finished": null,
+                    "trials_rewarded": 137
+                },
+                "notes": "",
+                "active_devices": [
+                    "Camstim DAQ",
+                    "Stimulus microphone",
+                    "Stimulus monitor",
+                    "Stimulus photodiode",
+                    "Stimulus speaker",
+                    "Sync DAQ",
+                    "TaskControl DAQ"
+                ],
+                "configurations": [
+                    {
+                        "object_type": "Speaker config",
+                        "device_name": "Speaker",
+                        "volume": 68,
+                        "volume_unit": "decibels"
+                    }
+                ],
+                "training_protocol_name": "dynamic_routing",
+                "curriculum_status": "stage 5"
+            },
+            {
+                "object_type": "Stimulus epoch",
+                "stimulus_start_time": "2023-08-31T14:15:25.738630-07:00",
+                "stimulus_end_time": "2023-08-31T14:25:26.226095-07:00",
+                "stimulus_name": "SpontaneousRewards",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://raw.githubusercontent.com/samgale/DynamicRoutingTask/5112923a6f7145cf5b800a6a662b01de5e5f6364/TaskControl.py",
+                    "name": null,
+                    "version": "5112923a6f7145cf5b800a6a662b01de5e5f6364",
+                    "container": null,
+                    "run_script": null,
+                    "language": "Python",
+                    "language_version": "3.9",
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": {
+                        "object_type": "Software",
+                        "name": "PsychoPy",
+                        "version": "2022.1.2"
+                    }
+                },
+                "stimulus_modalities": [
+                    "Visual"
+                ],
+                "performance_metrics": null,
+                "notes": "",
+                "active_devices": [
+                    "Camstim DAQ",
+                    "Stimulus monitor",
+                    "Stimulus photodiode",
+                    "Sync DAQ",
+                    "TaskControl DAQ"
+                ],
+                "configurations": [],
+                "training_protocol_name": null,
+                "curriculum_status": null
+            },
+            {
+                "object_type": "Stimulus epoch",
+                "stimulus_start_time": "2023-08-31T14:25:42.338510-07:00",
+                "stimulus_end_time": "2023-08-31T14:29:31.548100-07:00",
+                "stimulus_name": "OptoTagging",
+                "code": {
+                    "object_type": "Code",
+                    "url": "https://raw.githubusercontent.com/samgale/DynamicRoutingTask/5112923a6f7145cf5b800a6a662b01de5e5f6364/OptoTagging.py",
+                    "name": null,
+                    "version": "5112923a6f7145cf5b800a6a662b01de5e5f6364",
+                    "container": null,
+                    "run_script": null,
+                    "language": "Python",
+                    "language_version": "3.9",
+                    "input_data": null,
+                    "parameters": null,
+                    "core_dependency": {
+                        "object_type": "Software",
+                        "name": "PsychoPy",
+                        "version": "2022.1.2"
+                    }
+                },
+                "stimulus_modalities": [
+                    "Optogenetics"
+                ],
+                "performance_metrics": null,
+                "notes": "",
+                "active_devices": [
+                    "Camstim DAQ",
+                    "Opto DAQ",
+                    "Opto laser #1",
+                    "Opto laser #2",
+                    "Opto laser galvo X",
+                    "Opto laser galvo Y",
+                    "Sync DAQ",
+                    "TaskControl DAQ"
+                ],
+                "configurations": [
+                    {
+                        "object_type": "Laser config",
+                        "device_name": "Opto laser #1",
+                        "wavelength": 488,
+                        "wavelength_unit": "nanometer",
+                        "power": 5,
+                        "power_unit": "milliwatt",
+                        "power_measured_at": "Brain surface"
+                    },
+                    {
+                        "object_type": "Laser config",
+                        "device_name": "Opto laser #2",
+                        "wavelength": 633,
+                        "wavelength_unit": "nanometer",
+                        "power": 5,
+                        "power_unit": "milliwatt",
+                        "power_measured_at": "Brain surface"
+                    }
+                ],
+                "training_protocol_name": null,
+                "curriculum_status": null
+            }
+        ],
+        "manipulations": [],
+        "subject_details": {
+            "object_type": "Acquisition subject details",
+            "animal_weight_prior": null,
+            "animal_weight_post": null,
+            "weight_unit": "gram",
+            "anaesthesia": null,
+            "mouse_platform_name": "Brain Observatory running disc",
+            "reward_consumed_total": "4.17",
+            "reward_consumed_unit": "milliliter"
+        }
+    },
+    "instrument": {
+        "object_type": "Instrument",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
+        "schema_version": "2.2.0",
+        "location": "342",
+        "instrument_id": "NP3",
+        "modification_date": "2023-08-31",
+        "modalities": [
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            },
+            {
+                "name": "Extracellular electrophysiology",
+                "abbreviation": "ecephys"
+            }
+        ],
+        "calibrations": [],
+        "coordinate_system": {
+            "object_type": "Coordinate system",
+            "name": "BREGMA_PRU",
+            "origin": "Bregma",
+            "axes": [
+                {
+                    "object_type": "Axis",
+                    "name": "X",
+                    "direction": "Posterior_to_anterior"
+                },
+                {
+                    "object_type": "Axis",
+                    "name": "Y",
+                    "direction": "Right_to_left"
+                },
+                {
+                    "object_type": "Axis",
+                    "name": "Z",
+                    "direction": "Down_to_up"
+                }
+            ],
+            "axis_unit": "meter"
+        },
+        "temperature_control": null,
+        "notes": null,
+        "connections": [
+            {
+                "object_type": "Connection",
+                "source_device": "Reward delivery assembly",
+                "source_port": null,
+                "target_device": "Camstim DAQ",
+                "target_port": null,
+                "send_and_receive": true
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Brain Observatory running disc",
+                "source_port": null,
+                "target_device": "Camstim DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Stimulus speaker",
+                "source_port": null,
+                "target_device": "TaskControl DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Stimulus photodiode",
+                "source_port": null,
+                "target_device": "Sync DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Front camera",
+                "source_port": null,
+                "target_device": "Sync DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Side camera",
+                "source_port": null,
+                "target_device": "Sync DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Eye camera",
+                "source_port": null,
+                "target_device": "Sync DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Nose camera",
+                "source_port": null,
+                "target_device": "Sync DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Reward spout",
+                "source_port": null,
+                "target_device": "Sync DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Opto laser #1",
+                "source_port": null,
+                "target_device": "Sync DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Opto laser #2",
+                "source_port": null,
+                "target_device": "Sync DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Opto DAQ",
+                "source_port": null,
+                "target_device": "Opto laser #1",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Opto DAQ",
+                "source_port": null,
+                "target_device": "Opto laser #2",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Opto DAQ",
+                "source_port": null,
+                "target_device": "Opto laser galvo X",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Opto DAQ",
+                "source_port": null,
+                "target_device": "Opto laser galvo Y",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Stimulus speaker",
+                "source_port": null,
+                "target_device": "Ephys DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Stimulus microphone",
+                "source_port": null,
+                "target_device": "Ephys DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            },
+            {
+                "object_type": "Connection",
+                "source_device": "Stimulus photodiode",
+                "source_port": null,
+                "target_device": "Ephys DAQ",
+                "target_port": null,
+                "send_and_receive": false
+            }
+        ],
+        "components": [
+            {
+                "object_type": "Disc",
+                "name": "Brain Observatory running disc",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": null,
+                "additional_settings": null,
+                "notes": "Radius is distance from center to subject",
+                "radius": "4.69",
+                "radius_unit": "centimeter",
+                "output": "Digital Output",
+                "encoder": null,
+                "decoder": null,
+                "encoder_firmware": null,
+                "surface_material": "rubber"
+            },
+            {
+                "object_type": "Monitor",
+                "relative_position": [
+                    "Right",
+                    "Anterior",
+                    "Superior"
+                ],
+                "coordinate_system": {
+                    "object_type": "Coordinate system",
+                    "name": "MINDSCOPE_COPA_MONITOR_RDB",
+                    "origin": "Front_center",
+                    "axes": [
+                        {
+                            "object_type": "Axis",
+                            "name": "X",
+                            "direction": "Right_to_left"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Y",
+                            "direction": "Down_to_up"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Z",
+                            "direction": "Back_to_front"
+                        }
+                    ],
+                    "axis_unit": "meter"
+                },
+                "transform": [
+                    {
+                        "object_type": "Affine",
+                        "affine_transform": [
+                            [
+                                -0.80914,
+                                -0.58761,
+                                0
+                            ],
+                            [
+                                -0.12391,
+                                0.17063,
+                                0.97751
+                            ],
+                            [
+                                -0.5744,
+                                0.79095,
+                                -0.21087
+                            ],
+                            [
+                                0.08751,
+                                -0.12079,
+                                0.02298
+                            ]
+                        ]
+                    }
+                ],
+                "name": "Stimulus monitor",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "ASUS",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "00bxkz165"
+                },
+                "model": "PA248",
+                "additional_settings": null,
+                "notes": null,
+                "refresh_rate": 60,
+                "width": 1920,
+                "height": 1200,
+                "size_unit": "pixel",
+                "viewing_distance": "15.3",
+                "viewing_distance_unit": "centimeter",
+                "contrast": 50,
+                "contrast_unit": "percent",
+                "brightness": 43,
+                "brightness_unit": "percent"
+            },
+            {
+                "object_type": "Speaker",
+                "relative_position": [
+                    "Right",
+                    "Anterior",
+                    "Superior"
+                ],
+                "coordinate_system": {
+                    "object_type": "Coordinate system",
+                    "name": "MINDSCOPE_COPA_MONITOR_RDB",
+                    "origin": "Front_center",
+                    "axes": [
+                        {
+                            "object_type": "Axis",
+                            "name": "X",
+                            "direction": "Right_to_left"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Y",
+                            "direction": "Down_to_up"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Z",
+                            "direction": "Back_to_front"
+                        }
+                    ],
+                    "axis_unit": "meter"
+                },
+                "transform": [
+                    {
+                        "object_type": "Affine",
+                        "affine_transform": [
+                            [
+                                -0.82783,
+                                -0.4837,
+                                -0.28412
+                            ],
+                            [
+                                -0.55894,
+                                0.75426,
+                                0.34449
+                            ],
+                            [
+                                0.04767,
+                                0.44399,
+                                -0.89476
+                            ],
+                            [
+                                -0.00838,
+                                -0.09787,
+                                0.18228
+                            ]
+                        ]
+                    }
+                ],
+                "name": "Stimulus speaker",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "ISL Products International",
+                    "abbreviation": "ISL",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "SPK-I-81345",
+                "additional_settings": null,
+                "notes": null
+            },
+            {
+                "object_type": "Lick spout assembly",
+                "name": "Reward delivery assembly",
+                "lick_spouts": [
+                    {
+                        "object_type": "Lick spout",
+                        "name": "Reward spout",
+                        "serial_number": null,
+                        "manufacturer": {
+                            "name": "Hamilton",
+                            "abbreviation": null,
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "model": "8649-01",
+                        "additional_settings": null,
+                        "notes": "Spout diameter is inner. Outer diameter is 1.575 mm.",
+                        "spout_diameter": "0.672",
+                        "spout_diameter_unit": "millimeter",
+                        "solenoid_valve": {
+                            "object_type": "Device",
+                            "name": "Solenoid valve",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "NResearch Inc",
+                                "abbreviation": null,
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "161K011",
+                            "additional_settings": null,
+                            "notes": null
+                        },
+                        "lick_sensor": {
+                            "object_type": "Device",
+                            "name": "Lick sensor",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "TE Connectivity",
+                                "abbreviation": null,
+                                "registry": "Research Organization Registry (ROR)",
+                                "registry_identifier": "034frgp20"
+                            },
+                            "model": "1007079-1",
+                            "additional_settings": null,
+                            "notes": null
+                        },
+                        "lick_sensor_type": "Piezoelectric"
+                    }
+                ],
+                "motorized_stage": null
+            },
+            {
+                "object_type": "DAQ device",
+                "name": "Camstim DAQ",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "National Instruments",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "6323",
+                "additional_settings": null,
+                "notes": null,
+                "data_interface": "PCIe",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null
+            },
+            {
+                "object_type": "DAQ device",
+                "name": "TaskControl DAQ",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "National Instruments",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "6001",
+                "additional_settings": null,
+                "notes": null,
+                "data_interface": "USB",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null
+            },
+            {
+                "object_type": "Computer",
+                "name": "STIM",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": null,
+                "additional_settings": null,
+                "notes": null,
+                "operating_system": "Windows 10"
+            },
+            {
+                "object_type": "Computer",
+                "name": "SYNC",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": null,
+                "additional_settings": null,
+                "notes": null,
+                "operating_system": "Windows 10"
+            },
+            {
+                "object_type": "Computer",
+                "name": "MON",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": null,
+                "additional_settings": null,
+                "notes": null,
+                "operating_system": "Windows 10"
+            },
+            {
+                "object_type": "Computer",
+                "name": "ACQ",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": null,
+                "additional_settings": null,
+                "notes": null,
+                "operating_system": "Windows 10"
+            },
+            {
+                "object_type": "DAQ device",
+                "name": "Sync DAQ",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "National Instruments",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "NI-6612",
+                "additional_settings": null,
+                "notes": null,
+                "data_interface": "PCIe",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null
+            },
+            {
+                "object_type": "Device",
+                "name": "Stimulus microphone",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Dodotronic",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "momimic",
+                "additional_settings": null,
+                "notes": "Microphone used to record stimulus speaker output from approximately 50 mm"
+            },
+            {
+                "object_type": "Detector",
+                "name": "Stimulus photodiode",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "PDA25K",
+                "additional_settings": null,
+                "notes": "Photodiode used to measure stimulus monitor frame updates",
+                "detector_type": "Other",
+                "data_interface": "Coax",
+                "cooling": "No cooling",
+                "frame_rate": null,
+                "frame_rate_unit": null,
+                "immersion": null,
+                "chroma": null,
+                "sensor_width": null,
+                "sensor_height": null,
+                "size_unit": "pixel",
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "bit_depth": null,
+                "bin_mode": "No binning",
+                "bin_width": null,
+                "bin_height": null,
+                "bin_unit": "pixel",
+                "gain": null,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_width": null,
+                "crop_height": null,
+                "crop_unit": "pixel",
+                "recording_software": null,
+                "driver": null,
+                "driver_version": null
+            },
+            {
+                "object_type": "Camera assembly",
+                "relative_position": [
+                    "Anterior",
+                    "Superior"
+                ],
+                "coordinate_system": {
+                    "object_type": "Coordinate system",
+                    "name": "MINDSCOPE_COPA_CAMERA_LUB",
+                    "origin": "Front_center",
+                    "axes": [
+                        {
+                            "object_type": "Axis",
+                            "name": "X",
+                            "direction": "Left_to_right"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Y",
+                            "direction": "Up_to_down"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Z",
+                            "direction": "Back_to_front"
+                        }
+                    ],
+                    "axis_unit": "meter"
+                },
+                "transform": [
+                    {
+                        "object_type": "Affine",
+                        "affine_transform": [
+                            [
+                                -0.17365,
+                                0.98481,
+                                0
+                            ],
+                            [
+                                0.44709,
+                                0.07883,
+                                -0.89101
+                            ],
+                            [
+                                -0.87747,
+                                -0.15472,
+                                -0.45399
+                            ],
+                            [
+                                0.154,
+                                0.03078,
+                                0.06346
+                            ]
+                        ]
+                    }
+                ],
+                "name": "Front camera assembly",
+                "target": "Face",
+                "camera": {
+                    "object_type": "Camera",
+                    "name": "Front camera",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Allied",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "G-032",
+                    "additional_settings": null,
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "Ethernet",
+                    "cooling": "No cooling",
+                    "frame_rate": "60",
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 636,
+                    "sensor_height": 508,
+                    "size_unit": "pixel",
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "bit_depth": null,
+                    "bin_mode": "No binning",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": {
+                        "object_type": "Software",
+                        "name": "MultiVideoRecorder",
+                        "version": "1.1.7"
+                    },
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "object_type": "Lens",
+                    "name": "Front camera lens",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Edmund Optics",
+                        "abbreviation": null,
+                        "registry": "Research Organization Registry (ROR)",
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "86604",
+                    "additional_settings": {
+                        "focal_length": 8.5,
+                        "focal_length_unit": "millimeter"
+                    },
+                    "notes": null
+                },
+                "filter": {
+                    "object_type": "Filter",
+                    "name": "Front camera filter",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Semrock",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "FF01-715",
+                    "additional_settings": null,
+                    "notes": null,
+                    "filter_type": "Long pass",
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": 715,
+                    "center_wavelength": null,
+                    "wavelength_unit": "nanometer"
+                }
+            },
+            {
+                "object_type": "Light emitting diode",
+                "name": "Front camera illumination LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "ams OSRAM",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "045d0h266"
+                },
+                "model": "LZ4-40R308-0000",
+                "additional_settings": null,
+                "notes": null,
+                "wavelength": 740,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": null
+            },
+            {
+                "object_type": "Camera assembly",
+                "relative_position": [
+                    "Left"
+                ],
+                "coordinate_system": {
+                    "object_type": "Coordinate system",
+                    "name": "MINDSCOPE_COPA_CAMERA_LUB",
+                    "origin": "Front_center",
+                    "axes": [
+                        {
+                            "object_type": "Axis",
+                            "name": "X",
+                            "direction": "Left_to_right"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Y",
+                            "direction": "Up_to_down"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Z",
+                            "direction": "Back_to_front"
+                        }
+                    ],
+                    "axis_unit": "meter"
+                },
+                "transform": [
+                    {
+                        "object_type": "Affine",
+                        "affine_transform": [
+                            [
+                                -1,
+                                0,
+                                0
+                            ],
+                            [
+                                0,
+                                -1,
+                                0
+                            ],
+                            [
+                                -1,
+                                0,
+                                -0.03617
+                            ],
+                            [
+                                0.23887,
+                                -0.02535
+                            ]
+                        ]
+                    }
+                ],
+                "name": "Side camera assembly",
+                "target": "Body",
+                "camera": {
+                    "object_type": "Camera",
+                    "name": "Side camera",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Allied",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "G-032",
+                    "additional_settings": null,
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "Ethernet",
+                    "cooling": "No cooling",
+                    "frame_rate": "60",
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 636,
+                    "sensor_height": 508,
+                    "size_unit": "pixel",
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "bit_depth": null,
+                    "bin_mode": "No binning",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": {
+                        "object_type": "Software",
+                        "name": "MultiVideoRecorder",
+                        "version": "1.1.7"
+                    },
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "object_type": "Lens",
+                    "name": "Side camera lens",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Navitar",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": null,
+                    "additional_settings": {
+                        "focal_length": 6,
+                        "focal_length_unit": "millimeter"
+                    },
+                    "notes": null
+                },
+                "filter": {
+                    "object_type": "Filter",
+                    "name": "Side camera filter",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Semrock",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "FF01-747",
+                    "additional_settings": null,
+                    "notes": null,
+                    "filter_type": "Band pass",
+                    "cut_off_wavelength": 764,
+                    "cut_on_wavelength": 730,
+                    "center_wavelength": null,
+                    "wavelength_unit": "nanometer"
+                }
+            },
+            {
+                "object_type": "Light emitting diode",
+                "name": "Side camera illumination LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "ams OSRAM",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "045d0h266"
+                },
+                "model": "LZ4-40R308-0000",
+                "additional_settings": null,
+                "notes": null,
+                "wavelength": 740,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": null
+            },
+            {
+                "object_type": "Camera assembly",
+                "relative_position": [
+                    "Right"
+                ],
+                "coordinate_system": {
+                    "object_type": "Coordinate system",
+                    "name": "MINDSCOPE_COPA_CAMERA_LUB",
+                    "origin": "Front_center",
+                    "axes": [
+                        {
+                            "object_type": "Axis",
+                            "name": "X",
+                            "direction": "Left_to_right"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Y",
+                            "direction": "Up_to_down"
+                        },
+                        {
+                            "object_type": "Axis",
+                            "name": "Z",
+                            "direction": "Back_to_front"
+                        }
+                    ],
+                    "axis_unit": "meter"
+                },
+                "transform": [
+                    {
+                        "object_type": "Affine",
+                        "affine_transform": [
+                            [
+                                -0.5,
+                                -0.86603,
+                                0
+                            ],
+                            [
+                                -0.366,
+                                0.21131,
+                                -0.90631
+                            ],
+                            [
+                                0.78489,
+                                -0.45315,
+                                -0.42262
+                            ],
+                            [
+                                -0.14259,
+                                0.06209,
+                                0.09576
+                            ],
+                            [
+                                0.78489,
+                                -0.45315,
+                                -0.42262
+                            ],
+                            [
+                                -0.14259,
+                                0.06209,
+                                0.09576
+                            ]
+                        ]
+                    }
+                ],
+                "name": "Eye camera assembly",
+                "target": "Eye",
+                "camera": {
+                    "object_type": "Camera",
+                    "name": "Eye camera",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Allied",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "G-032",
+                    "additional_settings": null,
+                    "notes": "There is a mirror in the light path between the eye and the camera.",
+                    "detector_type": "Camera",
+                    "data_interface": "Ethernet",
+                    "cooling": "No cooling",
+                    "frame_rate": "60",
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 636,
+                    "sensor_height": 508,
+                    "size_unit": "pixel",
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "bit_depth": null,
+                    "bin_mode": "No binning",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": {
+                        "object_type": "Software",
+                        "name": "MultiVideoRecorder",
+                        "version": "1.1.7"
+                    },
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "object_type": "Lens",
+                    "name": "Eye camera lens",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Infinity Photo-Optical",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "213073",
+                    "additional_settings": {
+                        "focal_length": 6,
+                        "focal_length_unit": "millimeter"
+                    },
+                    "notes": null
+                },
+                "filter": {
+                    "object_type": "Filter",
+                    "name": "Eye camera filter",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Semrock",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "FF01-850",
+                    "additional_settings": null,
+                    "notes": null,
+                    "filter_type": "Band pass",
+                    "cut_off_wavelength": 855,
+                    "cut_on_wavelength": 845,
+                    "center_wavelength": null,
+                    "wavelength_unit": "nanometer"
+                }
+            },
+            {
+                "object_type": "Light emitting diode",
+                "name": "Eye camera illumination LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "ams OSRAM",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "045d0h266"
+                },
+                "model": "LZ4-40R608-0000",
+                "additional_settings": null,
+                "notes": null,
+                "wavelength": 850,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": null
+            },
+            {
+                "object_type": "Camera assembly",
+                "relative_position": [
+                    "Anterior",
+                    "Left"
+                ],
+                "coordinate_system": null,
+                "transform": null,
+                "name": "Nose camera assembly",
+                "target": "Face",
+                "camera": {
+                    "object_type": "Camera",
+                    "name": "Nose camera",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Allied",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "G-032",
+                    "additional_settings": null,
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "Ethernet",
+                    "cooling": "No cooling",
+                    "frame_rate": "60",
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 636,
+                    "sensor_height": 508,
+                    "size_unit": "pixel",
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "bit_depth": null,
+                    "bin_mode": "No binning",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": {
+                        "object_type": "Software",
+                        "name": "MultiVideoRecorder",
+                        "version": "1.1.7"
+                    },
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "object_type": "Lens",
+                    "name": "Nose camera lens",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Edmund Optics",
+                        "abbreviation": null,
+                        "registry": "Research Organization Registry (ROR)",
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "85360",
+                    "additional_settings": {
+                        "focal_length": 25,
+                        "focal_length_unit": "millimeter"
+                    },
+                    "notes": null
+                },
+                "filter": {
+                    "object_type": "Filter",
+                    "name": "Nose camera filter",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Semrock",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "FF01-715",
+                    "additional_settings": null,
+                    "notes": null,
+                    "filter_type": "Long pass",
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": 715,
+                    "center_wavelength": null,
+                    "wavelength_unit": "nanometer"
+                }
+            },
+            {
+                "object_type": "Light emitting diode",
+                "name": "Nose camera illumination LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "ams OSRAM",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "045d0h266"
+                },
+                "model": "LZ4-40R308-0000",
+                "additional_settings": null,
+                "notes": null,
+                "wavelength": 740,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": null
+            },
+            {
+                "object_type": "DAQ device",
+                "name": "Opto DAQ",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "National Instruments",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "9264",
+                "additional_settings": null,
+                "notes": null,
+                "data_interface": "Ethernet",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null
+            },
+            {
+                "object_type": "Laser",
+                "name": "Opto laser #1",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Vortran",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "Stradus 488-50",
+                "additional_settings": null,
+                "notes": null,
+                "wavelength": 488,
+                "wavelength_unit": "nanometer",
+                "coupling": null,
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent"
+            },
+            {
+                "object_type": "Laser",
+                "name": "Opto laser #2",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Vortran",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "Stradus 633-50",
+                "additional_settings": null,
+                "notes": null,
+                "wavelength": 633,
+                "wavelength_unit": "nanometer",
+                "coupling": null,
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent"
+            },
+            {
+                "object_type": "Additional imaging device",
+                "name": "Opto laser galvo X",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "GVS012",
+                "additional_settings": null,
+                "notes": null,
+                "imaging_device_type": "Galvo"
+            },
+            {
+                "object_type": "Additional imaging device",
+                "name": "Opto laser galvo Y",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "GVS012",
+                "additional_settings": null,
+                "notes": null,
+                "imaging_device_type": "Galvo"
+            },
+            {
+                "object_type": "Ephys assembly",
+                "name": "A",
+                "manipulator": {
+                    "object_type": "Manipulator",
+                    "name": "Manipulator A",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "New Scale Technologies",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "M3-LS-3.4-15",
+                    "additional_settings": null,
+                    "notes": null
+                },
+                "probes": [
+                    {
+                        "object_type": "Ephys probe",
+                        "name": "probeA",
+                        "serial_number": null,
+                        "manufacturer": {
+                            "name": "Interuniversity Microelectronics Center",
+                            "abbreviation": "IMEC",
+                            "registry": "Research Organization Registry (ROR)",
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "additional_settings": null,
+                        "notes": null,
+                        "probe_model": "Neuropixels 1.0",
+                        "headstage": null
+                    }
+                ]
+            },
+            {
+                "object_type": "Ephys assembly",
+                "name": "B",
+                "manipulator": {
+                    "object_type": "Manipulator",
+                    "name": "Manipulator B",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "New Scale Technologies",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "M3-LS-3.4-15",
+                    "additional_settings": null,
+                    "notes": null
+                },
+                "probes": [
+                    {
+                        "object_type": "Ephys probe",
+                        "name": "probeB",
+                        "serial_number": null,
+                        "manufacturer": {
+                            "name": "Interuniversity Microelectronics Center",
+                            "abbreviation": "IMEC",
+                            "registry": "Research Organization Registry (ROR)",
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "additional_settings": null,
+                        "notes": null,
+                        "probe_model": "Neuropixels 1.0",
+                        "headstage": null
+                    }
+                ]
+            },
+            {
+                "object_type": "Ephys assembly",
+                "name": "C",
+                "manipulator": {
+                    "object_type": "Manipulator",
+                    "name": "Manipulator C",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "New Scale Technologies",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "M3-LS-3.4-15",
+                    "additional_settings": null,
+                    "notes": null
+                },
+                "probes": [
+                    {
+                        "object_type": "Ephys probe",
+                        "name": "probeC",
+                        "serial_number": null,
+                        "manufacturer": {
+                            "name": "Interuniversity Microelectronics Center",
+                            "abbreviation": "IMEC",
+                            "registry": "Research Organization Registry (ROR)",
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "additional_settings": null,
+                        "notes": null,
+                        "probe_model": "Neuropixels 1.0",
+                        "headstage": null
+                    }
+                ]
+            },
+            {
+                "object_type": "Ephys assembly",
+                "name": "D",
+                "manipulator": {
+                    "object_type": "Manipulator",
+                    "name": "Manipulator D",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "New Scale Technologies",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "M3-LS-3.4-15",
+                    "additional_settings": null,
+                    "notes": null
+                },
+                "probes": [
+                    {
+                        "object_type": "Ephys probe",
+                        "name": "probeD",
+                        "serial_number": null,
+                        "manufacturer": {
+                            "name": "Interuniversity Microelectronics Center",
+                            "abbreviation": "IMEC",
+                            "registry": "Research Organization Registry (ROR)",
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "additional_settings": null,
+                        "notes": null,
+                        "probe_model": "Neuropixels 1.0",
+                        "headstage": null
+                    }
+                ]
+            },
+            {
+                "object_type": "Ephys assembly",
+                "name": "E",
+                "manipulator": {
+                    "object_type": "Manipulator",
+                    "name": "Manipulator E",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "New Scale Technologies",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "M3-LS-3.4-15",
+                    "additional_settings": null,
+                    "notes": null
+                },
+                "probes": [
+                    {
+                        "object_type": "Ephys probe",
+                        "name": "probeE",
+                        "serial_number": null,
+                        "manufacturer": {
+                            "name": "Interuniversity Microelectronics Center",
+                            "abbreviation": "IMEC",
+                            "registry": "Research Organization Registry (ROR)",
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "additional_settings": null,
+                        "notes": null,
+                        "probe_model": "Neuropixels 1.0",
+                        "headstage": null
+                    }
+                ]
+            },
+            {
+                "object_type": "Ephys assembly",
+                "name": "F",
+                "manipulator": {
+                    "object_type": "Manipulator",
+                    "name": "Manipulator F",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "New Scale Technologies",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "M3-LS-3.4-15",
+                    "additional_settings": null,
+                    "notes": null
+                },
+                "probes": [
+                    {
+                        "object_type": "Ephys probe",
+                        "name": "probeF",
+                        "serial_number": null,
+                        "manufacturer": {
+                            "name": "Interuniversity Microelectronics Center",
+                            "abbreviation": "IMEC",
+                            "registry": "Research Organization Registry (ROR)",
+                            "registry_identifier": "02kcbn207"
+                        },
+                        "model": null,
+                        "additional_settings": null,
+                        "notes": null,
+                        "probe_model": "Neuropixels 1.0",
+                        "headstage": null
+                    }
+                ]
+            },
+            {
+                "object_type": "Neuropixels basestation",
+                "name": "probes ABC",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Interuniversity Microelectronics Center",
+                    "abbreviation": "IMEC",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "02kcbn207"
+                },
+                "model": "PXIe",
+                "additional_settings": null,
+                "notes": null,
+                "data_interface": "PXI",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "basestation_firmware_version": "128.1760",
+                "bsc_firmware_version": "1.0.144",
+                "slot": 2,
+                "ports": [
+                    {
+                        "object_type": "Probe port",
+                        "index": 0,
+                        "probes": [
+                            "probeA"
+                        ]
+                    },
+                    {
+                        "object_type": "Probe port",
+                        "index": 1,
+                        "probes": [
+                            "probeB"
+                        ]
+                    },
+                    {
+                        "object_type": "Probe port",
+                        "index": 2,
+                        "probes": [
+                            "probeC"
+                        ]
+                    }
+                ]
+            },
+            {
+                "object_type": "Neuropixels basestation",
+                "name": "probes DEF",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Interuniversity Microelectronics Center",
+                    "abbreviation": "IMEC",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "02kcbn207"
+                },
+                "model": "PXIe",
+                "additional_settings": null,
+                "notes": null,
+                "data_interface": "PXI",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "basestation_firmware_version": "128.1760",
+                "bsc_firmware_version": "1.0.144",
+                "slot": 3,
+                "ports": [
+                    {
+                        "object_type": "Probe port",
+                        "index": 0,
+                        "probes": [
+                            "probeD"
+                        ]
+                    },
+                    {
+                        "object_type": "Probe port",
+                        "index": 1,
+                        "probes": [
+                            "probeE"
+                        ]
+                    },
+                    {
+                        "object_type": "Probe port",
+                        "index": 2,
+                        "probes": [
+                            "probeF"
+                        ]
+                    }
+                ]
+            },
+            {
+                "object_type": "DAQ device",
+                "name": "Ephys DAQ",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "National Instruments",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "6133",
+                "additional_settings": null,
+                "notes": null,
+                "data_interface": "PXI",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null
+            }
+        ]
+    },
+    "quality_control": null
+}

--- a/tests/test_v1v2_metadata_utils.py
+++ b/tests/test_v1v2_metadata_utils.py
@@ -109,6 +109,7 @@ class TestRepairAcquisitionTimezone(unittest.TestCase):
     """Tests for repair_acquisition_timezone"""
 
     def _make_acq(self, start, end, stream_starts=None, stream_ends=None, epoch_starts=None, epoch_ends=None):
+        """Helper to create acquisition dicts with specified start/end times for acquisition, streams, and epochs"""
         streams = []
         for i, ss in enumerate(stream_starts or []):
             stream = {"stream_start_time": ss}

--- a/tests/test_v1v2_metadata_utils.py
+++ b/tests/test_v1v2_metadata_utils.py
@@ -1,8 +1,16 @@
 """Tests for v1v2_metadata_utils ecephys ID mismatch handling"""
 
 import unittest
+from datetime import datetime
 
-from aind_metadata_upgrader.utils.v1v2_metadata_utils import repair_instrument_id_mismatch
+from aind_metadata_upgrader.utils.v1v2_metadata_utils import repair_instrument_id_mismatch, repair_acquisition_timezone
+
+
+def _iso(v):
+    """Normalise a string or datetime to an ISO string for assertion comparisons."""
+    if isinstance(v, datetime):
+        return v.isoformat()
+    return v
 
 
 def _make_data(instrument_id, acquisition_id):
@@ -95,6 +103,138 @@ class TestHandleEcephysIdMismatch(unittest.TestCase):
         data = _make_data("342_NP3_240906", None)
         result = repair_instrument_id_mismatch(data)
         self.assertIsNone(result["acquisition"]["instrument_id"])
+
+
+class TestRepairAcquisitionTimezone(unittest.TestCase):
+    """Tests for repair_acquisition_timezone"""
+
+    def _make_acq(self, start, end, stream_starts=None, stream_ends=None, epoch_starts=None, epoch_ends=None):
+        streams = []
+        for i, ss in enumerate(stream_starts or []):
+            stream = {"stream_start_time": ss}
+            if stream_ends and i < len(stream_ends):
+                stream["stream_end_time"] = stream_ends[i]
+            streams.append(stream)
+        epochs = []
+        for i, es in enumerate(epoch_starts or []):
+            epoch = {"stimulus_start_time": es}
+            if epoch_ends and i < len(epoch_ends):
+                epoch["stimulus_end_time"] = epoch_ends[i]
+            epochs.append(epoch)
+        return {
+            "acquisition": {
+                "acquisition_start_time": start,
+                "acquisition_end_time": end,
+                "data_streams": streams,
+                "stimulus_epochs": epochs,
+            }
+        }
+
+    def test_no_change_when_start_is_utc(self):
+        """No change when acquisition_start_time is UTC — values remain as original strings"""
+        data = self._make_acq(
+            "2023-08-31T12:33:31Z",
+            "2023-08-31T14:29:44Z",
+            ["2023-08-31T12:33:31Z"],
+        )
+        result = repair_acquisition_timezone(data)
+        self.assertEqual(result["acquisition"]["acquisition_end_time"], "2023-08-31T14:29:44Z")
+        self.assertEqual(result["acquisition"]["data_streams"][0]["stream_start_time"], "2023-08-31T12:33:31Z")
+
+    def test_fix_applied_when_reinterpretation_is_valid(self):
+        """Fix is applied when reinterpreting UTC times makes everything fit within acquisition bounds"""
+        data = self._make_acq(
+            "2023-08-31T12:33:31-07:00",
+            "2023-08-31T14:29:44.718331Z",
+            ["2023-08-31T12:33:31.218331Z"],
+            ["2023-08-31T14:29:44.497900-07:00"],
+        )
+        result = repair_acquisition_timezone(data)
+        self.assertEqual(_iso(result["acquisition"]["acquisition_end_time"]), "2023-08-31T14:29:44.718331-07:00")
+        self.assertEqual(_iso(result["acquisition"]["data_streams"][0]["stream_start_time"]), "2023-08-31T12:33:31.218331-07:00")
+        # stream_end_time was already -07:00, should be unchanged (not UTC → stays as original type)
+        self.assertEqual(_iso(result["acquisition"]["data_streams"][0]["stream_end_time"]), "2023-08-31T14:29:44.497900-07:00")
+
+    def test_no_fix_when_reinterpretation_invalid(self):
+        """No fix applied when reinterpreting UTC times would still violate containment"""
+        data = self._make_acq(
+            "2023-08-31T13:00:00-07:00",
+            "2023-08-31T14:29:44Z",
+            ["2023-08-31T12:00:00Z"],  # reinterpreted → 12:00-07:00 < 13:00-07:00: invalid
+        )
+        result = repair_acquisition_timezone(data)
+        self.assertEqual(result["acquisition"]["acquisition_end_time"], "2023-08-31T14:29:44Z")
+        self.assertEqual(result["acquisition"]["data_streams"][0]["stream_start_time"], "2023-08-31T12:00:00Z")
+
+    def test_no_change_when_end_already_has_tz(self):
+        """No change to end time when it already has a non-UTC timezone"""
+        data = self._make_acq(
+            "2023-08-31T12:33:31-07:00",
+            "2023-08-31T14:29:44-07:00",
+        )
+        result = repair_acquisition_timezone(data)
+        self.assertEqual(_iso(result["acquisition"]["acquisition_end_time"]), "2023-08-31T14:29:44-07:00")
+
+    def test_no_acquisition_key(self):
+        """No crash when acquisition key is missing"""
+        data = {"subject": {}}
+        result = repair_acquisition_timezone(data)
+        self.assertNotIn("acquisition", result)
+
+    def test_multiple_streams_partially_utc(self):
+        """Only UTC stream times are reinterpreted; non-UTC ones are left alone when valid"""
+        data = self._make_acq(
+            "2023-08-31T12:33:31-07:00",
+            "2023-08-31T14:29:44Z",
+            ["2023-08-31T12:33:31Z", "2023-08-31T13:00:00-07:00"],
+        )
+        result = repair_acquisition_timezone(data)
+        self.assertEqual(_iso(result["acquisition"]["data_streams"][0]["stream_start_time"]), "2023-08-31T12:33:31-07:00")
+        self.assertEqual(_iso(result["acquisition"]["data_streams"][1]["stream_start_time"]), "2023-08-31T13:00:00-07:00")
+
+    def test_stimulus_epochs_patched_when_valid(self):
+        """Stimulus epoch times are also patched when the fix is valid"""
+        data = self._make_acq(
+            "2023-08-31T12:33:31-07:00",
+            "2023-08-31T14:29:44Z",
+            [],
+            [],
+            ["2023-08-31T12:34:31Z"],
+            ["2023-08-31T12:48:51Z"],
+        )
+        result = repair_acquisition_timezone(data)
+        self.assertEqual(_iso(result["acquisition"]["stimulus_epochs"][0]["stimulus_start_time"]), "2023-08-31T12:34:31-07:00")
+        self.assertEqual(_iso(result["acquisition"]["stimulus_epochs"][0]["stimulus_end_time"]), "2023-08-31T12:48:51-07:00")
+
+    def test_no_fix_when_epoch_outside_bounds(self):
+        """No fix applied when a stimulus epoch would fall outside acquisition bounds after reinterpretation"""
+        data = self._make_acq(
+            "2023-08-31T12:33:31-07:00",
+            "2023-08-31T14:29:44Z",
+            [],
+            [],
+            ["2023-08-31T12:34:31Z"],
+            ["2023-08-31T15:00:00Z"],  # 15:00-07:00 > 14:29-07:00: invalid
+        )
+        result = repair_acquisition_timezone(data)
+        self.assertEqual(result["acquisition"]["stimulus_epochs"][0]["stimulus_end_time"], "2023-08-31T15:00:00Z")
+
+    def test_fix_works_with_datetime_objects(self):
+        """Works when values are already datetime objects (as from model_dump())"""
+        from datetime import timezone, timedelta
+        tz_minus7 = timezone(timedelta(hours=-7))
+        utc = timezone.utc
+        data = {
+            "acquisition": {
+                "acquisition_start_time": datetime(2023, 8, 31, 12, 33, 31, tzinfo=tz_minus7),
+                "acquisition_end_time": datetime(2023, 8, 31, 14, 29, 44, tzinfo=utc),
+                "data_streams": [{"stream_start_time": datetime(2023, 8, 31, 12, 33, 31, tzinfo=utc)}],
+                "stimulus_epochs": [],
+            }
+        }
+        result = repair_acquisition_timezone(data)
+        self.assertEqual(_iso(result["acquisition"]["acquisition_end_time"]), "2023-08-31T14:29:44-07:00")
+        self.assertEqual(_iso(result["acquisition"]["data_streams"][0]["stream_start_time"]), "2023-08-31T12:33:31-07:00")
 
 
 if __name__ == "__main__":

--- a/tests/test_v1v2_metadata_utils.py
+++ b/tests/test_v1v2_metadata_utils.py
@@ -151,9 +151,11 @@ class TestRepairAcquisitionTimezone(unittest.TestCase):
         )
         result = repair_acquisition_timezone(data)
         self.assertEqual(_iso(result["acquisition"]["acquisition_end_time"]), "2023-08-31T14:29:44.718331-07:00")
-        self.assertEqual(_iso(result["acquisition"]["data_streams"][0]["stream_start_time"]), "2023-08-31T12:33:31.218331-07:00")
+        actual_ss = _iso(result["acquisition"]["data_streams"][0]["stream_start_time"])
+        self.assertEqual(actual_ss, "2023-08-31T12:33:31.218331-07:00")
         # stream_end_time was already -07:00, should be unchanged (not UTC → stays as original type)
-        self.assertEqual(_iso(result["acquisition"]["data_streams"][0]["stream_end_time"]), "2023-08-31T14:29:44.497900-07:00")
+        actual_se = _iso(result["acquisition"]["data_streams"][0]["stream_end_time"])
+        self.assertEqual(actual_se, "2023-08-31T14:29:44.497900-07:00")
 
     def test_no_fix_when_reinterpretation_invalid(self):
         """No fix applied when reinterpreting UTC times would still violate containment"""
@@ -189,8 +191,10 @@ class TestRepairAcquisitionTimezone(unittest.TestCase):
             ["2023-08-31T12:33:31Z", "2023-08-31T13:00:00-07:00"],
         )
         result = repair_acquisition_timezone(data)
-        self.assertEqual(_iso(result["acquisition"]["data_streams"][0]["stream_start_time"]), "2023-08-31T12:33:31-07:00")
-        self.assertEqual(_iso(result["acquisition"]["data_streams"][1]["stream_start_time"]), "2023-08-31T13:00:00-07:00")
+        actual_s0 = _iso(result["acquisition"]["data_streams"][0]["stream_start_time"])
+        actual_s1 = _iso(result["acquisition"]["data_streams"][1]["stream_start_time"])
+        self.assertEqual(actual_s0, "2023-08-31T12:33:31-07:00")
+        self.assertEqual(actual_s1, "2023-08-31T13:00:00-07:00")
 
     def test_stimulus_epochs_patched_when_valid(self):
         """Stimulus epoch times are also patched when the fix is valid"""
@@ -203,8 +207,10 @@ class TestRepairAcquisitionTimezone(unittest.TestCase):
             ["2023-08-31T12:48:51Z"],
         )
         result = repair_acquisition_timezone(data)
-        self.assertEqual(_iso(result["acquisition"]["stimulus_epochs"][0]["stimulus_start_time"]), "2023-08-31T12:34:31-07:00")
-        self.assertEqual(_iso(result["acquisition"]["stimulus_epochs"][0]["stimulus_end_time"]), "2023-08-31T12:48:51-07:00")
+        actual_es = _iso(result["acquisition"]["stimulus_epochs"][0]["stimulus_start_time"])
+        actual_ee = _iso(result["acquisition"]["stimulus_epochs"][0]["stimulus_end_time"])
+        self.assertEqual(actual_es, "2023-08-31T12:34:31-07:00")
+        self.assertEqual(actual_ee, "2023-08-31T12:48:51-07:00")
 
     def test_no_fix_when_epoch_outside_bounds(self):
         """No fix applied when a stimulus epoch would fall outside acquisition bounds after reinterpretation"""
@@ -234,7 +240,8 @@ class TestRepairAcquisitionTimezone(unittest.TestCase):
         }
         result = repair_acquisition_timezone(data)
         self.assertEqual(_iso(result["acquisition"]["acquisition_end_time"]), "2023-08-31T14:29:44-07:00")
-        self.assertEqual(_iso(result["acquisition"]["data_streams"][0]["stream_start_time"]), "2023-08-31T12:33:31-07:00")
+        actual_ss = _iso(result["acquisition"]["data_streams"][0]["stream_start_time"])
+        self.assertEqual(actual_ss, "2023-08-31T12:33:31-07:00")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Important note for this PR, before this new code gets run the session/acquisition code attempts to coerce naive timezones into the acquisition_start_time timezone OR the pacific time zone as a fallback. If this fails, or if a v2 asset gets passed to the upgrader it will still get hit by the new `repair_naive_acquisition_times` function which should ensure consistent timezones. This logic hasn't changed.

The new logic is in the `repair_acquisition_timezone` function. What this does is try to turn everything that shows up as UTC into the `acquisition_start_time` timezone on the condition that all the data streams and stimulus epochs correctly validate as being between the acquisition_start_time and acquisition_end_time. This fixes an annoying situation found in the attached test asset where all of the datetimes have timezones attached (either PDT or UTC) but the UTC ones are not real. They must have been generated because the user provided a timezone for some fields (acquisition_start_time) but not for others and the pydantic "DatetimeAwareWithDefault" class had no choice but to use the computer's UTC timezone.