### PR TITLE
fix: only append _# for duplicates

### DIFF
--- a/src/aind_metadata_upgrader/processing/v1v2.py
+++ b/src/aind_metadata_upgrader/processing/v1v2.py
@@ -50,7 +50,7 @@ class ProcessingV1V2(CoreUpgrader):
             self.names[name] = 1
         else:
             self.names[name] += 1
-            
+
         if self.names[name] > 1:
             return f"{name}_{self.names[name]}"
         return name

--- a/src/aind_metadata_upgrader/processing/v1v2.py
+++ b/src/aind_metadata_upgrader/processing/v1v2.py
@@ -44,13 +44,16 @@ class ProcessingV1V2(CoreUpgrader):
         return repaired
 
     def _get_process_name(self, name: str) -> str:
-        """Get a name for this process, append 1/2/3 for duplicates"""
+        """Get a name for this process, append _2/_3/etc for duplicates"""
 
         if name not in self.names:
             self.names[name] = 1
         else:
             self.names[name] += 1
-        return f"{name}_{self.names[name]}"
+            
+        if self.names[name] > 1:
+            return f"{name}_{self.names[name]}"
+        return name
 
     def _convert_v1_process_to_v2(self, process_data: dict, stage: str) -> dict:
         """Convert a V1 process/analysis to V2 DataProcess format"""

