### PR TITLE
fix: bypass BrainInjection correctly

### DIFF
--- a/src/aind_metadata_upgrader/procedures/v1v2.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2.py
@@ -290,11 +290,13 @@ class ProceduresUpgraderV1V2(CoreUpgrader):
     def upgrade(self, data: dict, schema_version: str, metadata: Optional[dict] = None) -> dict:
         """Upgrade the procedures to v2"""
 
-        # Extract the nested procedures dict if it exists
+        # Extract the nested procedures dict if it exists.
+        # Deep-copy so that in-place mutations (e.g. remove("procedure_type")) don't
+        # corrupt the caller's dict on a second upgrade attempt.
         if "procedures" in data:
-            procedures_data = data["procedures"]
+            procedures_data = copy.deepcopy(data["procedures"])
         else:
-            procedures_data = data
+            procedures_data = copy.deepcopy(data)
 
         self.subject_id = procedures_data.get("subject_id")
 

--- a/src/aind_metadata_upgrader/procedures/v1v2_injections.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2_injections.py
@@ -255,17 +255,35 @@ def upgrade_brain_injection(data: dict, dynamics: list) -> tuple[dict, list]:
     validate_injection_coordinate_reference(data)
     data = upgrade_injection_coordinates(data)
     data, measured_coordinates = retrieve_bl_distance(data)
