### PR TITLE
fix: unnecessary Microscope, missing mapping

### DIFF
--- a/src/aind_metadata_upgrader/acquisition/v1v2_tiles.py
+++ b/src/aind_metadata_upgrader/acquisition/v1v2_tiles.py
@@ -288,6 +288,7 @@ MEDIUM_MAP = {
     "Cargille oil 1.5200": ImmersionMedium.OIL,
     "EasyIndex": ImmersionMedium.EASYINDEX,
     "0.05x SSC": ImmersionMedium.WATER,
+    "0.07x SSC": ImmersionMedium.WATER,
     "ACB": ImmersionMedium.ACB,
     "Ethyl cinnamate": ImmersionMedium.ECI,
     "EZ View": ImmersionMedium.OIL,

--- a/src/aind_metadata_upgrader/instrument/v1v2.py
+++ b/src/aind_metadata_upgrader/instrument/v1v2.py
@@ -258,12 +258,8 @@ class InstrumentUpgraderV1V2(CoreUpgrader):
         ) = device_collections
         saved_connections.extend(device_connections)
 
-        # Create the new Microscope device
-        microscope = Microscope(name=data.get("instrument_id", "Microscope"))
-        scope_name = microscope.name
-
         # Process connections and DAQs
-        upgraded_daqs, connection_data = self._process_connections_and_daqs(data, scope_name)
+        upgraded_daqs, connection_data = self._process_connections_and_daqs(data, data.get("instrument_id"))
         saved_connections.extend(connection_data)
 
         # Compile components list
@@ -277,7 +273,6 @@ class InstrumentUpgraderV1V2(CoreUpgrader):
             *scanning_stages,
             *additional_devices,
             *upgraded_daqs,
-            microscope.model_dump(),
         ]
         if enclosure:
             components.append(enclosure)
@@ -288,66 +283,6 @@ class InstrumentUpgraderV1V2(CoreUpgrader):
 
         # Validate and fix connections
         components = self._validate_and_fix_connections(components, connections)
-
-        return (components, connections)
-
-        # Compile components list
-        components = [
-            *objectives,
-            *upgraded_detectors,
-            *light_sources,
-            *lenses,
-            *fluorescence_filters,
-            *motorized_stages,
-            *scanning_stages,
-            *additional_devices,
-            *upgraded_daqs,
-            microscope.model_dump(),
-        ]
-        if enclosure:
-            components.append(enclosure)
-
-        # Handle connections and upgrade DAQDevice to new version
-
-        print(f"{len(saved_connections)} saved connections pending")
-        connections = []
-
-        for connection in saved_connections:
-            # Check if this is just a model_dump of a Connection object
-            if "object_type" in connection:
-                connections.append(connection)
-            else:
-                connections.append(
-                    Connection(
-                        source_device=connection["send"],
-                        target_device=connection["receive"],
-                    ).model_dump()
-                )
-
-        # Check that we're going to pass the connection validation
-        # Flatten the list of device names from all connections
-        connection_names = [name for conn in connections for name in [conn["source_device"], conn["target_device"]]]
-
-        component_names = []
-        for component in components:
-            component_names.extend(recursive_get_all_names(component))
-        component_names = [name for name in component_names if name is not None]
-
-        missing_names = []
-        for name in connection_names:
-            if name not in component_names:
-                missing_names.append(name)
-
-        for name in set(missing_names):
-            # Create an empty Device with the name
-            device = Device(
-                name=name,
-                notes=(
-                    "(v1v2 upgrade instrument) This device was not found in the components list, "
-                    "but is referenced in connections."
-                ),
-            )
-            components.append(device.model_dump())
 
         return (components, connections)
 

--- a/src/aind_metadata_upgrader/instrument/v1v2.py
+++ b/src/aind_metadata_upgrader/instrument/v1v2.py
@@ -5,7 +5,7 @@ from datetime import date
 from typing import Optional
 
 from aind_data_schema.components.coordinates import CoordinateSystemLibrary