--- a/tests/records/v1/0a1bad79-e708-47bb-bbb8-8fafa62dc81e.json
+++ b/tests/records/v1/0a1bad79-e708-47bb-bbb8-8fafa62dc81e.json
@@ -1,0 +1,2556 @@
+{
+    "_id": "0a1bad79-e708-47bb-bbb8-8fafa62dc81e",
+    "acquisition": null,
+    "created": "2025-06-28T04:43:47.059682",
+    "data_description": {
+        "creation_time": "2025-06-26T12:50:52-07:00",
+        "data_level": "raw",
+        "data_summary": "Videos are compressed after upload.",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "funding_source": [
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "AI",
+                    "name": "Allen Institute",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null
+            },
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "NIMH",
+                    "name": "National Institute of Mental Health",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04xeg9z08"
+                },
+                "grant_number": "1R01MH134833"
+            }
+        ],
+        "group": null,
+        "institution": {
+            "abbreviation": "AIND",
+            "name": "Allen Institute for Neural Dynamics",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "investigators": [
+            {
+                "abbreviation": null,
+                "name": "Alex Piet",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Jonathan Ting",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Kenta Hagihara",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Sue Su",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Yoav Ben-Simon",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "rachel.lee@alleninstitute.org",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "stefano.recanatesi@alleninstitute.org",
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "label": null,
+        "license": "CC-BY-4.0",
+        "modality": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "fib",
+                "name": "Fiber photometry"
+            }
+        ],
+        "name": "behavior_774212_2025-06-26_12-50-52",
+        "platform": {
+            "abbreviation": "behavior",
+            "name": "Behavior platform"
+        },
+        "project_name": "Discovery-Neuromodulator circuit dynamics during foraging - Subproject 3 Fiber Photometry Recordings of NM Release During Behavior",
+        "related_data": [],
+        "restrictions": null,
+        "schema_version": "1.0.3",
+        "subject_id": "774212"
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "eb4ca21d-a897-4396-a90a-73195296f88e"
+        ]
+    },
+    "instrument": null,
+    "last_modified": "2026-05-12T22:37:41.020Z",
+    "location": "s3://aind-open-data/behavior_774212_2025-06-26_12-50-52",
+    "metadata_status": "Missing",
+    "name": "behavior_774212_2025-06-26_12-50-52",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.1.3",
+        "specimen_procedures": [],
+        "subject_id": "774212",
+        "subject_procedures": [
+            {
+                "anaesthesia": {
+                    "duration": "150.0",
+                    "duration_unit": "minute",
+                    "level": "1.5",
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": "30.0",
+                "animal_weight_prior": "27.4",
+                "experimenter_full_name": "NSB",
+                "iacuc_protocol": null,
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "headframe_material": null,
+                        "headframe_part_number": null,
+                        "headframe_type": "L-shaped",
+                        "procedure_type": "Headframe",
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    },
+                    {
+                        "bregma_to_lambda_distance": "3.997",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": null,
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": "-5.4",
+                        "injection_coordinate_depth": [
+                            "2.9"
+                        ],
+                        "injection_coordinate_ml": "-0.85",
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Left",
+                        "injection_materials": [
+                            {
+                                "addgene_id": null,
+                                "material_type": "Virus",
+                                "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                "tars_identifiers": {
+                                    "plasmid_tars_alias": "AiP32066",
+                                    "prep_date": "2024-04-12",
+                                    "prep_lot_number": "VT7113G",
+                                    "prep_protocol": "SOP#VC003",
+                                    "prep_type": "Purified",
+                                    "virus_tars_id": "VIR32066_PHPeB"
+                                },
+                                "titer": 68700000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "injection_volume": [
+                            "300.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "instrument_id": null,
+                        "procedure_type": "Nanoject injection",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4",
+                        "recovery_time": "15.0",
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    },
+                    {
+                        "bregma_to_lambda_distance": "3.997",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": null,
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": "-5.4",
+                        "injection_coordinate_depth": [
+                            "2.9"
+                        ],
+                        "injection_coordinate_ml": "0.85",
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Right",
+                        "injection_materials": [
+                            {
+                                "addgene_id": null,
+                                "material_type": "Virus",
+                                "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                "tars_identifiers": {
+                                    "plasmid_tars_alias": "AiP32066",
+                                    "prep_date": "2024-04-12",
+                                    "prep_lot_number": "VT7113G",
+                                    "prep_protocol": "SOP#VC003",
+                                    "prep_type": "Purified",
+                                    "virus_tars_id": "VIR32066_PHPeB"
+                                },
+                                "titer": 68700000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "injection_volume": [
+                            "300.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "instrument_id": null,
+                        "procedure_type": "Nanoject injection",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4",
+                        "recovery_time": "15.0",
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    },
+                    {
+                        "probes": [
+                            {
+                                "angle": null,
+                                "angle_unit": "degrees",
+                                "bregma_to_lambda_distance": "3.997",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "notes": null,
+                                "ophys_probe": {
+                                    "active_length": null,
+                                    "additional_settings": {},
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "device_type": "Fiber optic probe",
+                                    "ferrule_material": "Ceramic",
+                                    "length_unit": "millimeter",
+                                    "manufacturer": {
+                                        "abbreviation": null,
+                                        "name": "Neurophotometrics",
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "name": "Fiber_0",
+                                    "notes": null,
+                                    "numerical_aperture": 0.37,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "serial_number": null,
+                                    "total_length": "2.5"
+                                },
+                                "stereotactic_coordinate_ap": "2.0",
+                                "stereotactic_coordinate_dv": "1.5",
+                                "stereotactic_coordinate_ml": "0.5",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "targeted_structure": null
+                            }
+                        ],
+                        "procedure_type": "Fiber implant"
+                    },
+                    {
+                        "probes": [
+                            {
+                                "angle": null,
+                                "angle_unit": "degrees",
+                                "bregma_to_lambda_distance": "3.997",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "notes": null,
+                                "ophys_probe": {
+                                    "active_length": null,
+                                    "additional_settings": {},
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "device_type": "Fiber optic probe",
+                                    "ferrule_material": "Ceramic",
+                                    "length_unit": "millimeter",
+                                    "manufacturer": {
+                                        "abbreviation": null,
+                                        "name": "Neurophotometrics",
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "name": "Fiber_1",
+                                    "notes": null,
+                                    "numerical_aperture": 0.37,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "serial_number": null,
+                                    "total_length": "4.0"
+                                },
+                                "stereotactic_coordinate_ap": "-1.6",
+                                "stereotactic_coordinate_dv": "3.2",
+                                "stereotactic_coordinate_ml": "-1.6",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "targeted_structure": null
+                            }
+                        ],
+                        "procedure_type": "Fiber implant"
+                    },
+                    {
+                        "probes": [
+                            {
+                                "angle": "12.0",
+                                "angle_unit": "degrees",
+                                "bregma_to_lambda_distance": "3.997",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "notes": null,
+                                "ophys_probe": {
+                                    "active_length": null,
+                                    "additional_settings": {},
+                                    "core_diameter_unit": "micrometer",
+                                    "device_type": "Fiber optic probe",
+                                    "ferrule_material": null,
+                                    "length_unit": "millimeter",
+                                    "manufacturer": null,
+                                    "model": null,
+                                    "name": "Fiber_2",
+                                    "notes": "Tapered fiber in burr hole 5 is 12 degree lateral. It should be angeled in the way that the ferrule is farther away from the midline than the bottom tip. Please also refer to the instructions for tapered fiber for this fiber. Please note: only burr hole 5 uses tapered fiber. ",
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "serial_number": null,
+                                    "total_length": "5.0"
+                                },
+                                "stereotactic_coordinate_ap": "-6.2",
+                                "stereotactic_coordinate_dv": "4.5",
+                                "stereotactic_coordinate_ml": "-1.5",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "targeted_structure": null
+                            }
+                        ],
+                        "procedure_type": "Fiber implant"
+                    }
+                ],
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2",
+                "start_date": "2025-03-24",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 4"
+            },
+            {
+                "baseline_weight": "28.1",
+                "end_date": "2025-06-27",
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "procedure_type": "Water restriction",
+                "start_date": "2025-04-11",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "weight_unit": "gram"
+            }
+        ]
+    },
+    "processing": {
+        "analyses": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "notes": null,
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-behavior-video-transformation",
+                    "end_date_time": "2025-10-17T04:18:48Z",
+                    "input_location": "//allen/aind/scratch/dynamic_foraging_rig_transfer/behavior_774212_2025-06-26_12-50-52/behavior-videos",
+                    "name": "Compression",
+                    "notes": "Called compression library with gamma-encoding-fix-colorspace.",
+                    "output_location": "s3://aind-open-data/behavior_774212_2025-06-26_12-50-52/behavior-videos",
+                    "outputs": {},
+                    "parameters": {
+                        "compression_requested": {
+                            "compression_enum": "gamma fix colorspace",
+                            "user_ffmpeg_input_options": null,
+                            "user_ffmpeg_output_options": null
+                        },
+                        "ffmpeg_thread_cnt": 4,
+                        "input_source": "/data",
+                        "output_directory": "/results",
+                        "parallel_compression": true,
+                        "video_specific_compression_requests": null
+                    },
+                    "software_version": "0.2.0",
+                    "start_date_time": "2025-10-16T14:18:48Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/ffmpeg-fix-colorrange-metadata-capsule",
+                    "code_version": "1.0.0",
+                    "end_date_time": "2026-04-06T22:28:06Z",
+                    "input_location": "",
+                    "name": "Fix Color Range",
+                    "notes": "Fixed mp4 color range metadata via ffmpeg.",
+                    "output_location": "",
+                    "parameters": {},
+                    "software_version": "",
+                    "start_date_time": "2026-04-06T22:18:33Z"
+                }
+            ],
+            "note": null,
+            "pipeline_url": null,
+            "pipeline_version": null,
+            "processor_full_name": "AIND Scientific Computing"
+        },
+        "schema_version": "1.1.3"
+    },
+    "quality_control": null,
+    "rig": {
+        "additional_devices": [
+            {
+                "additional_settings": {},
+                "device_type": "Photometry Clock",
+                "manufacturer": null,
+                "model": null,
+                "name": "Photometry Clock",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            }
+        ],
+        "calibrations": [
+            {
+                "calibration_date": "2025-06-24T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.045
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-06-17T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.065
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-06-10T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.02
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-06-03T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        1.76
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-05-13T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.13
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-05-06T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.235
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-29T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.17
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-23T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.27
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-15T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.105
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-08T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.09
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-01T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.205
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-25T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.1
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-18T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.185
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-12T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.1
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-04T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.19
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-25T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-18T00:00:00-08:00",
+                "description": "Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        1.732,
+                        2.634
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-06-24T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.235
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-06-17T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.155
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-06-10T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.265
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-06-03T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.015
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-05-13T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.23
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-05-06T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.16
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-29T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.215
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-23T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.22
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-15T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.145
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-08T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.25
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-01T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.18
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-25T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-18T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.145
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-12T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.25
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-04T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-25T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-18T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.05
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-11T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.1
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-01-06T00:00:00-08:00",
+                "description": "Water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        1.16,
+                        2.45
+                    ]
+                }
+            }
+        ],
+        "cameras": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT714027",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "Right size of face camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "24211019",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face side right",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Fujinon",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "CF16ZA-1S",
+                    "name": "Behavior Video Lens Right Side",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Right Camera assembly",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT714027",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "bottom of face camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "24210996",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face bottom",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "25",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Other",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "LM25HC",
+                    "name": "Behavior Video Lens Bottom of face",
+                    "notes": "Manufacturer is Kowa",
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Bottom Camera assembly",
+                "position": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "daqs": [
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "DI3",
+                        "channel_type": "Digital Input",
+                        "device_name": "Photometry Clock",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT714027",
+                "core_version": "1.11",
+                "data_interface": "Ethernet",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Behavior",
+                    "whoami": 1216
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp behavior board",
+                "notes": "Left lick spout and Right lick spout, as well as reward delivery solenoids are connected via ethernet cables",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714027",
+                "core_version": "1.4",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Sound Card",
+                    "whoami": 1280
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp sound card",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714027",
+                "core_version": "",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Clock Synchronizer",
+                    "whoami": 1152
+                },
+                "is_clock_generator": true,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp clock synchronization board",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714027",
+                "core_version": "",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Input Expander",
+                    "whoami": 1106
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp sound amplifier",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "detectors": [
+            {
+                "additional_settings": {},
+                "bin_height": 4,
+                "bin_mode": "Additive",
+                "bin_unit": "pixel",
+                "bin_width": 4,
+                "bit_depth": 16,
+                "chroma": "Monochrome",
+                "computer_name": null,
+                "cooling": "Air",
+                "crop_height": 200,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": 200,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": "2",
+                "immersion": "air",
+                "manufacturer": {
+                    "abbreviation": "FLIR",
+                    "name": "Teledyne FLIR",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "name": "Green CMOS",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "23391007",
+                "size_unit": "pixel"
+            },
+            {
+                "additional_settings": {},
+                "bin_height": 4,
+                "bin_mode": "Additive",
+                "bin_unit": "pixel",
+                "bin_width": 4,
+                "bit_depth": 16,
+                "chroma": "Monochrome",
+                "computer_name": null,
+                "cooling": "Air",
+                "crop_height": 200,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": 200,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": "2",
+                "immersion": "air",
+                "manufacturer": {
+                    "abbreviation": "FLIR",
+                    "name": "Teledyne FLIR",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "name": "Red CMOS",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "23391006",
+                "size_unit": "pixel"
+            }
+        ],
+        "digital_micromirror_devices": [],
+        "enclosure": {
+            "additional_settings": {},
+            "air_filtration": false,
+            "device_type": "Enclosure",
+            "external_material": "",
+            "grounded": false,
+            "internal_material": "",
+            "laser_interlock": false,
+            "manufacturer": {
+                "abbreviation": "AIND",
+                "name": "Allen Institute for Neural Dynamics",
+                "registry": {
+                    "abbreviation": "ROR",
+                    "name": "Research Organization Registry"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "name": "Behavior enclosure",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "size": {
+                "height": 54,
+                "length": 54,
+                "unit": "centimeter",
+                "width": 54
+            }
+        },
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "filters": [
+            {
+                "additional_settings": {},
+                "center_wavelength": 520,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-520/35-25",
+                "name": "Green emission filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 600,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-600/37-25",
+                "name": "Red emission filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": 562,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Dichroic",
+                "filter_wheel_index": null,
+                "height": "25",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF562-Di03-25x36",
+                "name": "Emission Dichroic",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "36"
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Multiband",
+                "filter_wheel_index": null,
+                "height": "25",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF493/574-Di01-25x36",
+                "name": "beamsplitter",
+                "notes": "493/574 nm BrightLine dual-edge standard epi-fluorescence dichroic beamsplitter",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "36"
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 410,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB410-10",
+                "name": "Excitation filter 410nm",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 470,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB470-10",
+                "name": "Excitation filter 470nm",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 560,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB560-10",
+                "name": "Excitation filter 560nm",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": 450,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Dichroic",
+                "filter_wheel_index": null,
+                "height": "25.2",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Edmund Optics",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "#69-898",
+                "name": "450 Dichroic Longpass Filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "35.6"
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": 500,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Dichroic",
+                "filter_wheel_index": null,
+                "height": "23.2",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Edmund Optics",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "#69-899",
+                "name": "500 Dichroic Longpass Filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "35.6"
+            }
+        ],
+        "laser_assemblies": [],
+        "lenses": [
+            {
+                "additional_settings": {},
+                "device_type": "Lens",
+                "focal_length": "80",
+                "focal_length_unit": "millimeter",
+                "lens_size_unit": "inch",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "max_aperture": null,
+                "model": "AC254-080-A-ML",
+                "name": "Image focusing lens",
+                "notes": null,
+                "optimized_wavelength_range": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size": 1,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "name": "IR LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M470F3",
+                "name": "470nm LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 470,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M415F3",
+                "name": "415nm LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 415,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M565F3",
+                "name": "565nm LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 565,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "fib",
+                "name": "Fiber photometry"
+            }
+        ],
+        "modification_date": "2025-06-24",
+        "mouse_platform": {
+            "additional_settings": {},
+            "date_surface_replaced": null,
+            "device_type": "Tube",
+            "diameter": "3.0",
+            "diameter_unit": "centimeter",
+            "manufacturer": {
+                "abbreviation": null,
+                "name": "Custom",
+                "registry": null,
+                "registry_identifier": null
+            },
+            "model": null,
+            "name": "mouse_tube_foraging",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "surface_material": null
+        },
+        "notes": null,
+        "objectives": [
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "air",
+                "magnification": "10",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Nikon",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "0280y9h11"
+                },
+                "model": "CFI Plan Apochromat Lambda D 10x",
+                "name": "Objective",
+                "notes": null,
+                "numerical_aperture": "0.45",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "0"
+            }
+        ],
+        "origin": null,
+        "patch_cords": [
+            {
+                "additional_settings": {},
+                "core_diameter": "200",
+                "device_type": "Patch",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Doric",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "059n53q30"
+                },
+                "model": "BBP(4)_200/220/900-0.37_Custom_FCM-4xMF1.25",
+                "name": "Bundle Branching Fiber-optic Patch Cord",
+                "notes": null,
+                "numerical_aperture": "0.37",
+                "path_to_cad": null,
+                "photobleaching_date": null,
+                "port_index": null,
+                "serial_number": null
+            }
+        ],
+        "pockels_cells": [],
+        "polygonal_scanners": [],
+        "rig_axes": null,
+        "rig_id": "447_2D_20250624",
+        "schema_version": "1.0.1",
+        "stick_microscopes": [],
+        "stimulus_devices": [
+            {
+                "device_type": "Reward delivery",
+                "reward_spouts": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Lick Sensor",
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Lick Sensor Left",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Left lick spout",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Left",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "name": "Solenoid Left",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    },
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Lick Sensor",
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Lick Sensor Right",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Right lick spout",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Right",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "name": "Solenoid Right",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    }
+                ],
+                "stage_type": {
+                    "additional_settings": {},
+                    "device_type": "Motorized stage",
+                    "firmware": null,
+                    "manufacturer": {
+                        "abbreviation": "AIND",
+                        "name": "Allen Institute for Neural Dynamics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04szwah67"
+                    },
+                    "model": null,
+                    "name": "AIND lick spout stage",
+                    "notes": "https://allenneuraldynamics.github.io/Bonsai.AllenNeuralDynamics/articles/aind-manipulator.html",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "travel": "30",
+                    "travel_unit": "millimeter"
+                }
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Speaker",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Tymphany",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "XT25SC90-04",
+                "name": "Stimulus Speaker",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "serial_number": null
+            }
+        ]
+    },
+    "schema_version": "1.1.1",
+    "session": {
+        "active_mouse_platform": false,
+        "anaesthesia": null,
+        "animal_weight_post": "23.02",
+        "animal_weight_prior": null,
+        "calibrations": [],
+        "data_streams": [
+            {
+                "camera_names": [
+                    "Face Side Right",
+                    "Face Bottom"
+                ],
+                "daq_names": [
+                    ""
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": "5109.467839",
+                        "exposure_time_unit": "microsecond",
+                        "name": "Green CMOS",
+                        "trigger_type": "External"
+                    },
+                    {
+                        "exposure_time": "5109.467839",
+                        "exposure_time_unit": "microsecond",
+                        "name": "Red CMOS",
+                        "trigger_type": "External"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_green",
+                            "intended_measurement": "calcium",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_green",
+                            "intended_measurement": "calcium",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_green",
+                            "intended_measurement": "calcium",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "disconnected",
+                        "patch_cord_name": "Patch Cord D",
+                        "patch_cord_output_power": "0.0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "disconnected",
+                            "intended_measurement": null,
+                            "light_source_name": "None",
+                            "filter_names": [
+                                "None"
+                            ],
+                            "detector_name": "None",
+                            "excitation_wavelength": 300,
+                            "excitation_power": 0,
+                            "emission_wavelength": 300,
+                            "description": "Not connected to any implanted fiber",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    }
+                ],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Light emitting diode",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "IR LED"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "470nm LED"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "415nm LED"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "565nm LED"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "None;Fib modality: fib mode: Axon This record has been updated to include intended measurements. Fiber connections are repeated for fibers with multiple channels. Disconnected fibers are marked with fiber_name 'disconnected'.",
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [
+                    {
+                        "name": "dynamic-foraging-task",
+                        "parameters": {},
+                        "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                        "version": "behavior branch:main   commit ID:a0867eda28955ad4adedab2d5cfac29e43f0d73f    version:1.6.47; metadata branch: main   commit ID:a0867eda28955ad4adedab2d5cfac29e43f0d73f   version:1.6.47"
+                    }
+                ],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-06-26T14:19:56.386999-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "behavior-videos",
+                        "name": "Behavior videos"
+                    },
+                    {
+                        "abbreviation": "fib",
+                        "name": "Fiber photometry"
+                    }
+                ],
+                "stream_start_time": "2025-06-26T12:51:13.443804-07:00"
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "experimenter_full_name": [
+            "Avalon Amaya"
+        ],
+        "headframe_registration": null,
+        "iacuc_protocol": "2414",
+        "maintenance": [],
+        "mouse_platform_name": "mouse_tube_foraging",
+        "notes": "",
+        "protocol_id": [
+            ""
+        ],
+        "reward_consumed_total": "418.0",
+        "reward_consumed_unit": "microliter",
+        "reward_delivery": null,
+        "rig_id": "447_2D_20250624",
+        "schema_version": "1.0.1",
+        "session_end_time": "2025-06-26T14:19:56.386999-07:00",
+        "session_start_time": "2025-06-26T12:51:13.443804-07:00",
+        "session_type": "Uncoupled Without Baiting",
+        "stimulus_epochs": [
+            {
+                "light_source_config": [],
+                "notes": "The duration of go cue is 100 ms. The frequency is 7500 Hz. Amplitude is 76dB. The total reward consumed in the session is 418.0 microliters. The total reward including consumed in the session and supplementary water is 1.285 milliliters.",
+                "output_parameters": {
+                    "meta": {
+                        "box": "447-2-D",
+                        "session_run_time_in_min": 85
+                    },
+                    "performance": {
+                        "foraging_efficiency": 0.6238805970149254,
+                        "foraging_efficiency_with_actual_random_seed": 0.6075581395348838
+                    },
+                    "task_parameters": {
+                        "BlockBeta": "20",
+                        "BlockMax": "35",
+                        "BlockMin": "20",
+                        "DelayBeta": "0.0",
+                        "DelayMax": "1.0",
+                        "DelayMin": "1.0",
+                        "ITIBeta": "3.0",
+                        "ITIMax": "15.0",
+                        "ITIMin": "2.0",
+                        "LeftValue_volume": "2.00",
+                        "RightValue_volume": "2.00",
+                        "Task": "Uncoupled Without Baiting",
+                        "reward_probability": "0.1, 0.5, 0.9",
+                        "curriculum_in_use": "Uncoupled Without Baiting (v2.3rwdDelay159@1.0)",
+                        "stage_in_use": "GRADUATED"
+                    },
+                    "water": {
+                        "water_after_session": 0.865,
+                        "water_day_total": 1.285,
+                        "water_in_session_foraging": 0.418,
+                        "water_in_session_manual": 0.0019999999999999463,
+                        "water_in_session_total": 0.41999999999999993
+                    }
+                },
+                "reward_consumed_during_epoch": "418.0",
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "dynamic-foraging-task",
+                        "parameters": {},
+                        "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                        "version": "behavior branch:main   commit ID:a0867eda28955ad4adedab2d5cfac29e43f0d73f    version:1.6.47; metadata branch: main   commit ID:a0867eda28955ad4adedab2d5cfac29e43f0d73f   version:1.6.47"
+                    }
+                ],
+                "speaker_config": {
+                    "name": "Stimulus Speaker",
+                    "volume": "76",
+                    "volume_unit": "decibels"
+                },
+                "stimulus_device_names": [
+                    "Stimulus Speaker"
+                ],
+                "stimulus_end_time": "2025-06-26T14:16:19.054634-07:00",
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_name": "The behavior auditory go cue",
+                "stimulus_parameters": [
+                    {
+                        "amplitude_modulation_frequency": 7500,
+                        "bandpass_filter_type": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_low_frequency": null,
+                        "bandpass_order": null,
+                        "frequency_unit": "hertz",
+                        "notes": null,
+                        "sample_frequency": "96000",
+                        "stimulus_name": "auditory go cue",
+                        "stimulus_type": "Auditory Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-06-26T12:51:13.443804-07:00",
+                "trials_finished": 393,
+                "trials_rewarded": 209,
+                "trials_total": 490
+            }
+        ],
+        "subject_id": "774212",
+        "weight_unit": "gram"
+    },
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Dbh-Cre-KI(ND)",
+            "maternal_genotype": "Dbh-Cre-KI/wt",
+            "maternal_id": "751771",
+            "paternal_genotype": "wt/wt",
+            "paternal_id": "756381"
+        },
+        "date_of_birth": "2024-10-25",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "Dbh-Cre-KI/wt",
+        "housing": {
+            "cage_id": "8291851",
+            "cohoused_subjects": [],
+            "home_cage_enrichment": [],
+            "light_cycle": null,
+            "room_id": "221"
+        },
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.2",
+        "sex": "Male",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "774212",
+        "wellness_reports": []
+    }
+}