-    injection = BrainInjection(
-        injection_materials=ensure_injection_materials_with_default(
-            upgrade_injection_materials(data.get("injection_materials", []))
-        ),
-        targeted_structure=get_targeted_structure_or_none(data),
-        relative_position=build_relative_position_from_hemisphere(data),
-        dynamics=dynamics,
-        protocol_id=data.get("protocol_id", None),
-        coordinate_system_name=CoordinateSystemLibrary.BREGMA_ARID.name,
-        coordinates=ensure_coordinates_match_dynamics(data.get("coordinates", []), dynamics),
+
+    injection_materials = ensure_injection_materials_with_default(
+        upgrade_injection_materials(data.get("injection_materials", []))
     )
+    targeted_structure = get_targeted_structure_or_none(data)
+    relative_position = build_relative_position_from_hemisphere(data)
+    protocol_id = data.get("protocol_id", None)
+    coordinates = ensure_coordinates_match_dynamics(data.get("coordinates", []), dynamics)
+
+    try:
+        injection = BrainInjection(
+            injection_materials=injection_materials,
+            targeted_structure=targeted_structure,
+            relative_position=relative_position,
+            dynamics=dynamics,
+            protocol_id=protocol_id,
+            coordinate_system_name=CoordinateSystemLibrary.BREGMA_ARID.name,
+            coordinates=coordinates,
+        )
+    except Exception:
+        injection = BrainInjection.model_construct(
+            injection_materials=injection_materials,
+            targeted_structure=targeted_structure,
+            relative_position=relative_position,
+            dynamics=dynamics,
+            protocol_id=protocol_id,
+            coordinate_system_name=CoordinateSystemLibrary.BREGMA_ARID.name,
+            coordinates=coordinates,
+        )
     return injection.model_dump(), measured_coordinates
 
 

--- a/tests/records/v1/018d5ad8-5c64-4aae-9ed2-071447cd12c5.json
+++ b/tests/records/v1/018d5ad8-5c64-4aae-9ed2-071447cd12c5.json
@@ -1,0 +1,6679 @@
+{
+    "_id": "018d5ad8-5c64-4aae-9ed2-071447cd12c5",
+    "acquisition": {
+        "active_objectives": [
+            "LCT 3.6x"
+        ],
+        "axes": [
+            {
+                "dimension": 0,
+                "direction": "Superior_to_inferior",
+                "name": "Z",
+                "unit": "micrometer"
+            },
+            {
+                "dimension": 1,
+                "direction": "Anterior_to_posterior",
+                "name": "Y",
+                "unit": "micrometer"
+            },
+            {
+                "dimension": 2,
+                "direction": "Left_to_right",
+                "name": "X",
+                "unit": "micrometer"
+            }
+        ],
+        "calibrations": [],
+        "chamber_immersion": {
+            "medium": "other",
+            "refractive_index": "1.5182"
+        },
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
+        "experimenter_full_name": [
+            "John Rohde"
+        ],
+        "external_storage_directory": "",
+        "instrument_id": "440_SmartSPIM1_20250116",
+        "local_storage_directory": "D:/SmartSPIM_Data",
+        "maintenance": [],
+        "notes": "Chamber immersion: oil - Sample immersion: easy index",
+        "processing_steps": [],
+        "protocol_id": [],
+        "sample_immersion": {
+            "medium": "other",
+            "refractive_index": "1.5165"
+        },
+        "schema_version": "1.0.0",
+        "session_end_time": "2025-04-17T12:31:33-07:00",
+        "session_start_time": "2025-04-16T21:39:58-07:00",
+        "session_type": null,
+        "software": [],
+        "specimen_id": "",
+        "subject_id": "784354",
+        "tiles": [
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "45718.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/433320/433320_457180/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "45718.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/433320/433320_457180/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "45718.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/465720/465720_457180/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "45718.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/465720/465720_457180/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "45718.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/498120/498120_457180/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "45718.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/498120/498120_457180/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "45718.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/530520/530520_457180/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "45718.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/530520/530520_457180/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "48310.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/433320/433320_483100/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "48310.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/433320/433320_483100/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "48310.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/465720/465720_483100/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "48310.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/465720/465720_483100/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "48310.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/498120/498120_483100/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "48310.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/498120/498120_483100/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "48310.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/530520/530520_483100/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "48310.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/530520/530520_483100/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "50902.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/433320/433320_509020/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "50902.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/433320/433320_509020/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "50902.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/465720/465720_509020/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "50902.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/465720/465720_509020/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "50902.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/498120/498120_509020/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "50902.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/498120/498120_509020/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "50902.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/530520/530520_509020/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "50902.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/530520/530520_509020/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "53494.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/433320/433320_534940/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "53494.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/433320/433320_534940/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "53494.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/465720/465720_534940/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "53494.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/465720/465720_534940/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "53494.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/498120/498120_534940/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "53494.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/498120/498120_534940/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "53494.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/530520/530520_534940/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "53494.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/530520/530520_534940/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "56086.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/433320/433320_560860/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "56086.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/433320/433320_560860/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "56086.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/465720/465720_560860/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "56086.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/465720/465720_560860/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "56086.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/498120/498120_560860/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "56086.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/498120/498120_560860/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "56086.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/530520/530520_560860/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "56086.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/530520/530520_560860/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "58678.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/433320/433320_586780/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "58678.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/433320/433320_586780/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "58678.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/465720/465720_586780/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "58678.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/465720/465720_586780/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "58678.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/498120/498120_586780/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "58678.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/498120/498120_586780/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "58678.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/530520/530520_586780/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "58678.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/530520/530520_586780/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "61270.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/433320/433320_612700/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "43332.0",
+                            "61270.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/433320/433320_612700/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90.91,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "61270.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/465720/465720_612700/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 90,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "46572.0",
+                            "61270.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/465720/465720_612700/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "61270.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/498120/498120_612700/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "49812.0",
+                            "61270.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/498120/498120_612700/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "561",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 2,
+                    "light_source_name": "561"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "61270.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_561_Em_593/530520/530520_612700/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            },
+            {
+                "acquisition_end_time": null,
+                "acquisition_start_time": null,
+                "channel": {
+                    "additional_device_names": [],
+                    "channel_name": "639",
+                    "description": null,
+                    "detector_name": "",
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "excitation_power": 100,
+                    "excitation_power_unit": "percent",
+                    "excitation_wavelength": 639,
+                    "excitation_wavelength_unit": "nanometer",
+                    "filter_names": [
+                        ""
+                    ],
+                    "filter_wheel_index": 4,
+                    "light_source_name": "639"
+                },
+                "coordinate_transformations": [
+                    {
+                        "translation": [
+                            "53052.0",
+                            "61270.0",
+                            "176.8"
+                        ],
+                        "type": "translation"
+                    },
+                    {
+                        "scale": [
+                            "1.8",
+                            "1.8",
+                            "2.0"
+                        ],
+                        "type": "scale"
+                    }
+                ],
+                "file_name": "Ex_639_Em_667/530520/530520_612700/",
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees",
+                "notes": "\nLaser power is in percentage of total, it needs calibration"
+            }
+        ]
+    },
+    "created": "2025-05-22T08:24:39.417954",
+    "data_description": {
+        "creation_time": "2025-05-21T16:45:59.586060Z",
+        "data_level": "derived",
+        "data_summary": null,
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "funding_source": [
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "AI",
+                    "name": "Allen Institute",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null
+            },
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "NINDS",
+                    "name": "National Institute of Neurological Disorders and Stroke",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01s5ya894"
+                },
+                "grant_number": "1U19NS123714-01"
+            },
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "NINDS",
+                    "name": "National Institute of Neurological Disorders and Stroke",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01s5ya894"
+                },
+                "grant_number": "1RF1MH128841-01"
+            }
+        ],
+        "group": null,
+        "input_data_name": "SmartSPIM_784354_2025-04-16_21-39-58",
+        "institution": {
+            "abbreviation": "AIND",
+            "name": "Allen Institute for Neural Dynamics",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "investigators": [
+            {
+                "abbreviation": null,
+                "name": "Jayaram Chandrashekar",
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "label": null,
+        "license": "CC-BY-4.0",
+        "modality": [
+            {
+                "abbreviation": "SPIM",
+                "name": "Selective plane illumination microscopy"
+            }
+        ],
+        "name": "SmartSPIM_784354_2025-04-16_21-39-58_stitched_2025-05-21_16-45-59",
+        "platform": {
+            "abbreviation": "SmartSPIM",
+            "name": "SmartSPIM platform"
+        },
+        "process_name": "stitched",
+        "project_name": "MSMA Platform",
+        "related_data": [],
+        "restrictions": null,
+        "schema_version": "1.0.4",
+        "subject_id": "784354"
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "479f80cd-361d-4ee0-a5a5-625860f7a377"
+        ]
+    },
+    "instrument": {
+        "additional_devices": [
+            {
+                "additional_settings": {},
+                "device_type": "Additional imaging device",
+                "imaging_device_type": "Other",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Julabo",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "200F",
+                "name": "Chiller",
+                "notes": "Water chiller for camera cooling",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "10436130"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Additional imaging device",
+                "imaging_device_type": "Other",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Optotune",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "EL-16-40-TC",
+                "name": "tunable lens",
+                "notes": "Electrically tunable lens",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Additional imaging device",
+                "imaging_device_type": "Other",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Optotune",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "EL-16-40-TC",
+                "name": "tunable lens",
+                "notes": "Electrically tunable lens",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Additional imaging device",
+                "imaging_device_type": "Sample Chamber",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "LifeCanvas",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "Large-uncoated-glass",
+                "name": "Sample Chamber",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1"
+            }
+        ],
+        "calibration_data": null,
+        "calibration_date": null,
+        "com_ports": [
+            {
+                "com_port": "COM3",
+                "hardware_name": "Laser Launch"
+            },
+            {
+                "com_port": "COM5",
+                "hardware_name": "Applied Scientific Instrumentation Tiger"
+            },
+            {
+                "com_port": "COM10",
+                "hardware_name": "MightyZap"
+            }
+        ],
+        "daqs": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/instrument.py",
+        "detectors": [
+            {
+                "additional_settings": {},
+                "bin_height": null,
+                "bin_mode": "None",
+                "bin_unit": "pixel",
+                "bin_width": null,
+                "bit_depth": null,
+                "chroma": null,
+                "computer_name": null,
+                "cooling": "Water",
+                "crop_height": null,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": null,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": null,
+                "immersion": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Hamamatsu",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03natb733"
+                },
+                "model": "C14440-20UP",
+                "name": "Camera",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "220302-SYS-060443",
+                "size_unit": "pixel"
+            }
+        ],
+        "enclosure": null,
+        "fluorescence_filters": [
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 0,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-469/35-32",
+                "name": "Em_469",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 1,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF03-525/50-32",
+                "name": "Em_525",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 2,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-593/40-32",
+                "name": "Em_593",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 3,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-624/40-32",
+                "name": "Em_624",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Band pass",
+                "filter_wheel_index": 4,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Chroma",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "ET667/30m",
+                "name": "Em_667",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-3",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 700,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Long pass",
+                "filter_wheel_index": 5,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FELH0700",
+                "name": "Em_700",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": "2.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "32",
+                "filter_type": "Long pass",
+                "filter_wheel_index": 6,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "none000",
+                "name": "Em_000",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "size_unit": "millimeter",
+                "thickness": "0.0",
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            }
+        ],
+        "humidity_control": false,
+        "instrument_id": "440_SmartSPIM1_20250116",
+        "instrument_type": "SmartSPIM",
+        "lenses": [],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "150",
+                "model": "Stradus",
+                "name": "Ex_445",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 445,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "150",
+                "model": "Stradus",
+                "name": "Ex_488",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 488,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "150",
+                "model": "Obis",
+                "name": "Ex_561",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "",
+                "wavelength": 561,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "150",
+                "model": "Stradus",
+                "name": "Ex_594",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 594,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "160",
+                "model": "Stradus",
+                "name": "Ex_639",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "",
+                "wavelength": 639,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "coupling": "Single-mode fiber",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Vortran",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "maximum_power": "160",
+                "model": "Stradus",
+                "name": "Ex_665",
+                "notes": "All lasers controlled via Vortran VersaLase System",
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": "VL08223M03",
+                "wavelength": 665,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "manufacturer": {
+            "abbreviation": null,
+            "name": "LifeCanvas",
+            "registry": null,
+            "registry_identifier": null
+        },
+        "modification_date": "2025-01-16",
+        "motorized_stages": [
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-100",
+                "name": "Focus stage",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-0",
+                "travel": "100",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": "Cylindrical lens #1",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1",
+                "travel": "41",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": "Cylindrical lens #2",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "travel": "41",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": "Cylindrical lens #3",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-3",
+                "travel": "41",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Other",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "L12-20F-4",
+                "name": "Cylindrical lens #4",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-4",
+                "travel": "41",
+                "travel_unit": "millimeter"
+            }
+        ],
+        "notes": null,
+        "objectives": [
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "multi",
+                "magnification": "3.6",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "TL4X-SAP",
+                "name": "LCT 3.6x",
+                "notes": "Thorlabs TL4X-SAP with LifeCanvas dipping cap and correction optics.",
+                "numerical_aperture": "0.2",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "multi",
+                "magnification": "1.6",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "TL2X-SAP",
+                "name": "LCT 1.625x",
+                "notes": null,
+                "numerical_aperture": "0.1",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "water",
+                "magnification": "16.0",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Nikon",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "0280y9h11"
+                },
+                "model": "MRD77220",
+                "name": "Nikon16x",
+                "notes": null,
+                "numerical_aperture": "0.8",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown"
+            }
+        ],
+        "optical_tables": [
+            {
+                "additional_settings": {},
+                "device_type": "Optical table",
+                "length": "29.5",
+                "manufacturer": {
+                    "abbreviation": "TMC",
+                    "name": "Technical Manufacturing Corporation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "63-533 micro-g",
+                "name": "Table McTable Face",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "2008983",
+                "table_size_unit": "inch",
+                "vibration_control": true,
+                "width": "35.5"
+            }
+        ],
+        "scanning_stages": [
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": "Sample stage Z",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-0",
+                "stage_axis_direction": "Detection axis",
+                "stage_axis_name": "Z",
+                "travel": "50",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": "Sample stage X",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-1",
+                "stage_axis_direction": "Illumination axis",
+                "stage_axis_name": "X",
+                "travel": "50",
+                "travel_unit": "millimeter"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Motorized stage",
+                "firmware": null,
+                "manufacturer": {
+                    "abbreviation": "ASI",
+                    "name": "Applied Scientific Instrumentation",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "name": "Sample stage Y",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "Unknown-2",
+                "stage_axis_direction": "Perpendicular axis",
+                "stage_axis_name": "Y",
+                "travel": "50",
+                "travel_unit": "millimeter"
+            }
+        ],
+        "schema_version": "1.0.0",
+        "temperature_control": false
+    },
+    "last_modified": "2026-05-18T23:27:42.052Z",
+    "location": "s3://aind-open-data/SmartSPIM_784354_2025-04-16_21-39-58_stitched_2025-05-21_16-45-59",
+    "metadata_status": "Invalid",
+    "name": "SmartSPIM_784354_2025-04-16_21-39-58_stitched_2025-05-21_16-45-59",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.1.3",
+        "specimen_procedures": [],
+        "subject_id": "784354",
+        "subject_procedures": [
+            {
+                "anaesthesia": null,
+                "animal_weight_post": null,
+                "animal_weight_prior": null,
+                "experimenter_full_name": "30333",
+                "iacuc_protocol": "2416",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "output_specimen_ids": [
+                            "784354"
+                        ],
+                        "procedure_type": "Perfusion",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.8epv51bejl1b/v6"
+                    }
+                ],
+                "start_date": "2025-03-03",
+                "weight_unit": "gram",
+                "workstation_id": null
+            },
+            {
+                "anaesthesia": {
+                    "duration": "60.0",
+                    "duration_unit": "minute",
+                    "level": "1.5",
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": "19.8",
+                "animal_weight_prior": "19.8",
+                "experimenter_full_name": "NSB",
+                "iacuc_protocol": null,
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": null,
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": "4.28",
+                        "injection_coordinate_depth": [
+                            "-2.3"
+                        ],
+                        "injection_coordinate_ml": "0.5",
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Right",
+                        "injection_materials": [
+                            {
+                                "addgene_id": {
+                                    "abbreviation": null,
+                                    "name": "AAV pEF1a-DIO-FLPo-WPRE-hGHpA",
+                                    "registry": null,
+                                    "registry_identifier": "Addgene #87306"
+                                },
+                                "material_type": "Virus",
+                                "name": "AAV pEF1a-DIO-FLPo-WPRE-hGHpA",
+                                "tars_identifiers": {
+                                    "plasmid_tars_alias": "ExP300023",
+                                    "prep_date": "2025-03-13",
+                                    "prep_lot_number": "V188462",
+                                    "prep_protocol": null,
+                                    "prep_type": null,
+                                    "virus_tars_id": "VIR300023_AAV2-Retro"
+                                },
+                                "titer": 16000000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "injection_volume": [
+                            "150.0"
+                        ],
+                        "injection_volume_unit": "nanoliter",
+                        "instrument_id": null,
+                        "procedure_type": "Nanoject injection",
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.bp2l6nr7kgqe/v4",
+                        "recovery_time": "5.0",
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    },
+                    {
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": null,
+                        "injection_angle_unit": "degrees",
+                        "injection_coordinate_ap": "4.28",
+                        "injection_coordinate_depth": [
+                            "-0.7"
+                        ],
+                        "injection_coordinate_ml": "1.2",
+                        "injection_coordinate_reference": "Bregma",
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "injection_hemisphere": "Right",
+                        "injection_materials": [
+                            {
+                                "addgene_id": {
+                                    "abbreviation": null,
+                                    "name": "AAV pEF1a-DIO-FLPo-WPRE-hGHpA",
+                                    "registry": null,
+                                    "registry_identifier": "Addgene #87306"
+                                },
+                                "material_type": "Virus",
+                                "name": "AAV pEF1a-DIO-FLPo-WPRE-hGHpA",
+                                "tars_identifiers": {
+                                    "plasmid_tars_alias": "ExP300023",
+                                    "prep_date": "2025-03-13",
+                                    "prep_lot_number": "V188462",
+                                    "prep_protocol": null,
+                                    "prep_type": null,
+                                    "virus_tars_id": "VIR300023_AAV2-Retro"
+                                },
+                                "titer": 16000000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "instrument_id": null,
+                        "recovery_time": "5.0",
+                        "recovery_time_unit": "minute",
+                        "targeted_structure": null
+                    }
+                ],
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2",
+                "start_date": "2025-01-31",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 9"
+            }
+        ]
+    },
+    "processing": {
+        "analyses": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "notes": "New folder structure in cell detection creating a proposals folder and visualization of proposals",
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-flatfield-estimation",
+                    "code_version": "0.0.1",
+                    "end_date_time": "2025-04-17T13:19:55.095201Z",
+                    "input_location": "/tmp/nxf.uASAw4fQIW/capsule/data/Ex_561_Em_593",
+                    "name": "Image flat-field correction",
+                    "notes": "Flatfield estimation for channel Ex_561_Em_593",
+                    "output_location": "/tmp/nxf.uASAw4fQIW/capsule/results",
+                    "outputs": {
+                        "flatfield_paths": [
+                            "/tmp/nxf.uASAw4fQIW/capsule/results/estimated_flat_laser_Ex_561_Em_593_side_0.tif",
+                            "/tmp/nxf.uASAw4fQIW/capsule/results/estimated_flat_laser_Ex_561_Em_593_side_1.tif"
+                        ]
+                    },
+                    "parameters": {
+                        "shading_parameters": {
+                            "get_darkfield": false,
+                            "max_reweight_iterations": 35,
+                            "max_workers": 16,
+                            "resize_mode": "skimage_dask",
+                            "smoothness_darkfield": 20,
+                            "smoothness_flatfield": 1,
+                            "sort_intensity": true
+                        }
+                    },
+                    "resources": null,
+                    "software_version": "0.0.1",
+                    "start_date_time": "2025-04-17T13:04:54.029820Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-flatfield-estimation",
+                    "code_version": "0.0.1",
+                    "end_date_time": "2025-04-17T13:31:46.537275Z",
+                    "input_location": "/tmp/nxf.uASAw4fQIW/capsule/data/Ex_639_Em_667",
+                    "name": "Image flat-field correction",
+                    "notes": "Flatfield estimation for channel Ex_639_Em_667",
+                    "output_location": "/tmp/nxf.uASAw4fQIW/capsule/results",
+                    "outputs": {
+                        "flatfield_paths": [
+                            "/tmp/nxf.uASAw4fQIW/capsule/results/estimated_flat_laser_Ex_639_Em_667_side_0.tif",
+                            "/tmp/nxf.uASAw4fQIW/capsule/results/estimated_flat_laser_Ex_639_Em_667_side_1.tif"
+                        ]
+                    },
+                    "parameters": {
+                        "shading_parameters": {
+                            "get_darkfield": false,
+                            "max_reweight_iterations": 35,
+                            "max_workers": 16,
+                            "resize_mode": "skimage_dask",
+                            "smoothness_darkfield": 20,
+                            "smoothness_flatfield": 1,
+                            "sort_intensity": true
+                        }
+                    },
+                    "resources": null,
+                    "software_version": "0.0.1",
+                    "start_date_time": "2025-04-17T13:19:55.095361Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.4",
+                    "end_date_time": "2025-04-17T17:07:16.907685Z",
+                    "input_location": "/tmp/nxf.Lbod4pbtwq/capsule/data/Ex_639_Em_667",
+                    "name": "Image destriping",
+                    "notes": "Destriping for channel Ex_639_Em_667 in zarr format",
+                    "output_location": "/tmp/nxf.Lbod4pbtwq/capsule/results",
+                    "outputs": {},
+                    "parameters": {
+                        "cells_config": {
+                            "level": null,
+                            "max_threshold": 3,
+                            "sigma": 64,
+                            "wavelet": "db3"
+                        },
+                        "no_cells_config": {
+                            "level": null,
+                            "max_threshold": 12,
+                            "sigma": 128,
+                            "wavelet": "db3"
+                        },
+                        "retrospective": true
+                    },
+                    "resources": null,
+                    "software_version": "0.0.4",
+                    "start_date_time": "2025-04-17T14:16:13.038100Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.4",
+                    "end_date_time": "2025-04-17T17:07:16.907685Z",
+                    "input_location": "/tmp/nxf.Lbod4pbtwq/capsule/data/Ex_639_Em_667",
+                    "name": "Image flat-field correction",
+                    "notes": "The flats were computed from the data             with basicpy, these were applied with the destriping algorithm             and with the current dark from the microscope.\n            ",
+                    "output_location": "/tmp/nxf.Lbod4pbtwq/capsule/results",
+                    "outputs": {},
+                    "parameters": {},
+                    "resources": null,
+                    "software_version": "0.0.4",
+                    "start_date_time": "2025-04-17T14:16:13.038100Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.4",
+                    "end_date_time": "2025-04-17T17:30:35.186594Z",
+                    "input_location": "/tmp/nxf.SJA6AwCIpz/capsule/data/Ex_561_Em_593",
+                    "name": "Image destriping",
+                    "notes": "Destriping for channel Ex_561_Em_593 in zarr format",
+                    "output_location": "/tmp/nxf.SJA6AwCIpz/capsule/results",
+                    "outputs": {},
+                    "parameters": {
+                        "cells_config": {
+                            "level": null,
+                            "max_threshold": 3,
+                            "sigma": 64,
+                            "wavelet": "db3"
+                        },
+                        "no_cells_config": {
+                            "level": null,
+                            "max_threshold": 12,
+                            "sigma": 128,
+                            "wavelet": "db3"
+                        },
+                        "retrospective": true
+                    },
+                    "resources": null,
+                    "software_version": "0.0.4",
+                    "start_date_time": "2025-04-17T14:25:55.404674Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-destripe",
+                    "code_version": "0.0.4",
+                    "end_date_time": "2025-04-17T17:30:35.186594Z",
+                    "input_location": "/tmp/nxf.SJA6AwCIpz/capsule/data/Ex_561_Em_593",
+                    "name": "Image flat-field correction",
+                    "notes": "The flats were computed from the data             with basicpy, these were applied with the destriping algorithm             and with the current dark from the microscope.\n            ",
+                    "output_location": "/tmp/nxf.SJA6AwCIpz/capsule/results",
+                    "outputs": {},
+                    "parameters": {},
+                    "resources": null,
+                    "software_version": "0.0.4",
+                    "start_date_time": "2025-04-17T14:25:55.404674Z"
+                },
+                {
+                    "code_url": "",
+                    "code_version": "1.2.5",
+                    "end_date_time": "2025-04-17T19:55:41.767580Z",
+                    "input_location": "SmartSPIM_784354_2025-04-16_21-39-58",
+                    "name": "Image tile alignment",
+                    "notes": "Creation of stitching parameters",
+                    "output_location": "/tmp/nxf.m4iJbfQJ25/capsule/results/SmartSPIM_784354_2025-04-16_21-39-58_stitch_channel_Ex_639_Em_667_params.json",
+                    "outputs": {
+                        "output_file": "/tmp/nxf.m4iJbfQJ25/capsule/results/SmartSPIM_784354_2025-04-16_21-39-58_stitch_channel_Ex_639_Em_667_params.json"
+                    },
+                    "parameters": {
+                        "dataset_xml": "/tmp/nxf.m4iJbfQJ25/capsule/results/SmartSPIM_784354_2025-04-16_21-39-58_stitching_channel_Ex_639_Em_667.xml",
+                        "do_detection": false,
+                        "do_phase_correlation": true,
+                        "do_registrations": false,
+                        "memgb": 100,
+                        "parallel": "16",
+                        "phase_correlation_params": {
+                            "downsample": 0,
+                            "max_shift_in_x": 10,
+                            "max_shift_in_y": 10,
+                            "max_shift_in_z": 10,
+                            "min_correlation": 0.6
+                        },
+                        "session_id": "SmartSPIM_784354_2025-04-16_21-39-58"
+                    },
+                    "resources": null,
+                    "software_version": "1.2.11",
+                    "start_date_time": "2025-04-17T19:55:41.644727Z"
+                },
+                {
+                    "code_url": "",
+                    "code_version": "0.0.2",
+                    "end_date_time": "2025-04-17T23:49:18.877669Z",
+                    "input_location": "/tmp/nxf.XUzkyma302/capsule/data/bigstitcher.xml",
+                    "name": "Image tile fusing",
+                    "notes": "Fusing channel Ex_561_Em_593.zarr",
+                    "output_location": "/tmp/nxf.XUzkyma302/capsule/results/Ex_561_Em_593.zarr",
+                    "outputs": {},
+                    "parameters": {
+                        "n_workers": 16,
+                        "pyramid_levels": 4,
+                        "scale_factor": [
+                            2,
+                            2,
+                            2
+                        ],
+                        "threads_per_worker": 1,
+                        "voxel_resolution": [
+                            1.8,
+                            1.8,
+                            2
+                        ]
+                    },
+                    "resources": null,
+                    "software_version": "0.0.2",
+                    "start_date_time": "2025-04-17T21:07:54.687260Z"
+                },
+                {
+                    "code_url": "",
+                    "code_version": "0.0.2",
+                    "end_date_time": "2025-04-17T23:48:57.897248Z",
+                    "input_location": "/tmp/nxf.g1OSvamoXI/capsule/data/bigstitcher.xml",
+                    "name": "Image tile fusing",
+                    "notes": "Fusing channel Ex_639_Em_667.zarr",
+                    "output_location": "/tmp/nxf.g1OSvamoXI/capsule/results/Ex_639_Em_667.zarr",
+                    "outputs": {},
+                    "parameters": {
+                        "n_workers": 16,
+                        "pyramid_levels": 4,
+                        "scale_factor": [
+                            2,
+                            2,
+                            2
+                        ],
+                        "threads_per_worker": 1,
+                        "voxel_resolution": [
+                            1.8,
+                            1.8,
+                            2
+                        ]
+                    },
+                    "resources": null,
+                    "software_version": "0.0.2",
+                    "start_date_time": "2025-04-17T21:07:26.192302Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-ccf-registration",
+                    "code_version": "0.0.31",
+                    "end_date_time": "2025-05-21T17:24:27.837355Z",
+                    "input_location": "/tmp/nxf.zPbDD8Ayus/capsule/data/fused/Ex_639_Em_667.zarr/3",
+                    "name": "Image importing",
+                    "notes": "Importing fused data for alignment",
+                    "output_location": "/tmp/nxf.zPbDD8Ayus/capsule/data/fused/Ex_639_Em_667.zarr/3",
+                    "outputs": {},
+                    "parameters": {},
+                    "resources": null,
+                    "software_version": "0.0.31",
+                    "start_date_time": "2025-05-21T17:24:25.672074Z"
+                },
+                {
+                    "code_url": "https://github.com/ANTsX/ANTs",
+                    "code_version": "0.4.2",
+                    "end_date_time": "2025-05-21T17:53:32.302364Z",
+                    "input_location": "/tmp/nxf.zPbDD8Ayus/capsule/data/fused/Ex_639_Em_667.zarr/3",
+                    "name": "Image atlas alignment",
+                    "notes": "Template based registration: LS -> template -> Allen CCFv3 Atlas",
+                    "output_location": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata",
+                    "outputs": {},
+                    "parameters": {
+                        "affine_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_affine.nii.gz",
+                        "ccf_anno_to_brain_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ccf_anno_to_ls.nii.gz",
+                        "moved_to_ccf_path": "../results/ccf_Ex_639_Em_667/moved_ls_to_ccf.nii.gz",
+                        "moved_to_template_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ls_to_template.nii.gz",
+                        "new_spacing": [
+                            25,
+                            25,
+                            25
+                        ],
+                        "rigid_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_rigid.nii.gz",
+                        "spacing": [
+                            0.016,
+                            0.0144,
+                            0.0144
+                        ],
+                        "template_orientations": {
+                            "anterior_to_posterior": 1,
+                            "right_to_left": 0,
+                            "superior_to_inferior": 2
+                        },
+                        "unit": "millimetre"
+                    },
+                    "resources": null,
+                    "software_version": "0.0.31",
+                    "start_date_time": "2025-05-21T17:24:27.841384Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-ccf-registration",
+                    "code_version": "0.0.31",
+                    "end_date_time": "2025-05-21T17:54:00.563257Z",
+                    "input_location": "In memory array",
+                    "name": "File format conversion",
+                    "notes": "Converting registered image to OMEZarr",
+                    "output_location": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/OMEZarr/image.zarr",
+                    "outputs": {},
+                    "parameters": {
+                        "OMEZarr_params": {
+                            "chunks": [
+                                64,
+                                64,
+                                64
+                            ],
+                            "clevel": 1,
+                            "compressor": "zstd"
+                        },
+                        "pixel_sizes": [
+                            25,
+                            25,
+                            25
+                        ]
+                    },
+                    "resources": null,
+                    "software_version": "0.0.31",
+                    "start_date_time": "2025-05-21T17:53:32.304364Z"
+                },
+                {
+                    "code_url": "https://github.com/ANTsX/ANTs",
+                    "code_version": "0.4.2",
+                    "end_date_time": "2025-05-21T18:00:35.666487Z",
+                    "input_location": "/tmp/nxf.zPbDD8Ayus/capsule/data/fused/Ex_639_Em_667.zarr/3",
+                    "name": "Image atlas alignment",
+                    "notes": "Template based reversed registration: annotations in template space -> LS",
+                    "output_location": "In memory array",
+                    "outputs": {},
+                    "parameters": {
+                        "affine_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_affine.nii.gz",
+                        "ccf_anno_to_brain_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ccf_anno_to_ls.nii.gz",
+                        "moved_to_ccf_path": "../results/ccf_Ex_639_Em_667/moved_ls_to_ccf.nii.gz",
+                        "moved_to_template_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ls_to_template.nii.gz",
+                        "new_spacing": [
+                            25,
+                            25,
+                            25
+                        ],
+                        "rigid_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_rigid.nii.gz",
+                        "spacing": [
+                            0.016,
+                            0.0144,
+                            0.0144
+                        ],
+                        "template_orientations": {
+                            "anterior_to_posterior": 1,
+                            "right_to_left": 0,
+                            "superior_to_inferior": 2
+                        },
+                        "unit": "millimetre"
+                    },
+                    "resources": null,
+                    "software_version": "0.0.31",
+                    "start_date_time": "2025-05-21T17:53:32.304364Z"
+                },
+                {
+                    "code_url": "https://github.com/ANTsX/ANTs",
+                    "code_version": "0.4.2",
+                    "end_date_time": "2025-05-21T18:01:25.449157Z",
+                    "input_location": "/tmp/nxf.zPbDD8Ayus/capsule/data/fused/Ex_561_Em_593.zarr/3",
+                    "name": "Image atlas alignment",
+                    "notes": "Template based registration using transforms: Ex_561_Em_593",
+                    "output_location": "In memory array",
+                    "outputs": {},
+                    "parameters": {
+                        "affine_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_affine.nii.gz",
+                        "ccf_anno_to_brain_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ccf_anno_to_ls.nii.gz",
+                        "moved_to_ccf_path": "../results/ccf_Ex_639_Em_667/moved_ls_to_ccf.nii.gz",
+                        "moved_to_template_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_ls_to_template.nii.gz",
+                        "new_spacing": [
+                            25,
+                            25,
+                            25
+                        ],
+                        "rigid_path": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_639_Em_667/metadata/registration_metadata/moved_rigid.nii.gz",
+                        "spacing": [
+                            0.016,
+                            0.0144,
+                            0.0144
+                        ],
+                        "template_orientations": {
+                            "anterior_to_posterior": 1,
+                            "right_to_left": 0,
+                            "superior_to_inferior": 2
+                        },
+                        "unit": "millimetre"
+                    },
+                    "resources": null,
+                    "software_version": "0.0.31",
+                    "start_date_time": "2025-05-21T18:00:35.668392Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-ccf-registration",
+                    "code_version": "0.0.31",
+                    "end_date_time": "2025-05-21T18:01:51.961086Z",
+                    "input_location": "In memory array",
+                    "name": "File format conversion",
+                    "notes": "Converting registered image for channel Ex_561_Em_593 to OMEZarr",
+                    "output_location": "/tmp/nxf.zPbDD8Ayus/capsule/results/ccf_Ex_561_Em_593/OMEZarr/image.zarr",
+                    "outputs": {},
+                    "parameters": {
+                        "OMEZarr_params": {
+                            "chunks": [
+                                64,
+                                64,
+                                64
+                            ],
+                            "clevel": 1,
+                            "compressor": "zstd"
+                        },
+                        "pixel_sizes": [
+                            25,
+                            25,
+                            25
+                        ]
+                    },
+                    "resources": null,
+                    "software_version": "0.0.31",
+                    "start_date_time": "2025-05-21T18:01:25.451028Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-classification",
+                    "code_version": "0.0.6",
+                    "end_date_time": "2025-05-22T02:40:37.901352Z",
+                    "input_location": "/tmp/nxf.vV5ElVv4OW/capsule/data/fused/Ex_561_Em_593.zarr",
+                    "name": "Image cell segmentation",
+                    "notes": "Classifying channel in path: /tmp/nxf.vV5ElVv4OW/capsule/data/fused/Ex_561_Em_593.zarr",
+                    "output_location": "/tmp/nxf.vV5ElVv4OW/capsule/results/cell_Ex_561_Em_593/metadata",
+                    "outputs": {},
+                    "parameters": {
+                        "background_path": "/tmp/nxf.vV5ElVv4OW/capsule/data/fused/Ex_639_Em_667.zarr",
+                        "image_path": "/tmp/nxf.vV5ElVv4OW/capsule/data/fused/Ex_561_Em_593.zarr",
+                        "mask_path": "/tmp/nxf.vV5ElVv4OW/capsule/data/fused/Ex_561_Em_593.zarr/3",
+                        "overlap_prediction_chunksize": [
+                            0,
+                            6,
+                            6,
+                            6
+                        ],
+                        "prediction_chunksize": [
+                            2,
+                            128,
+                            128,
+                            128
+                        ],
+                        "smartspim_cell_config": {
+                            "background_channel": "Ex_639_Em_667.zarr",
+                            "channel": "Ex_561_Em_593",
+                            "chunk_size": 128,
+                            "input_channel": "Ex_561_Em_593.zarr",
+                            "input_data": "/tmp/nxf.vV5ElVv4OW/capsule/data/fused",
+                            "input_scale": "0",
+                            "metadata_path": "/tmp/nxf.vV5ElVv4OW/capsule/results/cell_Ex_561_Em_593/metadata",
+                            "model_config": {
+                                "default_model": "/tmp/nxf.vV5ElVv4OW/capsule/data/smartspim_production_models/model_3_01012025/model.h5",
+                                "parameters": {
+                                    "cube_depth": 26,
+                                    "cube_height": 14,
+                                    "cube_width": 14,
+                                    "downsample": 1,
+                                    "mask_scale": 3
+                                }
+                            },
+                            "name": "SmartSPIM_784354_2025-04-16_21-39-58_stitched_2025-05-21_16-45-59",
+                            "save_path": "/tmp/nxf.vV5ElVv4OW/capsule/results/cell_Ex_561_Em_593"
+                        },
+                        "target_size_mb": 2048
+                    },
+                    "resources": null,
+                    "software_version": "0.0.6",
+                    "start_date_time": "2025-05-22T02:32:36.236258Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-SmartSPIM-segmentation",
+                    "code_version": "0.0.7",
+                    "end_date_time": "2025-05-21T17:28:17.536607Z",
+                    "input_location": "/tmp/nxf.R7UPwogiwk/capsule/data/fused/Ex_561_Em_593.zarr/0",
+                    "name": "Image importing",
+                    "notes": "Importing fused data for cell segmentation",
+                    "output_location": "/tmp/nxf.R7UPwogiwk/capsule/data/fused/Ex_561_Em_593.zarr/0",
+                    "outputs": {},
+                    "parameters": {},
+                    "resources": null,
+                    "software_version": "0.0.7",
+                    "start_date_time": "2025-05-21T17:28:17.458455Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-SmartSPIM-segmentation",
+                    "code_version": "0.0.7",
+                    "end_date_time": "2025-05-22T01:48:57.933313Z",
+                    "input_location": "/tmp/nxf.R7UPwogiwk/capsule/data/fused/Ex_561_Em_593.zarr/0",
+                    "name": "Image cell segmentation",
+                    "notes": "Detecting proposals in channel in path: /tmp/nxf.R7UPwogiwk/capsule/data/fused/Ex_561_Em_593.zarr/0",
+                    "output_location": "/tmp/nxf.R7UPwogiwk/capsule/results/cell_Ex_561_Em_593/metadata",
+                    "outputs": {},
+                    "parameters": {
+                        "chunk_step": 512,
+                        "image_path": "/tmp/nxf.R7UPwogiwk/capsule/data/fused/Ex_561_Em_593.zarr/0",
+                        "mask_path": "/tmp/nxf.R7UPwogiwk/capsule/data/fused/Ex_561_Em_593.zarr/3",
+                        "smartspim_cell_config": {
+                            "bkg_subtract": true,
+                            "cellfinder_params": {
+                                "ball_overlap_fraction": 0.6,
+                                "ball_xy_size": 20,
+                                "ball_z_size": 20,
+                                "end_plane": 3584,
+                                "log_sigma_size": 0.2,
+                                "max_cluster_size": 100000,
+                                "n_free_cpus": 0,
+                                "n_sds_above_mean_thresh": 6,
+                                "soma_diameter": 32,
+                                "soma_spread_factor": 1.4,
+                                "start_plane": 0,
+                                "voxel_sizes": [
+                                    2,
+                                    1.8,
+                                    1.8
+                                ]
+                            },
+                            "channel": "Ex_561_Em_593",
+                            "chunk_size": 128,
+                            "input_channel": "Ex_561_Em_593.zarr",
+                            "input_data": "/tmp/nxf.R7UPwogiwk/capsule/data/fused",
+                            "input_scale": "0",
+                            "mask_scale": 3,
+                            "metadata_path": "/tmp/nxf.R7UPwogiwk/capsule/results/cell_Ex_561_Em_593/metadata",
+                            "name": "SmartSPIM_784354_2025-04-16_21-39-58_stitched_2025-05-21_16-45-59",
+                            "padding": 20,
+                            "save_path": "/tmp/nxf.R7UPwogiwk/capsule/results/cell_Ex_561_Em_593",
+                            "subsample": [
+                                1,
+                                1,
+                                1
+                            ],
+                            "workers": 16
+                        }
+                    },
+                    "resources": null,
+                    "software_version": "0.0.7",
+                    "start_date_time": "2025-05-21T17:28:17.982952Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-quantification",
+                    "code_version": "1.6.1",
+                    "end_date_time": "2025-05-22T03:24:42.748548Z",
+                    "input_location": "/tmp/nxf.zCDYwiV9Op/capsule/data/fused/Ex_561_Em_593.zarr/0",
+                    "name": "Image cell quantification",
+                    "notes": "The output folder contains the precomputed format to visualize and count cells per CCF region",
+                    "output_location": "/tmp/nxf.zCDYwiV9Op/capsule/results",
+                    "outputs": {
+                        "output_folder": "/tmp/nxf.zCDYwiV9Op/capsule/results"
+                    },
+                    "parameters": {
+                        "bucket_path": "aind-open-data",
+                        "ccf_overlay_precomputed": {
+                            "ccf_reference_path": null,
+                            "input_path": "/tmp/nxf.zCDYwiV9Op/capsule/results/quant_Ex_561_Em_593/cell_count_by_region.csv",
+                            "output_path": "/tmp/nxf.zCDYwiV9Op/capsule/results/quant_Ex_561_Em_593/visualization/ccf_cell_precomputed"
+                        },
+                        "ccf_registration_folder": "/tmp/nxf.zCDYwiV9Op/capsule/data/ccf_Ex_561_Em_593",
+                        "cell_segmentation_folder": "/tmp/nxf.zCDYwiV9Op/capsule/data/cell_Ex_561_Em_593",
+                        "channel_name": "Ex_561_Em_593",
+                        "fused_folder": "/tmp/nxf.zCDYwiV9Op/capsule/data/fused",
+                        "input_params": {
+                            "ccf_transforms": [
+                                "/tmp/nxf.zCDYwiV9Op/capsule/data/lightsheet_template_ccf_registration/syn_0GenericAffine.mat",
+                                "/tmp/nxf.zCDYwiV9Op/capsule/data/lightsheet_template_ccf_registration/syn_1InverseWarp.nii.gz"
+                            ],
+                            "ccf_transforms_path": "/tmp/nxf.zCDYwiV9Op/capsule/data/ccf_Ex_561_Em_593/",
+                            "detected_cells_csv_path": "/tmp/nxf.zCDYwiV9Op/capsule/data/cell_Ex_561_Em_593/",
+                            "downsample_res": 3,
+                            "image_files": {
+                                "ccf_template": "/tmp/nxf.zCDYwiV9Op/capsule/data/lightsheet_template_ccf_registration/ccf_average_template_25.nii.gz",
+                                "smartspim_template": "/tmp/nxf.zCDYwiV9Op/capsule/data/lightsheet_template_ccf_registration/smartspim_lca_template_25.nii.gz"
+                            },
+                            "input_res": [
+                                3584,
+                                10240,
+                                7424
+                            ],
+                            "mode": "detect",
+                            "orientation": [
+                                {
+                                    "dimension": 0,
+                                    "direction": "Superior_to_inferior",
+                                    "name": "Z",
+                                    "unit": "micrometer"
+                                },
+                                {
+                                    "dimension": 1,
+                                    "direction": "Anterior_to_posterior",
+                                    "name": "Y",
+                                    "unit": "micrometer"
+                                },
+                                {
+                                    "dimension": 2,
+                                    "direction": "Left_to_right",
+                                    "name": "X",
+                                    "unit": "micrometer"
+                                }
+                            ],
+                            "reference_microns_ccf": 25,
+                            "scaling": [
+                                0.64,
+                                0.5760000000000001,
+                                0.5760000000000001
+                            ],
+                            "template_transforms": [
+                                "/tmp/nxf.zCDYwiV9Op/capsule/data/ccf_Ex_639_Em_667/ls_to_template_SyN_0GenericAffine.mat",
+                                "/tmp/nxf.zCDYwiV9Op/capsule/data/ccf_Ex_639_Em_667/ls_to_template_SyN_1InverseWarp.nii.gz"
+                            ]
+                        },
+                        "institute_abbreviation": "AIND",
+                        "name": "SmartSPIM_784354_2025-04-16_21-39-58_stitched_2025-05-21_16-45-59",
+                        "ng_config": {
+                            "base_url": "https://neuroglancer-demo.appspot.com/#!",
+                            "crossSectionScale": 1,
+                            "dimensions": {
+                                "t": [
+                                    0.001,
+                                    "s"
+                                ],
+                                "x": [
+                                    2.4999999999999998e-05,
+                                    "m"
+                                ],
+                                "y": [
+                                    2.4999999999999998e-05,
+                                    "m"
+                                ],
+                                "z": [
+                                    2.4999999999999998e-05,
+                                    "m"
+                                ]
+                            },
+                            "gpuMemoryLimit": 1500000000,
+                            "orientation": {
+                                "active_objectives": [
+                                    "LCT 3.6x"
+                                ],
+                                "axes": [
+                                    {
+                                        "dimension": 0,
+                                        "direction": "Superior_to_inferior",
+                                        "name": "Z",
+                                        "unit": "micrometer"
+                                    },
+                                    {
+                                        "dimension": 1,
+                                        "direction": "Anterior_to_posterior",
+                                        "name": "Y",
+                                        "unit": "micrometer"
+                                    },
+                                    {
+                                        "dimension": 2,
+                                        "direction": "Left_to_right",
+                                        "name": "X",
+                                        "unit": "micrometer"
+                                    }
+                                ],
+                                "calibrations": [],
+                                "chamber_immersion": {
+                                    "medium": "other",
+                                    "refractive_index": "1.5182"
+                                },
+                                "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/acquisition.py",
+                                "experimenter_full_name": [
+                                    "John Rohde"
+                                ],
+                                "external_storage_directory": "",
+                                "instrument_id": "440_SmartSPIM1_20250116",
+                                "local_storage_directory": "D:/SmartSPIM_Data",
+                                "maintenance": [],
+                                "notes": "Chamber immersion: oil - Sample immersion: easy index",
+                                "processing_steps": [],
+                                "protocol_id": [],
+                                "sample_immersion": {
+                                    "medium": "other",
+                                    "refractive_index": "1.5165"
+                                },
+                                "schema_version": "1.0.0",
+                                "session_end_time": "2025-04-17T12:31:33-07:00",
+                                "session_start_time": "2025-04-16T21:39:58-07:00",
+                                "session_type": null,
+                                "software": [],
+                                "specimen_id": "",
+                                "subject_id": "784354",
+                                "tiles": [
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "45718.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/433320/433320_457180/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "45718.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/433320/433320_457180/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "45718.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/465720/465720_457180/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "45718.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/465720/465720_457180/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "45718.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/498120/498120_457180/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "45718.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/498120/498120_457180/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "45718.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/530520/530520_457180/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "45718.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/530520/530520_457180/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "48310.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/433320/433320_483100/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "48310.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/433320/433320_483100/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "48310.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/465720/465720_483100/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "48310.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/465720/465720_483100/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "48310.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/498120/498120_483100/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "48310.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/498120/498120_483100/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "48310.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/530520/530520_483100/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "48310.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/530520/530520_483100/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "50902.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/433320/433320_509020/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "50902.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/433320/433320_509020/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "50902.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/465720/465720_509020/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "50902.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/465720/465720_509020/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "50902.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/498120/498120_509020/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "50902.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/498120/498120_509020/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "50902.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/530520/530520_509020/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "50902.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/530520/530520_509020/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "53494.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/433320/433320_534940/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "53494.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/433320/433320_534940/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "53494.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/465720/465720_534940/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "53494.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/465720/465720_534940/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "53494.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/498120/498120_534940/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "53494.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/498120/498120_534940/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "53494.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/530520/530520_534940/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "53494.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/530520/530520_534940/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "56086.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/433320/433320_560860/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "56086.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/433320/433320_560860/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "56086.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/465720/465720_560860/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "56086.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/465720/465720_560860/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "56086.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/498120/498120_560860/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "56086.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/498120/498120_560860/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "56086.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/530520/530520_560860/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "56086.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/530520/530520_560860/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "58678.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/433320/433320_586780/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "58678.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/433320/433320_586780/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "58678.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/465720/465720_586780/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "58678.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/465720/465720_586780/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "58678.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/498120/498120_586780/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "58678.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/498120/498120_586780/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "58678.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/530520/530520_586780/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "58678.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/530520/530520_586780/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "61270.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/433320/433320_612700/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "43332.0",
+                                                    "61270.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/433320/433320_612700/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90.91,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "61270.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/465720/465720_612700/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 90,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "46572.0",
+                                                    "61270.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/465720/465720_612700/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "61270.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/498120/498120_612700/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "49812.0",
+                                                    "61270.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/498120/498120_612700/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "561",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 561,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 2,
+                                            "light_source_name": "561"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "61270.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_561_Em_593/530520/530520_612700/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    },
+                                    {
+                                        "acquisition_end_time": null,
+                                        "acquisition_start_time": null,
+                                        "channel": {
+                                            "additional_device_names": [],
+                                            "channel_name": "639",
+                                            "description": null,
+                                            "detector_name": "",
+                                            "dilation": null,
+                                            "dilation_unit": "pixel",
+                                            "excitation_power": 100,
+                                            "excitation_power_unit": "percent",
+                                            "excitation_wavelength": 639,
+                                            "excitation_wavelength_unit": "nanometer",
+                                            "filter_names": [
+                                                ""
+                                            ],
+                                            "filter_wheel_index": 4,
+                                            "light_source_name": "639"
+                                        },
+                                        "coordinate_transformations": [
+                                            {
+                                                "translation": [
+                                                    "53052.0",
+                                                    "61270.0",
+                                                    "176.8"
+                                                ],
+                                                "type": "translation"
+                                            },
+                                            {
+                                                "scale": [
+                                                    "1.8",
+                                                    "1.8",
+                                                    "2.0"
+                                                ],
+                                                "type": "scale"
+                                            }
+                                        ],
+                                        "file_name": "Ex_639_Em_667/530520/530520_612700/",
+                                        "imaging_angle": 0,
+                                        "imaging_angle_unit": "degrees",
+                                        "notes": "\nLaser power is in percentage of total, it needs calibration"
+                                    }
+                                ]
+                            },
+                            "projectionScale": 512,
+                            "rank": 3
+                        },
+                        "region_list": [
+                            "1080",
+                            "262",
+                            "64",
+                            "214",
+                            "35",
+                            "1047",
+                            "672",
+                            "795"
+                        ],
+                        "registration_channel": "Ex_639_Em_667",
+                        "reverse_scaling": [
+                            1.5625,
+                            1.7361111111111112,
+                            1.7361111111111112
+                        ],
+                        "reverse_transforms": {
+                            "ccf_transforms": [
+                                "/tmp/nxf.zCDYwiV9Op/capsule/data/lightsheet_template_ccf_registration/spim_template_to_ccf_syn_1Warp.nii.gz",
+                                "/tmp/nxf.zCDYwiV9Op/capsule/data/lightsheet_template_ccf_registration/spim_template_to_ccf_syn_0GenericAffine.mat"
+                            ],
+                            "template_transforms": [
+                                "/tmp/nxf.zCDYwiV9Op/capsule/data/ccf_Ex_639_Em_667/ls_to_template_SyN_1Warp.nii.gz",
+                                "/tmp/nxf.zCDYwiV9Op/capsule/data/ccf_Ex_639_Em_667/ls_to_template_SyN_0GenericAffine.mat"
+                            ]
+                        },
+                        "save_path": "/tmp/nxf.zCDYwiV9Op/capsule/results/quant_Ex_561_Em_593",
+                        "stitched_s3_path": "s3://aind-open-data/SmartSPIM_784354_2025-04-16_21-39-58_stitched_2025-05-21_16-45-59"
+                    },
+                    "resources": null,
+                    "software_version": "1.6.1",
+                    "start_date_time": "2025-05-22T03:14:50.068019Z"
+                }
+            ],
+            "note": null,
+            "pipeline_url": "https://github.com/AllenNeuralDynamics/aind-smartspim-pipeline",
+            "pipeline_version": "3.0.1",
+            "processor_full_name": "Camilo Laiton"
+        },
+        "schema_version": "1.1.4"
+    },
+    "quality_control": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/quality_control.py",
+        "evaluations": [
+            {
+                "allow_failed_metrics": false,
+                "created": "2025-05-21T21:26:07.853377-07:00",
+                "description": "Checks that the whole-brain neuroglancer link was created",
+                "latest_status": "Pending",
+                "metrics": [
+                    {
+                        "description": "",
+                        "evaluated_assets": null,
+                        "name": "Dataset neuroglancer link",
+                        "reference": "https://neuroglancer-demo.appspot.com/#!s3://aind-open-data/SmartSPIM_784354_2025-04-16_21-39-58_stitched_2025-05-21_16-45-59/neuroglancer_config.json",
+                        "status_history": [
+                            {
+                                "evaluator": "Automated",
+                                "status": "Pending",
+                                "timestamp": "2025-05-21T21:26:07.853377-07:00"
+                            }
+                        ],
+                        "value": ""
+                    }
+                ],
+                "modality": {
+                    "abbreviation": "SPIM",
+                    "name": "Selective plane illumination microscopy"
+                },
+                "name": "Neuroglancer Link Evaluation",
+                "notes": "",
+                "stage": "Processing",
+                "tags": null
+            }
+        ],
+        "notes": null,
+        "schema_version": "1.2.2"
+    },
+    "rig": null,
+    "schema_version": "1.1.1",
+    "session": null,
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Dbh-Cre-KI;Ai65(ND)",
+            "maternal_genotype": "Ai65(RCFL-tdT)/Ai65(RCFL-tdT)",
+            "maternal_id": "757386",
+            "paternal_genotype": "Dbh-Cre-KI/wt",
+            "paternal_id": "753344"
+        },
+        "date_of_birth": "2024-12-25",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "Dbh-Cre-KI/wt;Ai65(RCFL-tdT)/wt",
+        "housing": null,
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.2",
+        "sex": "Male",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "784354",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
This PR adds a bypass for BrainInjection allowing invalid objects to get through the upgrader. It also fixes a mistake where if the full upgrader pass fails there were fields being removed from the original metadata dictionary which was then causing the individual core file upgraders to fail. Both issues are covered by the new test asset.