-from aind_data_schema.components.devices import Device, Microscope
+from aind_data_schema.components.devices import Device
 from aind_data_schema.components.measurements import Calibration
 from aind_data_schema.components.connections import (
     Connection,

--- a/tests/records/v1/a3f540dd-4945-4eb2-9b50-e8040a16ee5c.json
+++ b/tests/records/v1/a3f540dd-4945-4eb2-9b50-e8040a16ee5c.json
@@ -1,0 +1,2214 @@
+{
+    "_id": "a3f540dd-4945-4eb2-9b50-e8040a16ee5c",
+    "acquisition": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/acquisition.py",
+        "schema_version": "0.5.2",
+        "experimenter_full_name": [
+            "John Rohde"
+        ],
+        "specimen_id": "747820",
+        "subject_id": "747820",
+        "instrument_id": "exaspim-01",
+        "calibrations": null,
+        "maintenance": null,
+        "session_start_time": "2024-12-09T12:59:03",
+        "session_end_time": "2024-12-13T00:16:07",
+        "session_type": null,
+        "tiles": [
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            0,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0000_y_0000_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            0,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0000_y_0000_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            0,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0000_y_0001_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            0,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0000_y_0001_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            0,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0000_y_0002_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            0,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0000_y_0002_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            9.023273600000001,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0001_y_0000_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            9.023273600000001,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0001_y_0000_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            9.023273600000001,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0001_y_0001_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            9.023273600000001,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0001_y_0001_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            9.023273600000001,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0001_y_0002_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            9.023273600000001,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0001_y_0002_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            18.046547200000003,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0002_y_0000_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            18.046547200000003,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0002_y_0000_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            18.046547200000003,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0002_y_0001_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            18.046547200000003,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0002_y_0001_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            18.046547200000003,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0002_y_0002_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            18.046547200000003,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0002_y_0002_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            27.069820800000002,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0003_y_0000_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            27.069820800000002,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0003_y_0000_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            27.069820800000002,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0003_y_0001_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            27.069820800000002,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0003_y_0001_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            27.069820800000002,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0003_y_0002_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            27.069820800000002,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0003_y_0002_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            36.093094400000005,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0004_y_0000_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            36.093094400000005,
+                            13.529824000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0004_y_0000_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            36.093094400000005,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0004_y_0001_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            36.093094400000005,
+                            6.764912000000001,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0004_y_0001_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            5.984,
+                            5.984,
+                            8
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            36.093094400000005,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0004_y_0002_z_0000_ch_488.ims",
+                "channel": {
+                    "channel_name": "488",
+                    "light_source_name": "488",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 488,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            },
+            {
+                "coordinate_transformations": [
+                    {
+                        "type": "scale",
+                        "scale": [
+                            0.748,
+                            0.748,
+                            1
+                        ]
+                    },
+                    {
+                        "type": "translation",
+                        "translation": [
+                            36.093094400000005,
+                            0,
+                            0
+                        ]
+                    }
+                ],
+                "file_name": "tile_x_0004_y_0002_z_0000_ch_561.ims",
+                "channel": {
+                    "channel_name": "561",
+                    "light_source_name": "561",
+                    "filter_names": [],
+                    "detector_name": "",
+                    "additional_device_names": null,
+                    "excitation_wavelength": 561,
+                    "excitation_wavelength_unit": "nanometer",
+                    "excitation_power": 1000,
+                    "excitation_power_unit": "milliwatt",
+                    "filter_wheel_index": 0,
+                    "dilation": null,
+                    "dilation_unit": "pixel",
+                    "description": null
+                },
+                "notes": null,
+                "imaging_angle": 0,
+                "imaging_angle_unit": "degrees"
+            }
+        ],
+        "axes": [
+            {
+                "name": "X",
+                "dimension": 2,
+                "direction": "Anterior_to_posterior",
+                "unit": "micrometer"
+            },
+            {
+                "name": "Y",
+                "dimension": 1,
+                "direction": "Inferior_to_superior",
+                "unit": "micrometer"
+            },
+            {
+                "name": "Z",
+                "dimension": 0,
+                "direction": "Left_to_right",
+                "unit": "micrometer"
+            }
+        ],
+        "chamber_immersion": {
+            "medium": "0.07x SSC",
+            "refractive_index": 1.33
+        },
+        "sample_immersion": null,
+        "active_objectives": null,
+        "local_storage_directory": "E:\\exaSPIM_747820_2024-12-09_12-59-02\\exaSPIM",
+        "external_storage_directory": "Z:\\exaSPIM\\exaSPIM_747820_2024-12-09_12-59-02\\exaSPIM",
+        "processing_steps": null,
+        "notes": null
+    },
+    "created": "2025-01-23T08:15:06.821750",
+    "data_description": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "1.0.4",
+        "license": "CC-BY-4.0",
+        "platform": {
+            "name": "ExaSPIM platform",
+            "abbreviation": "exaSPIM"
+        },
+        "subject_id": "747820",
+        "creation_time": "2025-01-23 06:40:34-08:00",
+        "label": null,
+        "name": "exaSPIM_747820_2024-12-09_12-59-02_alignment_2025-01-23_06-40-34",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "funder": {
+                    "name": "Allen Institute",
+                    "abbreviation": "AI",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null,
+                "fundee": "Jayaram Chandrashekar"
+            },
+            {
+                "funder": {
+                    "name": "National Institute of Neurological Disorders and Stroke",
+                    "abbreviation": "NINDS",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01s5ya894"
+                },
+                "grant_number": "1U19NS123714-01",
+                "fundee": "Jayaram Chandrashekar"
+            },
+            {
+                "funder": {
+                    "name": "National Institute of Neurological Disorders and Stroke",
+                    "abbreviation": "NINDS",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01s5ya894"
+                },
+                "grant_number": "1RF1MH128841-01",
+                "fundee": "Jayaram Chandrashekar, Karel Svoboda"
+            }
+        ],
+        "data_level": "derived",
+        "group": null,
+        "investigators": [
+            {
+                "name": "Jayaram Chandrashekar",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "project_name": "MSMA Platform",
+        "restrictions": null,
+        "modality": [
+            {
+                "name": "Selective plane illumination microscopy",
+                "abbreviation": "SPIM"
+            }
+        ],
+        "related_data": [],
+        "data_summary": null,
+        "input_data_name": "exaSPIM_747820_2024-12-09_12-59-02",
+        "process_name": "alignment"
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "7103755a-cae9-4236-8de9-816f673d3721"
+        ]
+    },
+    "instrument": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/imaging/instrument.py",
+        "schema_version": "0.9.1",
+        "instrument_id": "exaSPIM1-01",
+        "modification_date": "2023-10-27",
+        "instrument_type": "exaSPIM",
+        "manufacturer": {
+            "name": "Custom",
+            "abbreviation": null,
+            "registry": null,
+            "registry_identifier": null
+        },
+        "temperature_control": false,
+        "humidity_control": false,
+        "optical_tables": [
+            {
+                "device_type": "OpticalTable",
+                "name": null,
+                "serial_number": "10349925",
+                "manufacturer": {
+                    "name": "MKS Newport",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "00k17f049"
+                },
+                "model": "VIS3648-PG2-325A",
+                "notes": null,
+                "length": 36,
+                "width": 48,
+                "table_size_unit": "inch",
+                "vibration_control": true
+            }
+        ],
+        "objectives": [
+            {
+                "device_type": "Objective",
+                "name": "Detection objective",
+                "serial_number": "15618844",
+                "manufacturer": {
+                    "name": "Vieworks",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "JM_DIAMOND 5.0X/1.3",
+                "notes": "detection objective. manufacturer collaboration between Schneider-Kreuznach and Vieworks",
+                "numerical_aperture": 0.305,
+                "magnification": 5,
+                "immersion": "air"
+            },
+            {
+                "device_type": "Objective",
+                "name": "Excitation objective",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "TL2X-SAP",
+                "notes": "excitation objective. magnification assuming 200 mm tube lens focal length",
+                "numerical_aperture": 0.1,
+                "magnification": 2,
+                "immersion": "air"
+            }
+        ],
+        "detectors": [
+            {
+                "device_type": "Detector",
+                "name": null,
+                "serial_number": "MP151BBX006",
+                "manufacturer": {
+                    "name": "Vieworks",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "VP-151MX-M6H0",
+                "notes": null,
+                "detector_type": "Camera",
+                "data_interface": "Coax",
+                "cooling": "air",
+                "immersion": null,
+                "chroma": null,
+                "sensor_width": null,
+                "sensor_height": null,
+                "size_unit": "pixel",
+                "bit_depth": null,
+                "bin_mode": "none",
+                "bin_width": null,
+                "bin_height": null,
+                "bin_unit": "pixel",
+                "gain": null,
+                "crop_width": null,
+                "crop_height": null,
+                "crop_unit": "pixel"
+            }
+        ],
+        "light_sources": [
+            {
+                "device_type": "Laser",
+                "name": "488 nm laser",
+                "serial_number": "MX1275",
+                "manufacturer": {
+                    "name": "Coherent Scientific",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "model": "Genesis MX488-1000 STM OPSLaser-Diode System",
+                "notes": "Housed in custom laser combiner. Water cooled.",
+                "wavelength": 488,
+                "wavelength_unit": "nanometer",
+                "maximum_power": 1000,
+                "power_unit": "milliwatt",
+                "coupling": "Free-space",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "item_number": null
+            },
+            {
+                "device_type": "Laser",
+                "name": "561 nm laser",
+                "serial_number": "MX1276",
+                "manufacturer": {
+                    "name": "Coherent Scientific",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "model": "Genesis MX561-1000 STM OPSLaser-Diode System",
+                "notes": "Housed in custom laser combiner. Water cooled.",
+                "wavelength": 561,
+                "wavelength_unit": "nanometer",
+                "maximum_power": 1000,
+                "power_unit": "milliwatt",
+                "coupling": "Free-space",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "item_number": null
+            },
+            {
+                "device_type": "Laser",
+                "name": "639 nm laser",
+                "serial_number": "MX1274",
+                "manufacturer": {
+                    "name": "Coherent Scientific",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "model": "Genesis MX639-1000 STM OPSLaser-Diode System",
+                "notes": "Housed in custom laser combiner. Water cooled.",
+                "wavelength": 639,
+                "wavelength_unit": "nanometer",
+                "maximum_power": 1000,
+                "power_unit": "milliwatt",
+                "coupling": "Free-space",
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "item_number": null
+            }
+        ],
+        "lenses": null,
+        "fluorescence_filters": [
+            {
+                "device_type": "Filter",
+                "name": "Emission filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Chroma",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "ZET488/561m",
+                "notes": "Custom made filter. No filter wheel.",
+                "filter_type": "Multiband",
+                "diameter": 44.05,
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": 1,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            }
+        ],
+        "motorized_stages": [
+            {
+                "device_type": "MotorizedStage",
+                "name": "Illumination objective stage 1",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Applied Scientific Instrumentation",
+                    "abbreviation": "ASI",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "notes": "translates illumination objective along detection axis. tiger M axis.",
+                "travel": 50,
+                "travel_unit": "millimeter",
+                "firmware": null
+            },
+            {
+                "device_type": "MotorizedStage",
+                "name": "Illumination objective stage 2",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Applied Scientific Instrumentation",
+                    "abbreviation": "ASI",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-50",
+                "notes": "translates illumination objective perpendicular to detection axis. tiger N axis.",
+                "travel": 50,
+                "travel_unit": "millimeter",
+                "firmware": null
+            }
+        ],
+        "scanning_stages": [
+            {
+                "device_type": "MotorizedStage",
+                "name": "X scanning stage",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Applied Scientific Instrumentation",
+                    "abbreviation": "ASI",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "MS-8000",
+                "notes": null,
+                "travel": 1000,
+                "travel_unit": "millimeter",
+                "firmware": null,
+                "stage_axis_direction": "Detection axis",
+                "stage_axis_name": "X"
+            },
+            {
+                "device_type": "MotorizedStage",
+                "name": "Y scanning stage",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Applied Scientific Instrumentation",
+                    "abbreviation": "ASI",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "MS-8000",
+                "notes": null,
+                "travel": 1000,
+                "travel_unit": "millimeter",
+                "firmware": null,
+                "stage_axis_direction": "Perpendicular axis",
+                "stage_axis_name": "Y"
+            },
+            {
+                "device_type": "MotorizedStage",
+                "name": "Z scanning stage",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Applied Scientific Instrumentation",
+                    "abbreviation": "ASI",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LS-100",
+                "notes": null,
+                "travel": 100,
+                "travel_unit": "millimeter",
+                "firmware": null,
+                "stage_axis_direction": "Illumination axis",
+                "stage_axis_name": "Z"
+            }
+        ],
+        "daqs": [
+            {
+                "device_type": "DAQDevice",
+                "name": "NIDAQ",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "National Instruments",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "PCIe-6738",
+                "notes": "Dev2",
+                "data_interface": "PCIe",
+                "computer_name": "W10DTA03416",
+                "channels": [
+                    {
+                        "channel_name": "AO0",
+                        "device_name": "ETL",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    },
+                    {
+                        "channel_name": "AO1",
+                        "device_name": "Imaging camera",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    },
+                    {
+                        "channel_name": "AO2",
+                        "device_name": "Z scanning stage",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    },
+                    {
+                        "channel_name": "AO3",
+                        "device_name": "AOTF RF driver, 488 nm",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    },
+                    {
+                        "channel_name": "AO3",
+                        "device_name": "AOTF RF driver, 488 nm",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    },
+                    {
+                        "channel_name": "AO4",
+                        "device_name": "AOTF RF driver, 639 nm",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    },
+                    {
+                        "channel_name": "AO13",
+                        "device_name": "AOTF RF driver, 561 nm",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    },
+                    {
+                        "channel_name": "AO17",
+                        "device_name": "Galvo servo 1",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    },
+                    {
+                        "channel_name": "AO19",
+                        "device_name": "Galvo servo 2",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": 10000,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": false
+                    }
+                ]
+            }
+        ],
+        "additional_devices": [
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "L1",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Other",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "LMPLANFL N 50X",
+                "notes": "L1. first beam expander lens. f = 3.6 mm",
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "L2",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Other",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "7.5X Mitutoyo Plan Apo",
+                "notes": "L2. second beam expander lens. f = 26.67 mm",
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "L3",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "ACY254-050-A-ML",
+                "notes": "L3. cylindrical lens. f = 50 mm",
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "L4",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "AC508-200-A-ML",
+                "notes": "L4. first relay lens. f = 200 mm",
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "L5",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "AC508-300-A-ML",
+                "notes": "L5. second relay lens. f = 300 mm",
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "ETL",
+                "serial_number": "ANAC4286",
+                "manufacturer": {
+                    "name": "Optotune",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "EL-16-40-TC-VIS-20D-C",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "Cylindrical lens rotation stage",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Applied Scientific Instrumentation",
+                    "abbreviation": "ASI",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "C60-3060-CMR-MO",
+                "notes": null,
+                "type": "Rotation mount"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "AOTF",
+                "serial_number": "1002-Q220234",
+                "manufacturer": {
+                    "name": "Other",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "AOTFnC-400.650-TN",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "AOTF RF driver",
+                "serial_number": "2001-Q220234",
+                "manufacturer": {
+                    "name": "Other",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "MPDS8C-D65-22-74.158-RS",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "Tiger controller",
+                "serial_number": "2112-2317-8584-5632-5631",
+                "manufacturer": {
+                    "name": "Applied Scientific Instrumentation",
+                    "abbreviation": "ASI",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "TG8-XY:A(Xb)H-Z/F:5A:FTP",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "NIDAQ breakout board",
+                "serial_number": "1FCD210",
+                "manufacturer": {
+                    "name": "National Instruments",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "SCB-68A",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "Galvo 1",
+                "serial_number": "20375",
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "QS20Y-AG",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "Galvo 2",
+                "serial_number": "20385",
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "QS20Y-AG",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "Galvo servo 1",
+                "serial_number": "02232",
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "QS20Y-AG",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "Galvo servo 2",
+                "serial_number": "02216",
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "QS20Y-AG",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "488 nm laser 210 Watt Thermoelectric Chiller with Coherent Logo",
+                "serial_number": "A76636",
+                "manufacturer": {
+                    "name": "Coherent Scientific",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "model": "0P9T257P30",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "561 nm laser 210 Watt Thermoelectric Chiller with Coherent Logo",
+                "serial_number": "A76626",
+                "manufacturer": {
+                    "name": "Coherent Scientific",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "model": "0P9T257P30",
+                "notes": null,
+                "type": "Other"
+            },
+            {
+                "device_type": "AdditionalImagingDevice",
+                "name": "639 nm laser 210 Watt Thermoelectric Chiller with Coherent Logo",
+                "serial_number": "A76606",
+                "manufacturer": {
+                    "name": "Coherent Scientific",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "model": "0P9T257P30",
+                "notes": null,
+                "type": "Other"
+            }
+        ],
+        "calibration_date": null,
+        "calibration_data": null,
+        "com_ports": [
+            {
+                "hardware_name": "AOTF RF driver",
+                "com_port": "COM13"
+            },
+            {
+                "hardware_name": "Tiger Controller",
+                "com_port": "COM5"
+            }
+        ],
+        "notes": null
+    },
+    "last_modified": "2025-10-27T21:51:49.967Z",
+    "location": "s3://aind-open-data/exaSPIM_747820_2024-12-09_12-59-02_alignment_2025-01-23_06-40-34",
+    "metadata_status": "Invalid",
+    "name": "exaSPIM_747820_2024-12-09_12-59-02_alignment_2025-01-23_06-40-34",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "schema_version": "1.1.3",
+        "subject_id": "747820",
+        "subject_procedures": [
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2024-06-20",
+                "experimenter_full_name": "13040",
+                "iacuc_protocol": "2109",
+                "animal_weight_prior": null,
+                "animal_weight_post": null,
+                "weight_unit": "gram",
+                "anaesthesia": null,
+                "workstation_id": null,
+                "procedures": [
+                    {
+                        "recovery_time": null,
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "procedure_type": "Retro-orbital injection",
+                        "injection_volume": null,
+                        "injection_volume_unit": "microliter",
+                        "injection_eye": null,
+                        "protocol_id": null
+                    }
+                ],
+                "notes": null
+            },
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2024-07-25",
+                "experimenter_full_name": "13040",
+                "iacuc_protocol": "2109",
+                "animal_weight_prior": null,
+                "animal_weight_post": null,
+                "weight_unit": "gram",
+                "anaesthesia": null,
+                "workstation_id": null,
+                "procedures": [
+                    {
+                        "procedure_type": "Perfusion",
+                        "output_specimen_ids": [
+                            "747820"
+                        ],
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.8epv51bejl1b/v6"
+                    }
+                ],
+                "notes": null
+            },
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2024-06-20",
+                "experimenter_full_name": "LAS-90",
+                "iacuc_protocol": "2109",
+                "animal_weight_prior": null,
+                "animal_weight_post": null,
+                "weight_unit": "gram",
+                "anaesthesia": null,
+                "workstation_id": null,
+                "procedures": [
+                    {
+                        "recovery_time": null,
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "procedure_type": "Intraperitoneal injection",
+                        "injection_volume": null,
+                        "injection_volume_unit": "microliter",
+                        "protocol_id": null
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "NA",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "AiV2001_PHPeB",
+                                    "plasmid_tars_alias": null,
+                                    "prep_lot_number": "VT6885C",
+                                    "prep_date": "2024-02-22",
+                                    "prep_type": "Crude",
+                                    "prep_protocol": "PHPeB-SOP#VC004"
+                                },
+                                "addgene_id": null,
+                                "titer": null,
+                                "titer_unit": "gc/mL"
+                            },
+                            {
+                                "material_type": "Virus",
+                                "name": "VIR300002_PHPeB",
+                                "tars_identifiers": {
+                                    "virus_tars_id": null,
+                                    "plasmid_tars_alias": null,
+                                    "prep_lot_number": "VT4358g",
+                                    "prep_date": "2022-09-23",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": null,
+                                "titer": null,
+                                "titer_unit": "gc/mL"
+                            },
+                            {
+                                "material_type": "Virus",
+                                "name": "pAAV-7x-TRE-tDTomato",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "AiV300006",
+                                    "plasmid_tars_alias": null,
+                                    "prep_lot_number": "VT6173g",
+                                    "prep_date": "2023-10-03",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": null,
+                                "titer": null,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": null,
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "procedure_type": "Retro-orbital injection",
+                        "injection_volume": "100",
+                        "injection_volume_unit": "microliter",
+                        "injection_eye": null,
+                        "protocol_id": null
+                    }
+                ],
+                "notes": null
+            }
+        ],
+        "specimen_procedures": [],
+        "notes": null
+    },
+    "processing": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "schema_version": "0.4.5",
+        "processing_pipeline": {
+            "data_processes": [],
+            "processor_full_name": "AIND Scientific Computing",
+            "pipeline_version": null,
+            "pipeline_url": null,
+            "note": null
+        },
+        "analyses": [],
+        "notes": null
+    },
+    "quality_control": null,
+    "rig": null,
+    "schema_version": "1.1.1",
+    "session": null,
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": null,
+        "date_of_birth": "2024-05-14",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "wt/wt",
+        "housing": null,
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.2",
+        "sex": "Male",
+        "source": {
+            "abbreviation": null,
+            "name": "Other",
+            "registry": null,
+            "registry_identifier": null
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "747820",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
The changes here remove an unnecessary Microscope device. We added this code before we had the idea of using instrument_id for situations where the entire instrument is the microscope. 

Also added a new SSC -> water mapping which was missing.

Test assets checks both paths.