### PR TITLE
feat: normalize fiber names

### DIFF
--- a/src/aind_metadata_upgrader/utils/normalizers.py
+++ b/src/aind_metadata_upgrader/utils/normalizers.py
@@ -249,11 +249,66 @@ def normalize_camera_names(data: dict) -> dict:
     return data
 
 
+_FIBER_UNDERSCORE_RE = re.compile(r"^Fiber_(\d+)$")
+
+
+def _has_fiber_underscore_name(obj) -> bool:
+    """Return True if any 'name' field anywhere in *obj* contains a Fiber_N value."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if k == "name" and isinstance(v, str) and _FIBER_UNDERSCORE_RE.match(v):
+                return True
+            if _has_fiber_underscore_name(v):
+                return True
+    elif isinstance(obj, list):
+        return any(_has_fiber_underscore_name(item) for item in obj)
+    return False
+
+
+def _fix_fiber_names(obj):
+    """Return a new object with Fiber_N replaced by Fiber N in every 'name' field."""
+    if isinstance(obj, dict):
+        return {
+            k: re.sub(r"^Fiber_(\d+)$", r"Fiber \1", v)
+            if k == "name" and isinstance(v, str)
+            else _fix_fiber_names(v)
+            for k, v in obj.items()
+        }
+    if isinstance(obj, list):
+        return [_fix_fiber_names(item) for item in obj]
+    return obj
+
+
+def normalize_fiber_names(data: dict) -> dict:
+    """Normalize fiber name fields: replace ``'Fiber_N'`` with ``'Fiber N'`` in any
+    ``'name'`` field found anywhere in the record.
+
+    The substitution is driven by the regex ``^Fiber_(\\d+)$``, so only exact
+    matches are changed (e.g. ``"Fiber_0"`` → ``"Fiber 0"``).  Fields named
+    anything other than ``"name"`` are left untouched.
+
+    Parameters
+    ----------
+    data:
+        Raw record dict.
+
+    Returns
+    -------
+    dict
+        A deep copy with all matching name fields normalised, or the original
+        *data* dict unchanged when no normalisation is needed.
+    """
+    if not _has_fiber_underscore_name(data):
+        return data
+    return _fix_fiber_names(copy.deepcopy(data))
+
+
 def pre_upgrade_normalize(data: dict) -> dict:
     """Apply all pre-upgrade normalisations to a raw metadata record.
 
     Currently normalises:
     * Camera assembly names (session ↔ rig).
+    * Fiber name fields: ``'Fiber_N'`` → ``'Fiber N'`` in any ``'name'`` field.
 
     Each normalisation is conservative and is skipped when any ambiguity is
     detected, so the function is safe to call on all records.