--- a/tests/test_processing_v1v2.py
+++ b/tests/test_processing_v1v2.py
@@ -82,16 +82,16 @@ class TestProcessingV1V2(unittest.TestCase):
 
         # Check that duplicate names are handled
         process_names = [proc["name"] for proc in result["data_processes"]]
-        self.assertIn("Analysis_1", process_names)  # First processing process
+        self.assertIn("Analysis", process_names)  # First processing process
         self.assertIn("Analysis_2", process_names)  # First analysis (duplicate resolved)
         self.assertIn("Analysis_3", process_names)  # Second analysis (duplicate resolved)
 
     def test_upgrade_with_analyses_complex_duplicate_names(self):
         """Test upgrade with analyses having complex duplicate names - covers lines 132-135"""
 
-        # Create a scenario where processing creates "Analysis_1", "Analysis_2",
+        # Create a scenario where processing creates "Analysis", "Analysis_2",
         # and then analyses has "Analysis" which should become "Analysis_3"
-        # and another "Analysis" which should check if "Analysis_1" is in seen_names
+        # and another "Analysis" which should check if "Analysis" is in seen_names
         data = {
             "processing_pipeline": {
                 "data_processes": [
@@ -133,7 +133,7 @@ class TestProcessingV1V2(unittest.TestCase):
 
         # Check that the while loop incremented properly when Analysis_1, Analysis_2, Analysis_3 were already seen
         process_names = [proc["name"] for proc in result["data_processes"]]
-        self.assertIn("Analysis_1", process_names)  # First processing process
+        self.assertIn("Analysis", process_names)  # First processing process
         self.assertIn("Analysis_2", process_names)  # Second processing process
         self.assertIn("Analysis_3", process_names)  # First analysis
         self.assertIn("Analysis_4", process_names)  # Second analysis (had to skip Analysis_1, 2, 3)


### PR DESCRIPTION
Small PR makes it so that we don't unnecessarily append new name information onto DataProcess objects that are unique. So the first time you see "Fix color range" it shows up like that, and not as "Fix color range_1". If someone has duplicate DataProcess names the second and onward still get _2, _3, etc appended.