### PR TITLE
fix: remove instead of del, and return empty experimenters

### DIFF
--- a/src/aind_metadata_upgrader/acquisition/v1v2.py
+++ b/src/aind_metadata_upgrader/acquisition/v1v2.py
@@ -10,7 +10,7 @@ from aind_metadata_upgrader.acquisition.v1v2_tiles import (
     upgrade_tiles_to_data_stream,
 )
 from aind_metadata_upgrader.base import CoreUpgrader
-from aind_metadata_upgrader.utils.v1v2_utils import upgrade_calibration, upgrade_reagent, ensure_pacific_timezone
+from aind_metadata_upgrader.utils.v1v2_utils import upgrade_calibration, upgrade_reagent, ensure_pacific_timezone, upgrade_experimenter_names
 from aind_data_schema.components.coordinates import (
     CoordinateSystem,
     Origin,
@@ -22,18 +22,6 @@ from aind_data_schema.components.coordinates import (
 
 class AcquisitionV1V2(CoreUpgrader):
     """Upgrade acquisition from v1.4 to v2.0"""
-
-    def _upgrade_experimenter_names(self, experimenter_names: List[str]) -> List[Dict]:
-        """Convert experimenter full names to Person objects"""
-        experimenters = []
-
-        if isinstance(experimenter_names, str):
-            experimenter_names = [experimenter_names]
-
-        for name in experimenter_names:
-            if name and name.strip():
-                experimenters.append(name.strip())
-        return experimenters
 
     def _upgrade_maintenance(self, maintenance: List[Dict]) -> List[Dict]:
         """Upgrade maintenance objects"""
@@ -190,7 +178,7 @@ class AcquisitionV1V2(CoreUpgrader):
         )
 
         # Upgrade experimenter names to Person objects
-        experimenters = self._upgrade_experimenter_names(experimenter_full_name)
+        experimenters = upgrade_experimenter_names(experimenter_full_name)
 
         # Create coordinate system from axes (needed both at the acquisition
         # level and inside ImagingConfig when ImageSPIM tiles are present)

--- a/src/aind_metadata_upgrader/acquisition/v1v2.py
+++ b/src/aind_metadata_upgrader/acquisition/v1v2.py
@@ -10,7 +10,12 @@ from aind_metadata_upgrader.acquisition.v1v2_tiles import (
     upgrade_tiles_to_data_stream,
 )
 from aind_metadata_upgrader.base import CoreUpgrader
-from aind_metadata_upgrader.utils.v1v2_utils import upgrade_calibration, upgrade_reagent, ensure_pacific_timezone, upgrade_experimenter_names
+from aind_metadata_upgrader.utils.v1v2_utils import (
+    upgrade_calibration,
+    upgrade_reagent,
+    ensure_pacific_timezone,
+    upgrade_experimenter_names,
+)
 from aind_data_schema.components.coordinates import (
     CoordinateSystem,
     Origin,

--- a/src/aind_metadata_upgrader/instrument/v1v2.py
+++ b/src/aind_metadata_upgrader/instrument/v1v2.py
@@ -22,6 +22,7 @@ from aind_metadata_upgrader.instrument.v1v2_devices import (
     upgrade_scanning_stages,
 )
 from aind_metadata_upgrader.utils.v1v2_utils import (
+    remove,
     upgrade_enclosure,
     upgrade_filter,
     upgrade_lens,
@@ -185,7 +186,7 @@ class InstrumentUpgraderV1V2(CoreUpgrader):
             daq, connections = upgrade_daq_devices(daq)
             saved_connections.extend(connections)
             upgraded_daqs.append(daq)
-        del data["daqs"]
+        remove(data, "daqs")
 
         return upgraded_daqs, saved_connections
 

--- a/src/aind_metadata_upgrader/rig/v1v2.py
+++ b/src/aind_metadata_upgrader/rig/v1v2.py
@@ -34,6 +34,7 @@ from aind_metadata_upgrader.rig.v1v2_devices import (
     upgrade_stimulus_device,
 )
 from aind_metadata_upgrader.utils.v1v2_utils import (
+    remove,
     upgrade_calibration,
     upgrade_enclosure,
     upgrade_filter,
@@ -363,7 +364,7 @@ class RigUpgraderV1V2(CoreUpgrader):
         daqs = self._none_to_list(data.get("daqs", []))
         upgraded_daqs, daq_connections = self._upgrade_devices_with_connections(daqs, upgrade_daq_devices)
         all_connections.extend(daq_connections)
-        del data["daqs"]
+        remove(data, "daqs")
 
         # Create components list and validate connections
         components = self._create_components_list(

--- a/src/aind_metadata_upgrader/session/v1v2.py
+++ b/src/aind_metadata_upgrader/session/v1v2.py
@@ -62,23 +62,12 @@ from aind_metadata_upgrader.utils.v1v2_utils import (
     upgrade_targeted_structure,
     upgrade_v1_modalities,
     validate_angle_unit,
+    upgrade_experimenter_names,
 )
 
 
 class SessionV1V2(CoreUpgrader):
     """Upgrade session from v1.4 to v2.0 (acquisition)"""
-
-    def _upgrade_experimenter_names(self, experimenter_names: List[str]) -> List[str]:
-        """Convert experimenter full names to Person objects"""
-        experimenters = []
-
-        if isinstance(experimenter_names, str):
-            experimenter_names = [experimenter_names]
-
-        for name in experimenter_names:
-            if name and name.strip():
-                experimenters.append(name.strip())
-        return experimenters
 
     def _upgrade_maintenance(self, maintenance: List[Dict]) -> List[Dict]:
         """Upgrade maintenance objects"""
@@ -990,7 +979,7 @@ class SessionV1V2(CoreUpgrader):
                 self._rig_filters = rig.get("filters", []) or []
 
         # Upgrade experimenter names to Person objects
-        experimenters = self._upgrade_experimenter_names(experimenter_full_name)
+        experimenters = upgrade_experimenter_names(experimenter_full_name)
 
         # Extract the timezone from session_start_time to use as fallback for naive sub-timestamps.
         # This prevents Pydantic's _coerce_naive_datetime from attaching the server's local

--- a/src/aind_metadata_upgrader/utils/v1v2_utils.py
+++ b/src/aind_metadata_upgrader/utils/v1v2_utils.py
@@ -88,6 +88,24 @@ def ensure_pacific_timezone(dt: Optional[str]) -> Optional[datetime]:
     return ensure_timezone(dt, fallback_tz=None)
 
 
+def upgrade_experimenter_names(experimenter_names) -> list:
+    """Convert experimenter names to a list, handling both string and list inputs.
+    
+    Filters out None and empty values.
+    """
+    if not experimenter_names:
+        return []
+    
+    if isinstance(experimenter_names, str):
+        experimenter_names = [experimenter_names]
+
+    experimenters = []
+    for name in experimenter_names:
+        if name and isinstance(name, str) and name.strip():
+            experimenters.append(name.strip())
+    return experimenters
+
+
 def validate_frequency_unit(frequency_unit: str) -> str:
     """Validate a frequency unit and repair it if needed"""
     if frequency_unit in [member.value for member in FrequencyUnit]:

--- a/src/aind_metadata_upgrader/utils/v1v2_utils.py
+++ b/src/aind_metadata_upgrader/utils/v1v2_utils.py
@@ -90,12 +90,12 @@ def ensure_pacific_timezone(dt: Optional[str]) -> Optional[datetime]:
 
 def upgrade_experimenter_names(experimenter_names) -> list:
     """Convert experimenter names to a list, handling both string and list inputs.
-    
+
     Filters out None and empty values.
     """
     if not experimenter_names:
         return []
-    
+
     if isinstance(experimenter_names, str):
         experimenter_names = [experimenter_names]
 
@@ -981,9 +981,9 @@ CCF_MAPPING = {
     "V1 center": CCFv3.VISP,
     "GenFacCran": CCFv3.GVIIN,
     "385": CCFv3.VISP,
-    "AntComMid": CCFv3.ACO,          # anterior commissure, olfactory limb / midline guess
-    "CCant": CCFv3.CC,               # corpus callosum anterior
-    "CCpst": CCFv3.CC,               # corpus callosum posterior
+    "AntComMid": CCFv3.ACO,  # anterior commissure, olfactory limb / midline guess
+    "CCant": CCFv3.CC,  # corpus callosum anterior
+    "CCpst": CCFv3.CC,  # corpus callosum posterior
     "Ccant": CCFv3.CC,
     "Cortex": CCFv3.CTX,
     "DRN": CCFv3.DR,
@@ -1006,7 +1006,7 @@ CCF_MAPPING = {
     "Striatum and GPe (probe A) MRN (probe B)": CCFv3.STR,
     "Striatum, GPe": CCFv3.STR,
     "Thalamus": CCFv3.TH,
-    "VM/VAL": CCFv3.VM,             # could be VM + VAL composite
+    "VM/VAL": CCFv3.VM,  # could be VM + VAL composite
     "VP, NAc": CCFv3.VP,
     "Ventral Striatum": CCFv3.ACB,
     "Ventral Striatum/ NAc": CCFv3.ACB,


### PR DESCRIPTION
Two small repairs:

1. Used the remove function instead of calling del (del alone throws an exception if the field isn't present)
2. Fixed the experimenter upgrade function to return an empty list if the input is empty

The test asset for these didn't end up being upgradeable (old pilot asset), so it was ignored.