@@ -269,4 +324,5 @@ def pre_upgrade_normalize(data: dict) -> dict:
         The record with normalisations applied (deep-copied when changed).
     """
     data = normalize_camera_names(data)
+    data = normalize_fiber_names(data)
     return data

--- a/tests/records/v1/8fe25e69-cfd0-4a49-9ffd-af807c998622.json
+++ b/tests/records/v1/8fe25e69-cfd0-4a49-9ffd-af807c998622.json
@@ -1,0 +1,2749 @@
+{
+    "_id": "8fe25e69-cfd0-4a49-9ffd-af807c998622",
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "schema_version": "1.2.1",
+    "name": "behavior_854145_2026-05-29_12-49-50",
+    "created": "2026-05-30T16:52:16.469566Z",
+    "last_modified": "2026-06-01T22:37:18.676Z",
+    "location": "s3://aind-open-data/behavior_854145_2026-05-29_12-49-50",
+    "metadata_status": "Invalid",
+    "external_links": {
+        "Code Ocean": [
+            "a72f99f9-3bf9-49b3-ab7b-1bc12a5c12fa"
+        ]
+    },
+    "subject": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "schema_version": "1.0.3",
+        "subject_id": "854145",
+        "sex": "Male",
+        "date_of_birth": "2026-02-15",
+        "genotype": "Gad2-IRES-Cre/Gad2-IRES-Cre",
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "name": "National Center for Biotechnology Information",
+                "abbreviation": "NCBI"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Exp-ND-01-039-2414",
+            "maternal_id": "823167",
+            "maternal_genotype": "Gad2-IRES-Cre/Gad2-IRES-Cre",
+            "paternal_id": "823162",
+            "paternal_genotype": "Gad2-IRES-Cre/Gad2-IRES-Cre"
+        },
+        "source": {
+            "name": "Allen Institute",
+            "abbreviation": "AI",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "rrid": null,
+        "restrictions": null,
+        "wellness_reports": [],
+        "housing": {
+            "cage_id": "8324992",
+            "room_id": "221",
+            "light_cycle": null,
+            "home_cage_enrichment": [],
+            "cohoused_subjects": []
+        },
+        "notes": null
+    },
+    "data_description": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "1.0.3",
+        "license": "CC-BY-4.0",
+        "platform": {
+            "name": "Behavior platform",
+            "abbreviation": "behavior"
+        },
+        "subject_id": "854145",
+        "creation_time": "2026-05-29T12:49:50-07:00",
+        "label": null,
+        "name": "behavior_854145_2026-05-29_12-49-50",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "funder": {
+                    "name": "Allen Institute",
+                    "abbreviation": "AI",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null,
+                "fundee": "Alex Piet, Jeremiah Cohen, Kanghoon Jung, Polina Kosillo, Sue Su"
+            },
+            {
+                "funder": {
+                    "name": "National Institute of Mental Health",
+                    "abbreviation": "NIMH",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04xeg9z08"
+                },
+                "grant_number": "1R01MH134833",
+                "fundee": "Jeremiah Cohen, Jonathan Ting, Kenta Hagihara, Polina Kosillo, Yoav Ben-Simon"
+            }
+        ],
+        "data_level": "raw",
+        "group": null,
+        "investigators": [
+            {
+                "name": "Alex Piet",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Kenta Hagihara",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Rachel Lee",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Stefano Recanatesi",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Sue Su",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "project_name": "Discovery Neuromodulation - Subproject 3 Fiber Photometry Recordings of NM Release During Behavior",
+        "restrictions": null,
+        "modality": [
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            },
+            {
+                "name": "Fiber photometry",
+                "abbreviation": "fib"
+            }
+        ],
+        "related_data": [],
+        "data_summary": null
+    },
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "schema_version": "1.2.1",
+        "subject_id": "854145",
+        "subject_procedures": [
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2026-04-21",
+                "experimenter_full_name": "NSB-3543",
+                "iacuc_protocol": "2414",
+                "animal_weight_prior": "26.6",
+                "animal_weight_post": "28.6",
+                "weight_unit": "gram",
+                "anaesthesia": {
+                    "type": "isoflurane",
+                    "duration": "150.0",
+                    "duration_unit": "minute",
+                    "level": "1.5"
+                },
+                "workstation_id": "SWS 2",
+                "procedures": [
+                    {
+                        "procedure_type": "Headframe",
+                        "headframe_type": "AI Straight bar",
+                        "headframe_part_number": null,
+                        "headframe_material": null,
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32205-pAAV-hSyn-GRAB-5HT3.0-myc-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32205_PHPeB",
+                                    "plasmid_tars_alias": "AiP32205",
+                                    "prep_lot_number": "VT7925G",
+                                    "prep_date": "2024-08-30",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32205-pAAV-hSyn-GRAB-5HT3.0-myc-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            },
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32024-pND-pAAV-hSyn-GRAB-rDA3m-HA-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32024_PHPeB",
+                                    "plasmid_tars_alias": "AiP32024",
+                                    "prep_lot_number": "VT6553G",
+                                    "prep_date": "2023-12-21",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32024-pND-pAAV-hSyn-GRAB-rDA3m-HA-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "-1.1",
+                        "injection_coordinate_ap": "1.0",
+                        "injection_coordinate_depth": [
+                            "4.2"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.335",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "5.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Nucleus accumbens",
+                            "acronym": "ACB",
+                            "id": "56"
+                        },
+                        "injection_hemisphere": "Left",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "150.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "4.5",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_0"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Nucleus accumbens",
+                                    "acronym": "ACB",
+                                    "id": "56"
+                                },
+                                "stereotactic_coordinate_ap": "1.0",
+                                "stereotactic_coordinate_ml": "-1.1",
+                                "stereotactic_coordinate_dv": "4.1",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.335",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "5.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32205-pAAV-hSyn-GRAB-5HT3.0-myc-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32205_PHPeB",
+                                    "plasmid_tars_alias": "AiP32205",
+                                    "prep_lot_number": "VT7925G",
+                                    "prep_date": "2024-08-30",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32205-pAAV-hSyn-GRAB-5HT3.0-myc-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            },
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32024-pND-pAAV-hSyn-GRAB-rDA3m-HA-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32024_PHPeB",
+                                    "plasmid_tars_alias": "AiP32024",
+                                    "prep_lot_number": "VT6553G",
+                                    "prep_date": "2023-12-21",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32024-pND-pAAV-hSyn-GRAB-rDA3m-HA-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "1.1",
+                        "injection_coordinate_ap": "1.0",
+                        "injection_coordinate_depth": [
+                            "4.2"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.335",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "5.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Nucleus accumbens",
+                            "acronym": "ACB",
+                            "id": "56"
+                        },
+                        "injection_hemisphere": "Right",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "150.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "4.5",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_1"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Nucleus accumbens",
+                                    "acronym": "ACB",
+                                    "id": "56"
+                                },
+                                "stereotactic_coordinate_ap": "1.0",
+                                "stereotactic_coordinate_ml": "1.1",
+                                "stereotactic_coordinate_dv": "4.1",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.335",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "5.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32205-pAAV-hSyn-GRAB-5HT3.0-myc-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32205_PHPeB",
+                                    "plasmid_tars_alias": "AiP32205",
+                                    "prep_lot_number": "VT7925G",
+                                    "prep_date": "2024-08-30",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32205-pAAV-hSyn-GRAB-5HT3.0-myc-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            },
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32024-pND-pAAV-hSyn-GRAB-rDA3m-HA-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32024_PHPeB",
+                                    "plasmid_tars_alias": "AiP32024",
+                                    "prep_lot_number": "VT6553G",
+                                    "prep_date": "2023-12-21",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32024-pND-pAAV-hSyn-GRAB-rDA3m-HA-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "-3.6",
+                        "injection_coordinate_ap": "-1.8",
+                        "injection_coordinate_depth": [
+                            "3.2"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.335",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Piriform area",
+                            "acronym": "PIR",
+                            "id": "961"
+                        },
+                        "injection_hemisphere": "Left",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "200.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "3.5",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_2"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Piriform area",
+                                    "acronym": "PIR",
+                                    "id": "961"
+                                },
+                                "stereotactic_coordinate_ap": "-1.8",
+                                "stereotactic_coordinate_ml": "-3.6",
+                                "stereotactic_coordinate_dv": "3.1",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.335",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "0.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "injection_materials": [],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "3.6",
+                        "injection_coordinate_ap": "-1.8",
+                        "injection_coordinate_depth": [
+                            "3.2"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.335",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Piriform area",
+                            "acronym": "PIR",
+                            "id": "961"
+                        },
+                        "injection_hemisphere": "Right",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "200.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "3.5",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_3"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Piriform area",
+                                    "acronym": "PIR",
+                                    "id": "961"
+                                },
+                                "stereotactic_coordinate_ap": "-1.8",
+                                "stereotactic_coordinate_ml": "3.6",
+                                "stereotactic_coordinate_dv": "3.1",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.335",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "0.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    }
+                ],
+                "notes": null,
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2"
+            },
+            {
+                "procedure_type": "Water restriction",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "baseline_weight": "29.37",
+                "weight_unit": "gram",
+                "start_date": "2026-05-15",
+                "end_date": null
+            },
+            {
+                "procedure_type": "Water restriction",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "baseline_weight": "29.37",
+                "weight_unit": "gram",
+                "start_date": "2026-05-08",
+                "end_date": "2026-05-13"
+            }
+        ],
+        "specimen_procedures": [],
+        "notes": null
+    },
+    "session": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "schema_version": "1.0.1",
+        "protocol_id": [
+            ""
+        ],
+        "experimenter_full_name": [
+            "madeline.tom"
+        ],
+        "session_start_time": "2026-05-29T12:49:57.761419-07:00",
+        "session_end_time": "2026-05-29T14:25:58.876140-07:00",
+        "session_type": "Uncoupled Baiting",
+        "iacuc_protocol": "2414.0",
+        "rig_id": "447_3D_20260527",
+        "calibrations": [],
+        "maintenance": [],
+        "subject_id": "854145",
+        "animal_weight_prior": null,
+        "animal_weight_post": "23.9",
+        "weight_unit": "gram",
+        "anaesthesia": null,
+        "data_streams": [
+            {
+                "stream_start_time": "2026-05-29T12:49:57.761419-07:00",
+                "stream_end_time": "2026-05-29T14:25:58.876140-07:00",
+                "daq_names": [
+                    ""
+                ],
+                "camera_names": [
+                    "Face Side Right",
+                    "Face Bottom"
+                ],
+                "light_sources": [
+                    {
+                        "device_type": "Light emitting diode",
+                        "name": "IR LED",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "name": "470nm LED",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "name": "415nm LED",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "name": "565nm LED",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt"
+                    }
+                ],
+                "ephys_modules": [],
+                "stick_microscopes": [],
+                "manipulator_modules": [],
+                "detectors": [
+                    {
+                        "name": "Green CMOS",
+                        "exposure_time": "4694.537197",
+                        "exposure_time_unit": "microsecond",
+                        "trigger_type": "External"
+                    },
+                    {
+                        "name": "Red CMOS",
+                        "exposure_time": "4694.537197",
+                        "exposure_time_unit": "microsecond",
+                        "trigger_type": "External"
+                    }
+                ],
+                "fiber_connections": [
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Red emission (590nm) with yellow excitation (565nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_green",
+                            "intended_measurement": null,
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Green emission (510nm) with blue excitation (470nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Red emission (590nm) with yellow excitation (565nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_green",
+                            "intended_measurement": null,
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Green emission (510nm) with blue excitation (470nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Red emission (590nm) with yellow excitation (565nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_green",
+                            "intended_measurement": null,
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Green emission (510nm) with blue excitation (470nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 3",
+                        "patch_cord_name": "Patch Cord D",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 3_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Red emission (590nm) with yellow excitation (565nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 3",
+                        "patch_cord_name": "Patch Cord D",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 3_green",
+                            "intended_measurement": null,
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Green emission (510nm) with blue excitation (470nm)"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 3",
+                        "patch_cord_name": "Patch Cord D",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 3_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "emission_wavelength_unit": "nanometer",
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)"
+                        }
+                    }
+                ],
+                "fiber_modules": [],
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "stack_parameters": null,
+                "mri_scans": [],
+                "stream_modalities": [
+                    {
+                        "name": "Behavior videos",
+                        "abbreviation": "behavior-videos"
+                    },
+                    {
+                        "name": "Fiber photometry",
+                        "abbreviation": "fib"
+                    }
+                ],
+                "software": [
+                    {
+                        "name": "dynamic-foraging-task",
+                        "version": "behavior branch:main   commit ID:cf605f1cfac2de1cffb32ffd46158e7866235634    version:1.6.71; metadata branch: main   commit ID:cf605f1cfac2de1cffb32ffd46158e7866235634   version:1.6.71",
+                        "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                        "parameters": {}
+                    }
+                ],
+                "notes": "None;Fib modality: fib mode: Normal This record has been updated to include intended measurements. Fiber connections are repeated for fibers with multiple channels. Disconnected fibers are marked with fiber_name 'disconnected'."
+            }
+        ],
+        "stimulus_epochs": [
+            {
+                "stimulus_start_time": "2026-05-29T12:49:57.761419-07:00",
+                "stimulus_end_time": "2026-05-29T14:08:08.832203-07:00",
+                "stimulus_name": "The behavior auditory go cue",
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "dynamic-foraging-task",
+                        "version": "behavior branch:main   commit ID:cf605f1cfac2de1cffb32ffd46158e7866235634    version:1.6.71; metadata branch: main   commit ID:cf605f1cfac2de1cffb32ffd46158e7866235634   version:1.6.71",
+                        "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                        "parameters": {}
+                    }
+                ],
+                "script": null,
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_parameters": [
+                    {
+                        "stimulus_type": "Auditory Stimulation",
+                        "sitmulus_name": "auditory go cue",
+                        "sample_frequency": "96000",
+                        "amplitude_modulation_frequency": 7500,
+                        "frequency_unit": "hertz",
+                        "bandpass_low_frequency": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_order": null,
+                        "notes": null
+                    }
+                ],
+                "stimulus_device_names": [
+                    "Stimulus Speaker"
+                ],
+                "speaker_config": {
+                    "name": "Stimulus Speaker",
+                    "volume": "71",
+                    "volume_unit": "decibels"
+                },
+                "light_source_config": [],
+                "output_parameters": {
+                    "meta": {
+                        "box": "447-3-D",
+                        "session_run_time_in_min": 78
+                    },
+                    "water": {
+                        "water_in_session_foraging": 0.463,
+                        "water_in_session_manual": 0.0020000000000000573,
+                        "water_in_session_total": 0.4650000000000001,
+                        "water_after_session": 1.065,
+                        "water_day_total": 1.53
+                    },
+                    "performance": {
+                        "foraging_efficiency": 0.7331662333627043,
+                        "foraging_efficiency_with_actual_random_seed": 0.7533783783783784
+                    },
+                    "task_parameters": {
+                        "ITIMin": "1.0",
+                        "DelayMin": "0.5",
+                        "DelayBeta": "0.0",
+                        "DelayMax": "0.5",
+                        "Task": "Uncoupled Baiting",
+                        "BlockMax": "35",
+                        "ITIMax": "15.0",
+                        "ITIBeta": "3.0",
+                        "BlockBeta": "10",
+                        "BlockMin": "20",
+                        "RightValue_volume": "2.00",
+                        "LeftValue_volume": "2.00",
+                        "stage_in_use": "STAGE_3",
+                        "curriculum_in_use": "Uncoupled Baiting (v2.3@1.0)",
+                        "reward_probability": "0.1, 0.4, 0.7"
+                    },
+                    "ffmpeg_parameters": {
+                        "ffmpeg_input_args": "-colorspace bt709 -color_primaries bt709 -color_range full -color_trc linear",
+                        "ffmpeg_output_args": "-vf \"scale=out_range=full,setparams=range=full:colorspace=bt709:color_primaries=bt709:color_trc=linear\" -c:v h264_nvenc -pix_fmt yuv420p -color_range full -colorspace bt709 -color_trc linear -tune hq -preset p3 -rc vbr -cq 18 -b:v 0M -metadata author=\"Allen Institute for Neural Dynamics\" -maxrate 700M -bufsize 350M -f matroska -write_crc32 0"
+                    }
+                },
+                "reward_consumed_during_epoch": "463.0",
+                "reward_consumed_unit": "microliter",
+                "trials_total": 569,
+                "trials_finished": 477,
+                "trials_rewarded": 223,
+                "notes": "The duration of go cue is 100 ms. The frequency is 7500 Hz. Amplitude is 71dB. The total reward consumed in the session is 463.0 microliters. The total reward including consumed in the session and supplementary water is 1.53 milliliters."
+            }
+        ],
+        "mouse_platform_name": "mouse_tube_foraging",
+        "active_mouse_platform": false,
+        "headframe_registration": null,
+        "reward_delivery": null,
+        "reward_consumed_total": "463.0",
+        "reward_consumed_unit": "microliter",
+        "notes": ""
+    },
+    "rig": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "schema_version": "1.0.1",
+        "rig_id": "447_3D_20260527",
+        "modification_date": "2026-05-27",
+        "mouse_platform": {
+            "device_type": "Tube",
+            "name": "mouse_tube_foraging",
+            "serial_number": null,
+            "manufacturer": {
+                "name": "Custom",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            "model": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "additional_settings": {},
+            "notes": null,
+            "surface_material": null,
+            "date_surface_replaced": null,
+            "diameter": "3.0",
+            "diameter_unit": "centimeter"
+        },
+        "stimulus_devices": [
+            {
+                "device_type": "Reward delivery",
+                "stage_type": {
+                    "device_type": "Motorized stage",
+                    "name": "AIND lick spout stage",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Allen Institute for Neural Dynamics",
+                        "abbreviation": "AIND",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "04szwah67"
+                    },
+                    "model": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": "https://allenneuraldynamics.github.io/Bonsai.AllenNeuralDynamics/articles/aind-manipulator.html",
+                    "travel": "30",
+                    "travel_unit": "millimeter",
+                    "firmware": null
+                },
+                "reward_spouts": [
+                    {
+                        "device_type": "Reward spout",
+                        "name": "Left lick spout",
+                        "serial_number": null,
+                        "manufacturer": null,
+                        "model": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "additional_settings": {},
+                        "notes": null,
+                        "side": "Left",
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null,
+                        "solenoid_valve": {
+                            "device_type": "Solenoid",
+                            "name": "Solenoid Left",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "The Lee Company",
+                                "abbreviation": null,
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor": {
+                            "device_type": "Lick Sensor",
+                            "name": "Lick Sensor Left",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "Janelia Research Campus",
+                                "abbreviation": "Janelia",
+                                "registry": {
+                                    "name": "Research Organization Registry",
+                                    "abbreviation": "ROR"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor_type": "Capacitive"
+                    },
+                    {
+                        "device_type": "Reward spout",
+                        "name": "Right lick spout",
+                        "serial_number": null,
+                        "manufacturer": null,
+                        "model": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "additional_settings": {},
+                        "notes": null,
+                        "side": "Right",
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null,
+                        "solenoid_valve": {
+                            "device_type": "Solenoid",
+                            "name": "Solenoid Right",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "The Lee Company",
+                                "abbreviation": null,
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor": {
+                            "device_type": "Lick Sensor",
+                            "name": "Lick Sensor Right",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "Janelia Research Campus",
+                                "abbreviation": "Janelia",
+                                "registry": {
+                                    "name": "Research Organization Registry",
+                                    "abbreviation": "ROR"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor_type": "Capacitive"
+                    }
+                ]
+            },
+            {
+                "device_type": "Speaker",
+                "name": "Stimulus Speaker",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Tymphany",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "XT25SC90-04",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "position": null
+            }
+        ],
+        "cameras": [
+            {
+                "name": "Right Camera assembly",
+                "camera_target": "Face side right",
+                "camera": {
+                    "device_type": "Detector",
+                    "name": "Right size of face camera",
+                    "serial_number": "23349434",
+                    "manufacturer": {
+                        "name": "Teledyne FLIR",
+                        "abbreviation": "FLIR",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "USB",
+                    "cooling": "Air",
+                    "computer_name": "W10DT714030",
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 720,
+                    "sensor_height": 540,
+                    "size_unit": "pixel",
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "bit_depth": null,
+                    "bin_mode": "None",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": null,
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "device_type": "Lens",
+                    "name": "Behavior Video Lens Right Side",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Fujinon",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "CF16ZA-1S",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "size": null,
+                    "lens_size_unit": "inch",
+                    "optimized_wavelength_range": null,
+                    "wavelength_unit": "nanometer",
+                    "max_aperture": null
+                },
+                "filter": null,
+                "position": null
+            },
+            {
+                "name": "Bottom Camera assembly",
+                "camera_target": "Face bottom",
+                "camera": {
+                    "device_type": "Detector",
+                    "name": "bottom of face camera",
+                    "serial_number": "23347798",
+                    "manufacturer": {
+                        "name": "Teledyne FLIR",
+                        "abbreviation": "FLIR",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "USB",
+                    "cooling": "Air",
+                    "computer_name": "W10DT714030",
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 720,
+                    "sensor_height": 540,
+                    "size_unit": "pixel",
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "bit_depth": null,
+                    "bin_mode": "None",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": null,
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "device_type": "Lens",
+                    "name": "Behavior Video Lens Bottom of face",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Other",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "LM25HC",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": "Manufacturer is Kowa",
+                    "focal_length": "25",
+                    "focal_length_unit": "millimeter",
+                    "size": null,
+                    "lens_size_unit": "inch",
+                    "optimized_wavelength_range": null,
+                    "wavelength_unit": "nanometer",
+                    "max_aperture": null
+                },
+                "filter": null,
+                "position": null
+            }
+        ],
+        "enclosure": {
+            "device_type": "Enclosure",
+            "name": "Behavior enclosure",
+            "serial_number": null,
+            "manufacturer": {
+                "name": "Allen Institute for Neural Dynamics",
+                "abbreviation": "AIND",
+                "registry": {
+                    "name": "Research Organization Registry",
+                    "abbreviation": "ROR"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "additional_settings": {},
+            "notes": null,
+            "size": {
+                "width": 54,
+                "length": 54,
+                "height": 54,
+                "unit": "centimeter"
+            },
+            "internal_material": "",
+            "external_material": "",
+            "grounded": false,
+            "laser_interlock": false,
+            "air_filtration": false
+        },
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "stick_microscopes": [],
+        "laser_assemblies": [],
+        "patch_cords": [
+            {
+                "device_type": "Patch",
+                "name": "Bundle Branching Fiber-optic Patch Cord",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Doric",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "059n53q30"
+                },
+                "model": "BBP(4)_200/220/900-0.37_Custom_FCM-4xMF1.25",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "core_diameter": "200",
+                "numerical_aperture": "0.37",
+                "photobleaching_date": null
+            }
+        ],
+        "light_sources": [
+            {
+                "device_type": "Light emitting diode",
+                "name": "IR LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            },
+            {
+                "device_type": "Light emitting diode",
+                "name": "470nm LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M470F3",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 470,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            },
+            {
+                "device_type": "Light emitting diode",
+                "name": "415nm LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M415F3",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 415,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            },
+            {
+                "device_type": "Light emitting diode",
+                "name": "565nm LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M565F3",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 565,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            }
+        ],
+        "detectors": [
+            {
+                "device_type": "Detector",
+                "name": "Green CMOS",
+                "serial_number": "23391004",
+                "manufacturer": {
+                    "name": "Teledyne FLIR",
+                    "abbreviation": "FLIR",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "detector_type": "Camera",
+                "data_interface": "USB",
+                "cooling": "Air",
+                "computer_name": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "immersion": "air",
+                "chroma": "Monochrome",
+                "sensor_width": null,
+                "sensor_height": null,
+                "size_unit": "pixel",
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "bit_depth": 16,
+                "bin_mode": "Additive",
+                "bin_width": 4,
+                "bin_height": 4,
+                "bin_unit": "pixel",
+                "gain": "2",
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_width": 200,
+                "crop_height": 200,
+                "crop_unit": "pixel",
+                "recording_software": null,
+                "driver": null,
+                "driver_version": null
+            },
+            {
+                "device_type": "Detector",
+                "name": "Red CMOS",
+                "serial_number": "23320855",
+                "manufacturer": {
+                    "name": "Teledyne FLIR",
+                    "abbreviation": "FLIR",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "detector_type": "Camera",
+                "data_interface": "USB",
+                "cooling": "Air",
+                "computer_name": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "immersion": "air",
+                "chroma": "Monochrome",
+                "sensor_width": null,
+                "sensor_height": null,
+                "size_unit": "pixel",
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "bit_depth": 16,
+                "bin_mode": "Additive",
+                "bin_width": 4,
+                "bin_height": 4,
+                "bin_unit": "pixel",
+                "gain": "2",
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_width": 200,
+                "crop_height": 200,
+                "crop_unit": "pixel",
+                "recording_software": null,
+                "driver": null,
+                "driver_version": null
+            }
+        ],
+        "objectives": [
+            {
+                "device_type": "Objective",
+                "name": "FIP Objective",
+                "serial_number": "128023323",
+                "manufacturer": {
+                    "name": "Nikon",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "0280y9h11"
+                },
+                "model": "CFI Plan Apochromat Lambda D 10x",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "numerical_aperture": "0.45",
+                "magnification": "10",
+                "immersion": "air",
+                "objective_type": null
+            }
+        ],
+        "filters": [
+            {
+                "device_type": "Filter",
+                "name": "Green emission filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Semrock",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-520/35-25",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 520,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Red emission filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Semrock",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-600/37-25",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 600,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Emission Dichroic",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Semrock",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF562-Di03-25x36",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Dichroic",
+                "diameter": null,
+                "width": "36",
+                "height": "25",
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": 562,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "beamsplitter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Semrock",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF493/574-Di01-25x36",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": "493/574 nm BrightLine dual-edge standard epi-fluorescence dichroic beamsplitter",
+                "filter_type": "Multiband",
+                "diameter": null,
+                "width": "36",
+                "height": "25",
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Excitation filter 410nm",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB410-10",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 410,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Excitation filter 470nm",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB470-10",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 470,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Excitation filter 560nm",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB560-10",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 560,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "450 Dichroic Longpass Filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Edmund Optics",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "#69-898",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Dichroic",
+                "diameter": null,
+                "width": "35.6",
+                "height": "25.2",
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": 450,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "500 Dichroic Longpass Filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Edmund Optics",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "#69-899",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Dichroic",
+                "diameter": null,
+                "width": "35.6",
+                "height": "23.2",
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": 500,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            }
+        ],
+        "lenses": [
+            {
+                "device_type": "Lens",
+                "name": "Image focusing lens",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "AC254-080-A-ML",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "focal_length": "80",
+                "focal_length_unit": "millimeter",
+                "size": 1,
+                "lens_size_unit": "inch",
+                "optimized_wavelength_range": null,
+                "wavelength_unit": "nanometer",
+                "max_aperture": null
+            }
+        ],
+        "digital_micromirror_devices": [],
+        "polygonal_scanners": [],
+        "pockels_cells": [],
+        "additional_devices": [
+            {
+                "device_type": "Photometry Clock",
+                "name": "Photometry Clock",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null
+            }
+        ],
+        "daqs": [
+            {
+                "device_type": "Harp device",
+                "name": "harp behavior board",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": "Left lick spout and Right lick spout, as well as reward delivery solenoids are connected via ethernet cables",
+                "data_interface": "Ethernet",
+                "computer_name": "W10DT714030",
+                "channels": [
+                    {
+                        "channel_name": "DI3",
+                        "device_name": "Photometry Clock",
+                        "channel_type": "Digital Input",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    }
+                ],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Behavior",
+                    "whoami": 1216
+                },
+                "core_version": "1.11",
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp sound card",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "W10DT714030",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Sound Card",
+                    "whoami": 1280
+                },
+                "core_version": "1.4",
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp clock synchronization board",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "W10DT714030",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Clock Synchronizer",
+                    "whoami": 1152
+                },
+                "core_version": "",
+                "tag_version": null,
+                "is_clock_generator": true
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp sound amplifier",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "W10DT714030",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Input Expander",
+                    "whoami": 1106
+                },
+                "core_version": "",
+                "tag_version": null,
+                "is_clock_generator": false
+            }
+        ],
+        "calibrations": [
+            {
+                "calibration_date": "2026-05-26T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.0316
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.975
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-05-12T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.0316
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.07
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-05-06T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.0316
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.05
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-04-28T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.0316
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.005
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-04-21T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.0316
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.07
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-04-15T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.0316
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.99
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-04-07T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.0316
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.95
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-03-31T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.0316
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.055
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-03-24T00:00:00-07:00",
+                "device_name": "Lick spout Left",
+                "description": "Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03,
+                        0.04
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.174,
+                        1.881,
+                        2.597
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-05-26T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.925
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-05-12T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.015
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-05-06T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.03
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-04-28T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.05
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-04-21T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.04
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-04-15T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.91
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-04-07T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.86
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-03-31T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.975
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-03-24T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.755
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-03-17T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.945
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-03-10T00:00:00-07:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-03-03T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.98
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-02-25T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.97
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-02-17T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.065
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-02-03T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.04
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-01-27T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.04
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-01-20T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.005
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-01-13T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.99
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-01-06T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.08
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2026-01-05T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "input": {
+                    "valve open time (s):": [
+                        0.025
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.985
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2025-12-22T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.602,
+                        2.403
+                    ]
+                },
+                "notes": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "origin": null,
+        "rig_axes": null,
+        "modalities": [
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            },
+            {
+                "name": "Fiber photometry",
+                "abbreviation": "fib"
+            }
+        ],
+        "notes": null
+    },
+    "processing": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "schema_version": "1.1.3",
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "name": "Other",
+                    "software_version": "",
+                    "input_location": "//allen/aind/scratch/dynamic_foraging_rig_transfer/behavior_854145_2026-05-29_12-49-50/behavior",
+                    "output_location": "",
+                    "code_url": "",
+                    "parameters": {
+                        "input_source": "//allen/aind/scratch/dynamic_foraging_rig_transfer/behavior_854145_2026-05-29_12-49-50/behavior"
+                    },
+                    "notes": "Data was copied",
+                    "start_date_time": "2026-05-30 04:29:16+00:00",
+                    "end_date_time": "2026-05-30 04:29:16+00:00"
+                },
+                {
+                    "name": "Other",
+                    "software_version": "0.2.2",
+                    "input_location": "//allen/aind/scratch/dynamic_foraging_rig_transfer/behavior_854145_2026-05-29_12-49-50/behavior-videos",
+                    "output_location": "/allen/aind/stage/svc_aind_airflow/prod/behavior_854145_2026-05-29_12-49-50_077fb62b0e/behavior-videos",
+                    "code_url": "ghcr.io/allenneuraldynamics/aind-behavior-video-transformation",
+                    "parameters": {
+                        "output_directory": "/allen/aind/stage/svc_aind_airflow/prod/behavior_854145_2026-05-29_12-49-50_077fb62b0e/behavior-videos",
+                        "input_source": "//allen/aind/scratch/dynamic_foraging_rig_transfer/behavior_854145_2026-05-29_12-49-50/behavior-videos"
+                    },
+                    "notes": null,
+                    "start_date_time": "2026-05-30 04:29:16+00:00",
+                    "end_date_time": "2026-05-30 16:46:30+00:00"
+                },
+                {
+                    "name": "Other",
+                    "software_version": "",
+                    "input_location": "//allen/aind/scratch/dynamic_foraging_rig_transfer/behavior_854145_2026-05-29_12-49-50/fib",
+                    "output_location": "",
+                    "code_url": "",
+                    "parameters": {
+                        "input_source": "//allen/aind/scratch/dynamic_foraging_rig_transfer/behavior_854145_2026-05-29_12-49-50/fib"
+                    },
+                    "notes": "Data was copied",
+                    "start_date_time": "2026-05-30 04:29:00+00:00",
+                    "end_date_time": "2026-05-30 04:29:00+00:00"
+                }
+            ],
+            "processor_full_name": "AIND Scientific Computing",
+            "pipeline_version": null,
+            "pipeline_url": null,
+            "note": null
+        },
+        "analyses": [],
+        "notes": null
+    },
+    "acquisition": null,
+    "instrument": null,
+    "quality_control": null
+}

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -8,6 +8,7 @@ from aind_metadata_upgrader.utils.normalizers import (
     _get_rig_camera_assembly_names,
     _get_session_camera_names,
     normalize_camera_names,
+    normalize_fiber_names,
     pre_upgrade_normalize,
 )
 
@@ -322,6 +323,82 @@ class TestPreUpgradeNormalize(unittest.TestCase):
         """Empty record is no-op."""
         data: dict = {}
         result = pre_upgrade_normalize(data)
+        self.assertIs(result, data)
+
+    def test_delegates_to_fiber_normalization(self):
+        """Delegates to fiber name normalization."""
+        data = {"rig": {"fibers": [{"name": "Fiber_0"}, {"name": "Fiber_1"}]}}
+        result = pre_upgrade_normalize(data)
+        names = [f["name"] for f in result["rig"]["fibers"]]
+        self.assertEqual(names, ["Fiber 0", "Fiber 1"])
+
+
+class TestNormalizeFiberNames(unittest.TestCase):
+    """Test normalize_fiber_names."""
+
+    def test_replaces_fiber_underscore_in_name_field(self):
+        """Fiber_N in a 'name' field becomes Fiber N."""
+        data = {"fibers": [{"name": "Fiber_0"}, {"name": "Fiber_1"}, {"name": "Fiber_2"}]}
+        result = normalize_fiber_names(data)
+        names = [f["name"] for f in result["fibers"]]
+        self.assertEqual(names, ["Fiber 0", "Fiber 1", "Fiber 2"])
+
+    def test_handles_large_numbers(self):
+        """Works for multi-digit fiber numbers."""
+        data = {"name": "Fiber_42"}
+        result = normalize_fiber_names(data)
+        self.assertEqual(result["name"], "Fiber 42")
+
+    def test_does_not_touch_non_name_fields(self):
+        """Only 'name' fields are changed; other fields with Fiber_N are left alone."""
+        data = {"label": "Fiber_0", "name": "Fiber_0"}
+        result = normalize_fiber_names(data)
+        self.assertEqual(result["label"], "Fiber_0")
+        self.assertEqual(result["name"], "Fiber 0")
+
+    def test_already_normalized_is_no_op(self):
+        """Records with 'Fiber N' (space) are returned unchanged."""
+        data = {"fibers": [{"name": "Fiber 0"}, {"name": "Fiber 1"}]}
+        result = normalize_fiber_names(data)
+        self.assertIs(result, data)
+
+    def test_empty_record_is_no_op(self):
+        """Empty dict is returned as-is."""
+        data: dict = {}
+        result = normalize_fiber_names(data)
+        self.assertIs(result, data)
+
+    def test_does_not_mutate_original(self):
+        """Original dict is not mutated."""
+        data = {"name": "Fiber_0"}
+        normalize_fiber_names(data)
+        self.assertEqual(data["name"], "Fiber_0")
+
+    def test_nested_structure(self):
+        """Replacement works deep inside nested dicts and lists."""
+        data = {
+            "session": {
+                "data_streams": [
+                    {"fiber_modules": [{"name": "Fiber_3"}]}
+                ]
+            }
+        }
+        result = normalize_fiber_names(data)
+        self.assertEqual(
+            result["session"]["data_streams"][0]["fiber_modules"][0]["name"],
+            "Fiber 3",
+        )
+
+    def test_non_fiber_name_unchanged(self):
+        """Names that don't match Fiber_N pattern are not changed."""
+        data = {"name": "Laser_0"}
+        result = normalize_fiber_names(data)
+        self.assertIs(result, data)
+
+    def test_partial_match_unchanged(self):
+        """'Fiber_0_extra' is not a match (anchored regex)."""
+        data = {"name": "Fiber_0_extra"}
+        result = normalize_fiber_names(data)
         self.assertIs(result, data)
 
 


### PR DESCRIPTION
This PR normalizes fields that look like {"name": "Fiber_N"} to {"name": "Fiber N"}. This avoids an annoying issue where all the fibers are named "Fiber N" in the instrument but "Fiber_N" in the acquisition, causing the upgrader to create empty "Fiber_N" devices in the instrument.