### PR TITLE
fix: capture all top-level procedures into surgeries, fix bug in RO

### DIFF
--- a/src/aind_metadata_upgrader/procedures/v1v2.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2.py
@@ -514,6 +514,11 @@ class ProceduresUpgraderV1V2(CoreUpgrader):
             # procedure instead of nesting it inside a Surgery object.
             return self._wrap_procedure_in_surgery(data, data)
 
+        elif procedure_type in PROC_UPGRADE_MAP:
+            # Some legacy records store surgery sub-procedures (e.g. injections) directly
+            # as top-level subject procedures instead of nesting them inside a Surgery object.
+            return self._wrap_procedure_in_surgery(data, data)
+
         raise ValueError("Unsupported subject procedure type: {}".format(procedure_type))
 
     def _upgrade_specimen_procedure(self, data: dict) -> dict:

--- a/src/aind_metadata_upgrader/procedures/v1v2_injections.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2_injections.py
@@ -304,7 +304,7 @@ def upgrade_retro_orbital_injection(data: dict) -> dict:
     upgraded_data.pop("procedure_type", None)
 
     upgraded_data = upgrade_generic_injection(upgraded_data)
-    injection_materials = upgrade_injection_materials(data.get("injection_materials", []))
+    injection_materials = upgrade_injection_materials(data.get("injection_materials") or [])
 
     if len(injection_materials) == 0:
         injection_materials.append(


### PR DESCRIPTION
This PR fixes two very small issues. First it fixes an old issue from when procedures weren't yet wrapped in Surgery objects. I had helper functions that captured some kinds of procedures and wrapped them, but I missed others. This now just handles them all the same way (through the MAP dictionary).

The second issue was that if the injection materials were empty it would pass None to the upgrade function, but that particular function expects an empty list.