### PR TITLE
feat: support repairs of core_diameter/numerical_aperture

### DIFF
--- a/src/aind_metadata_upgrader/rig/v1v2_devices.py
+++ b/src/aind_metadata_upgrader/rig/v1v2_devices.py
@@ -821,6 +821,12 @@ def upgrade_fiber_probe(data: dict) -> dict:
 
     data = basic_device_checks(data, "FiberProbe")
 
+    # If core diameter is missing or empty, set it to 200
+    if "core_diameter" in data and not data["core_diameter"] or "core_diameter" not in data:
+        data["core_diameter"] = 200
+        data["core_diameter_unit"] = "micrometer"
+        data["numerical_aperture"] = 0.37
+
     if "core_diameter_unit" in data and data["core_diameter_unit"]:
         data["core_diameter_unit"] = repair_unit(data["core_diameter_unit"])
 

--- a/tests/records/v1/64bc1f4c-1b36-4630-8696-92d5a515a2b2.json
+++ b/tests/records/v1/64bc1f4c-1b36-4630-8696-92d5a515a2b2.json
@@ -1,0 +1,1029 @@
+{
+    "_id": "64bc1f4c-1b36-4630-8696-92d5a515a2b2",
+    "acquisition": {
+        "acquisition_end_time": "2023-07-07T18:42:15.484000-07:00",
+        "acquisition_start_time": "2023-07-07T17:52:04-07:00",
+        "acquisition_type": "Fiber photometry recording",
+        "calibrations": [],
+        "coordinate_system": null,
+        "data_streams": [
+            {
+                "active_devices": [
+                    "470nm LED",
+                    "415nm LED",
+                    "565nm LED",
+                    "Fiber optic patch cord",
+                    "Green CMOS",
+                    "Red CMOS",
+                    "Pupil camera assembly",
+                    "Tongue camera assembly",
+                    "Lick spout assembly",
+                    "Speaker",
+                    "Arduino",
+                    "Fiber 0",
+                    "Fiber 1",
+                    "Fiber 2",
+                    "Fiber 3",
+                    "Patch Cord A",
+                    "Patch Cord B",
+                    "Patch Cord C",
+                    "Patch Cord D"
+                ],
+                "code": null,
+                "configurations": [
+                    {
+                        "device_name": "470nm LED",
+                        "object_type": "Light emitting diode config",
+                        "power": 60,
+                        "power_unit": "microwatt"
+                    },
+                    {
+                        "device_name": "415nm LED",
+                        "object_type": "Light emitting diode config",
+                        "power": 40,
+                        "power_unit": "microwatt"
+                    },
+                    {
+                        "device_name": "565nm LED",
+                        "object_type": "Light emitting diode config",
+                        "power": 0,
+                        "power_unit": "microwatt"
+                    },
+                    {
+                        "channels": [
+                            {
+                                "additional_device_names": null,
+                                "channel_name": "Fiber channel",
+                                "detector": {
+                                    "compression": null,
+                                    "device_name": "Green CMOS",
+                                    "exposure_time": 0,
+                                    "exposure_time_unit": "second",
+                                    "object_type": "Detector config",
+                                    "trigger_type": "Internal"
+                                },
+                                "emission_filters": null,
+                                "emission_wavelength": null,
+                                "emission_wavelength_unit": null,
+                                "excitation_filters": null,
+                                "intended_measurement": null,
+                                "light_sources": [],
+                                "object_type": "Channel",
+                                "variable_power": false
+                            },
+                            {
+                                "additional_device_names": null,
+                                "channel_name": "Fiber channel",
+                                "detector": {
+                                    "compression": null,
+                                    "device_name": "Red CMOS",
+                                    "exposure_time": 0,
+                                    "exposure_time_unit": "second",
+                                    "object_type": "Detector config",
+                                    "trigger_type": "Internal"
+                                },
+                                "emission_filters": null,
+                                "emission_wavelength": null,
+                                "emission_wavelength_unit": null,
+                                "excitation_filters": null,
+                                "intended_measurement": null,
+                                "light_sources": [],
+                                "object_type": "Channel",
+                                "variable_power": false
+                            }
+                        ],
+                        "device_name": "Fiber optic patch cord",
+                        "object_type": "Patch cord config"
+                    }
+                ],
+                "connections": [
+                    {
+                        "object_type": "Connection",
+                        "send_and_receive": true,
+                        "source_device": "Fiber 0",
+                        "source_port": null,
+                        "target_device": "Patch Cord A",
+                        "target_port": null
+                    },
+                    {
+                        "object_type": "Connection",
+                        "send_and_receive": true,
+                        "source_device": "Fiber 1",
+                        "source_port": null,
+                        "target_device": "Patch Cord B",
+                        "target_port": null
+                    },
+                    {
+                        "object_type": "Connection",
+                        "send_and_receive": true,
+                        "source_device": "Fiber 2",
+                        "source_port": null,
+                        "target_device": "Patch Cord C",
+                        "target_port": null
+                    },
+                    {
+                        "object_type": "Connection",
+                        "send_and_receive": true,
+                        "source_device": "Fiber 3",
+                        "source_port": null,
+                        "target_device": "Patch Cord D",
+                        "target_port": null
+                    }
+                ],
+                "modalities": [
+                    {
+                        "abbreviation": "behavior",
+                        "name": "Behavior"
+                    },
+                    {
+                        "abbreviation": "fib",
+                        "name": "Fiber photometry"
+                    }
+                ],
+                "notes": "LED power measured at patch cable end; fib mode: Axon",
+                "object_type": "Data stream",
+                "stream_end_time": "2023-07-07T18:42:15.484000-07:00",
+                "stream_start_time": "2023-07-07T17:52:04-07:00"
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
+        "ethics_review_id": [
+            "2115"
+        ],
+        "experimenters": [
+            "Sue Su"
+        ],
+        "instrument_id": "FIP_Sue",
+        "maintenance": [],
+        "notes": "Legacy fiber photometry recording session for subject 669492. Note: Actual power and exposure duration values are not available in the legacy data.",
+        "object_type": "Acquisition",
+        "protocol_id": null,
+        "schema_version": "2.0.35",
+        "specimen_id": null,
+        "stimulus_epochs": [
+            {
+                "active_devices": [
+                    "Speaker"
+                ],
+                "code": null,
+                "configurations": [],
+                "curriculum_status": null,
+                "notes": "Behavioral foraging task during fiber photometry recording",
+                "object_type": "Stimulus epoch",
+                "performance_metrics": {
+                    "object_type": "Performance metrics",
+                    "output_parameters": {},
+                    "reward_consumed_during_epoch": "777.0",
+                    "reward_consumed_unit": "microliter",
+                    "trials_finished": 465,
+                    "trials_rewarded": 259,
+                    "trials_total": 465
+                },
+                "stimulus_end_time": "2023-07-07T18:42:15.484000-07:00",
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_name": "Behavioral foraging task",
+                "stimulus_start_time": "2023-07-07T17:52:04-07:00",
+                "training_protocol_name": null
+            }
+        ],
+        "subject_details": {
+            "anaesthesia": null,
+            "animal_weight_post": null,
+            "animal_weight_prior": null,
+            "mouse_platform_name": "fiber_photometry_platform",
+            "object_type": "Acquisition subject details",
+            "reward_consumed_total": "0.777",
+            "reward_consumed_unit": "milliliter",
+            "weight_unit": "gram"
+        },
+        "subject_id": "669492"
+    },
+    "created": "2025-09-21T22:17:47.491838",
+    "data_description": {
+        "creation_time": "2023-07-07T17:52:04-07:00",
+        "data_level": "derived",
+        "data_summary": "Fiber photometry recording session for subject 669492",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "funding_source": [
+            {
+                "fundee": [
+                    {
+                        "name": "Sue Su",
+                        "object_type": "Person",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": "0000-0002-0138-7433"
+                    },
+                    {
+                        "name": "Jeremiah Cohen",
+                        "object_type": "Person",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": "0000-0002-4768-7433"
+                    }
+                ],
+                "funder": {
+                    "abbreviation": "AI",
+                    "name": "Allen Institute",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null,
+                "object_type": "Funding"
+            }
+        ],
+        "group": null,
+        "institution": {
+            "abbreviation": "AIND",
+            "name": "Allen Institute for Neural Dynamics",
+            "registry": "Research Organization Registry (ROR)",
+            "registry_identifier": "04szwah67"
+        },
+        "investigators": [
+            {
+                "name": "Sue Su",
+                "object_type": "Person",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": "0000-0002-0138-7433"
+            }
+        ],
+        "license": "CC-BY-4.0",
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "fib",
+                "name": "Fiber photometry"
+            }
+        ],
+        "name": "669492_2023-07-07_17-52-04_nwb_2025-09-05_16-22-41",
+        "object_type": "Data description",
+        "project_name": "Dynamic Foraging with Fiber Photometry",
+        "restrictions": null,
+        "schema_version": "2.1.0",
+        "source_data": null,
+        "subject_id": "669492",
+        "tags": null
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "1712560f-a346-4f53-bf28-390b0d8db1ff"
+        ]
+    },
+    "instrument": {
+        "calibrations": null,
+        "components": [
+            {
+                "camera": {
+                    "additional_settings": null,
+                    "bin_height": null,
+                    "bin_mode": "No binning",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": null,
+                    "cooling": "No cooling",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": "30",
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Thorlabs",
+                        "registry": "Research Organization Registry (ROR)",
+                        "registry_identifier": "04gsnvb07"
+                    },
+                    "model": null,
+                    "name": "Pupil camera",
+                    "notes": null,
+                    "object_type": "Camera",
+                    "recording_software": {
+                        "name": "ThorCam",
+                        "object_type": "Software",
+                        "version": null
+                    },
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "sensor_height": null,
+                    "sensor_width": null,
+                    "serial_number": null,
+                    "size_unit": "pixel"
+                },
+                "coordinate_system": null,
+                "filter": null,
+                "lens": {
+                    "additional_settings": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": "Research Organization Registry (ROR)",
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "58-430",
+                    "name": "Silver Telecentric lens",
+                    "notes": null,
+                    "object_type": "Lens",
+                    "serial_number": null
+                },
+                "name": "Pupil camera assembly",
+                "object_type": "Camera assembly",
+                "relative_position": [
+                    "Anterior",
+                    "Left"
+                ],
+                "target": "Eye",
+                "transform": null
+            },
+            {
+                "camera": {
+                    "additional_settings": null,
+                    "bin_height": null,
+                    "bin_mode": "No binning",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": null,
+                    "cooling": "No cooling",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": "550",
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Basler",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "acA640-750um",
+                    "name": "Tongue camera",
+                    "notes": null,
+                    "object_type": "Camera",
+                    "recording_software": null,
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "sensor_height": null,
+                    "sensor_width": null,
+                    "serial_number": "24621482",
+                    "size_unit": "pixel"
+                },
+                "coordinate_system": null,
+                "filter": null,
+                "lens": {
+                    "additional_settings": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": "Research Organization Registry (ROR)",
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "55-349",
+                    "name": "Gold Telecentric lens",
+                    "notes": null,
+                    "object_type": "Lens",
+                    "serial_number": null
+                },
+                "name": "Tongue camera assembly",
+                "object_type": "Camera assembly",
+                "relative_position": [
+                    "Left"
+                ],
+                "target": "Tongue",
+                "transform": null
+            },
+            {
+                "additional_settings": null,
+                "core_diameter": "200",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Doric",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "059n53q30"
+                },
+                "model": null,
+                "name": "Fiber optic patch cord",
+                "notes": null,
+                "numerical_aperture": "0.37",
+                "object_type": "Fiber patch cord",
+                "photobleaching_date": null,
+                "serial_number": null
+            },
+            {
+                "additional_settings": null,
+                "bandwidth": null,
+                "bandwidth_unit": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M470F3",
+                "name": "470nm LED",
+                "notes": null,
+                "object_type": "Light emitting diode",
+                "serial_number": null,
+                "wavelength": 470,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": null,
+                "bandwidth": null,
+                "bandwidth_unit": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M415F3",
+                "name": "415nm LED",
+                "notes": null,
+                "object_type": "Light emitting diode",
+                "serial_number": null,
+                "wavelength": 415,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": null,
+                "bandwidth": null,
+                "bandwidth_unit": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M565F3",
+                "name": "565nm LED",
+                "notes": null,
+                "object_type": "Light emitting diode",
+                "serial_number": null,
+                "wavelength": 565,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": null,
+                "bandwidth": null,
+                "bandwidth_unit": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "name": "810nm LED",
+                "notes": null,
+                "object_type": "Light emitting diode",
+                "serial_number": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": null,
+                "bin_height": 4,
+                "bin_mode": "Additive",
+                "bin_unit": "pixel",
+                "bin_width": 4,
+                "bit_depth": 16,
+                "chroma": "Monochrome",
+                "cooling": "Air",
+                "crop_height": 200,
+                "crop_offset_x": 0,
+                "crop_offset_y": 0,
+                "crop_unit": "pixel",
+                "crop_width": 200,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": null,
+                "gain": "2",
+                "immersion": "air",
+                "manufacturer": {
+                    "abbreviation": "FLIR",
+                    "name": "Teledyne FLIR",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "name": "Green CMOS",
+                "notes": null,
+                "object_type": "Detector",
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "21396991",
+                "size_unit": "pixel"
+            },
+            {
+                "additional_settings": null,
+                "bin_height": 4,
+                "bin_mode": "Additive",
+                "bin_unit": "pixel",
+                "bin_width": 4,
+                "bit_depth": 16,
+                "chroma": "Monochrome",
+                "cooling": "Air",
+                "crop_height": 200,
+                "crop_offset_x": 0,
+                "crop_offset_y": 0,
+                "crop_unit": "pixel",
+                "crop_width": 200,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": null,
+                "gain": "2",
+                "immersion": "air",
+                "manufacturer": {
+                    "abbreviation": "FLIR",
+                    "name": "Teledyne FLIR",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "name": "Red CMOS",
+                "notes": null,
+                "object_type": "Detector",
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "21396991",
+                "size_unit": "pixel"
+            },
+            {
+                "lick_spouts": [
+                    {
+                        "additional_settings": null,
+                        "lick_sensor": {
+                            "additional_settings": null,
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": "Research Organization Registry (ROR)",
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Janelia_Lick_Detector Left",
+                            "notes": null,
+                            "object_type": "Device",
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Left lick spout",
+                        "notes": null,
+                        "object_type": "Lick spout",
+                        "serial_number": null,
+                        "solenoid_valve": {
+                            "additional_settings": null,
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "DigiKey",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "1568-11015-ND",
+                            "name": "Solenoid left",
+                            "notes": null,
+                            "object_type": "Device",
+                            "serial_number": null
+                        },
+                        "spout_diameter": "0.8",
+                        "spout_diameter_unit": "millimeter"
+                    },
+                    {
+                        "additional_settings": null,
+                        "lick_sensor": {
+                            "additional_settings": null,
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": "Research Organization Registry (ROR)",
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Janelia_Lick_Detector Right",
+                            "notes": null,
+                            "object_type": "Device",
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Right lick spout",
+                        "notes": null,
+                        "object_type": "Lick spout",
+                        "serial_number": null,
+                        "solenoid_valve": {
+                            "additional_settings": null,
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "DigiKey",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "1568-11015-ND",
+                            "name": "Solenoid right",
+                            "notes": null,
+                            "object_type": "Device",
+                            "serial_number": null
+                        },
+                        "spout_diameter": "0.8",
+                        "spout_diameter_unit": "millimeter"
+                    }
+                ],
+                "motorized_stage": null,
+                "name": "Lick spout assembly",
+                "object_type": "Lick spout assembly"
+            },
+            {
+                "additional_settings": null,
+                "coordinate_system": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": null,
+                "name": "Speaker",
+                "notes": "Unknown manufacturer",
+                "object_type": "Speaker",
+                "relative_position": [
+                    "Anterior"
+                ],
+                "serial_number": null,
+                "transform": null
+            },
+            {
+                "additional_settings": null,
+                "diameter": "4.0",
+                "diameter_unit": "centimeter",
+                "manufacturer": null,
+                "model": null,
+                "name": "Mouse Tube",
+                "notes": null,
+                "object_type": "Tube",
+                "serial_number": null
+            },
+            {
+                "additional_settings": null,
+                "channels": [],
+                "data_interface": "USB",
+                "firmware_version": null,
+                "hardware_version": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Arduino",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "Arduino Uno",
+                "name": "Arduino",
+                "notes": null,
+                "object_type": "DAQ device",
+                "serial_number": null
+            }
+        ],
+        "connections": [
+            {
+                "object_type": "Connection",
+                "send_and_receive": false,
+                "source_device": "Arduino",
+                "source_port": "10",
+                "target_device": "Solenoid right",
+                "target_port": null
+            },
+            {
+                "object_type": "Connection",
+                "send_and_receive": false,
+                "source_device": "Arduino",
+                "source_port": "11",
+                "target_device": "Solenoid left",
+                "target_port": null
+            },
+            {
+                "object_type": "Connection",
+                "send_and_receive": false,
+                "source_device": "Arduino",
+                "source_port": "5",
+                "target_device": "Speaker",
+                "target_port": null
+            },
+            {
+                "object_type": "Connection",
+                "send_and_receive": false,
+                "source_device": "Arduino",
+                "source_port": "7",
+                "target_device": "Speaker",
+                "target_port": null
+            },
+            {
+                "object_type": "Connection",
+                "send_and_receive": false,
+                "source_device": "Janelia_Lick_Detector Right",
+                "source_port": null,
+                "target_device": "Arduino",
+                "target_port": "3"
+            },
+            {
+                "object_type": "Connection",
+                "send_and_receive": false,
+                "source_device": "Janelia_Lick_Detector Left",
+                "source_port": null,
+                "target_device": "Arduino",
+                "target_port": "4"
+            }
+        ],
+        "coordinate_system": {
+            "axes": [
+                {
+                    "direction": "Posterior_to_anterior",
+                    "name": "AP",
+                    "object_type": "Axis"
+                },
+                {
+                    "direction": "Left_to_right",
+                    "name": "ML",
+                    "object_type": "Axis"
+                },
+                {
+                    "direction": "Superior_to_inferior",
+                    "name": "SI",
+                    "object_type": "Axis"
+                }
+            ],
+            "axis_unit": "millimeter",
+            "name": "BREGMA_ARI",
+            "object_type": "Coordinate system",
+            "origin": "Bregma"
+        },
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
+        "instrument_id": "FIP_Sue",
+        "location": "321",
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "fib",
+                "name": "Fiber photometry"
+            }
+        ],
+        "modification_date": "2021-02-10",
+        "notes": "Instrument made retroactively from incomplete records.",
+        "object_type": "Instrument",
+        "schema_version": "2.0.38",
+        "temperature_control": null
+    },
+    "last_modified": "2025-09-25T23:53:05.038Z",
+    "location": "s3://aind-open-data/669492_2023-07-07_17-52-04_nwb_2025-09-05_16-22-41",
+    "metadata_status": "Missing",
+    "name": "669492_2023-07-07_17-52-04_nwb_2025-09-05_16-22-41",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.2.1",
+        "specimen_procedures": [],
+        "subject_id": "669492",
+        "subject_procedures": [
+            {
+                "anaesthesia": {
+                    "duration": "120.0",
+                    "duration_unit": "minute",
+                    "level": "1.5",
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": "24.0",
+                "animal_weight_prior": "22.6",
+                "experimenter_full_name": "NSB-949",
+                "iacuc_protocol": "2115",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "headframe_material": null,
+                        "headframe_part_number": null,
+                        "headframe_type": null,
+                        "procedure_type": "Headframe",
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    },
+                    {
+                        "bregma_to_lambda_distance": "3.901",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": "-5.4",
+                        "injection_coordinate_depth": [
+                            "-3.1"
+                        ],
+                        "injection_coordinate_ml": "-0.85",
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Left",
+                        "injection_materials": [],
+                        "injection_volume": [
+                            "600.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "instrument_id": "NJ#3",
+                        "procedure_type": "Nanoject injection",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4",
+                        "recovery_time": "15.0",
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    },
+                    {
+                        "probes": [
+                            {
+                                "angle": "0.0",
+                                "angle_unit": "degrees",
+                                "bregma_to_lambda_distance": "3.901",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "notes": null,
+                                "ophys_probe": {
+                                    "active_length": null,
+                                    "additional_settings": {},
+                                    "core_diameter_unit": "micrometer",
+                                    "device_type": "Fiber optic probe",
+                                    "ferrule_material": null,
+                                    "length_unit": "millimeter",
+                                    "manufacturer": null,
+                                    "model": null,
+                                    "name": "Fiber_1",
+                                    "notes": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "serial_number": null,
+                                    "total_length": "4.5"
+                                },
+                                "stereotactic_coordinate_ap": "-5.4",
+                                "stereotactic_coordinate_dv": "-2.95",
+                                "stereotactic_coordinate_ml": "-0.85",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "targeted_structure": null
+                            }
+                        ],
+                        "procedure_type": "Fiber implant"
+                    },
+                    {
+                        "probes": [
+                            {
+                                "angle": "0.0",
+                                "angle_unit": "degrees",
+                                "bregma_to_lambda_distance": "3.901",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "notes": null,
+                                "ophys_probe": {
+                                    "active_length": null,
+                                    "additional_settings": {},
+                                    "core_diameter_unit": "micrometer",
+                                    "device_type": "Fiber optic probe",
+                                    "ferrule_material": null,
+                                    "length_unit": "millimeter",
+                                    "manufacturer": null,
+                                    "model": null,
+                                    "name": "Fiber_0",
+                                    "notes": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "serial_number": null,
+                                    "total_length": "2.5"
+                                },
+                                "stereotactic_coordinate_ap": "2.0",
+                                "stereotactic_coordinate_dv": "-1.05",
+                                "stereotactic_coordinate_ml": "-0.5",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "targeted_structure": null
+                            }
+                        ],
+                        "procedure_type": "Fiber implant"
+                    },
+                    {
+                        "probes": [
+                            {
+                                "angle": "7.0",
+                                "angle_unit": "degrees",
+                                "bregma_to_lambda_distance": "3.901",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "notes": null,
+                                "ophys_probe": {
+                                    "active_length": null,
+                                    "additional_settings": {},
+                                    "core_diameter_unit": "micrometer",
+                                    "device_type": "Fiber optic probe",
+                                    "ferrule_material": null,
+                                    "length_unit": "millimeter",
+                                    "manufacturer": null,
+                                    "model": null,
+                                    "name": "Fiber_2",
+                                    "notes": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "serial_number": null,
+                                    "total_length": "2.5"
+                                },
+                                "stereotactic_coordinate_ap": "-6.1",
+                                "stereotactic_coordinate_dv": "-1.8",
+                                "stereotactic_coordinate_ml": "-2.46",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "targeted_structure": null
+                            }
+                        ],
+                        "procedure_type": "Fiber implant"
+                    }
+                ],
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2",
+                "start_date": "2023-03-27",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 3"
+            }
+        ]
+    },
+    "processing": null,
+    "quality_control": null,
+    "rig": null,
+    "schema_version": "1.1.1",
+    "session": null,
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Exp-ND-01-001-2115",
+            "maternal_genotype": "wt/wt",
+            "maternal_id": "652667",
+            "paternal_genotype": "Dbh-Cre-KI/wt",
+            "paternal_id": "655804"
+        },
+        "date_of_birth": "2023-02-11",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "Dbh-Cre-KI/wt",
+        "housing": null,
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.3",
+        "sex": "Male",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "669492",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
PR adds support for repairing missing core_diameter/numerical_aperture fields. These have always been the same (confirmed w/ both Ali and Kenta)