### PR TITLE
fix: repair passing Version objects

### DIFF
--- a/src/aind_metadata_upgrader/upgrade.py
+++ b/src/aind_metadata_upgrader/upgrade.py
@@ -216,7 +216,9 @@ class Upgrade:
             # Apply all upgraders (in order) that match the original schema version
             for specifier_set, upgrader in MAPPING[core_file]:
                 if original_schema_version in specifier_set:
-                    upgraded_data = upgrader().upgrade(core_data, upgraded_schema_version, metadata=self.raw_data)
+                    upgraded_data = upgrader().upgrade(
+                        core_data, UPGRADE_VERSIONS[core_file], metadata=self.raw_data
+                    )
 
         if upgraded_data is None:
             logging.info(f"Upgrader for {core_file} returned None, dropping file")

--- a/tests/records/v1/daa84702-3650-4c4f-b376-4950c2c9e127.json
+++ b/tests/records/v1/daa84702-3650-4c4f-b376-4950c2c9e127.json
@@ -1,0 +1,2554 @@
+{
+    "_id": "daa84702-3650-4c4f-b376-4950c2c9e127",
+    "acquisition": null,
+    "created": "2025-05-21T04:25:56.134640",
+    "data_description": {
+        "creation_time": "2025-05-20T09:20:14-07:00",
+        "data_level": "raw",
+        "data_summary": "Videos are compressed after upload.",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "funding_source": [
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "AI",
+                    "name": "Allen Institute",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null
+            }
+        ],
+        "group": null,
+        "institution": {
+            "abbreviation": "AIND",
+            "name": "Allen Institute for Neural Dynamics",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "investigators": [
+            {
+                "abbreviation": null,
+                "name": "Yoh Isogai",
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "label": null,
+        "license": "CC-BY-4.0",
+        "modality": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "fib",
+                "name": "Fiber photometry"
+            }
+        ],
+        "name": "behavior_779531_2025-05-20_09-20-14",
+        "platform": {
+            "abbreviation": "behavior",
+            "name": "Behavior platform"
+        },
+        "project_name": "AIND Viral Genetic Tools",
+        "related_data": [],
+        "restrictions": null,
+        "schema_version": "1.0.3",
+        "subject_id": "779531"
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "484a2a63-3ff4-484c-b198-df1ad607219b"
+        ]
+    },
+    "instrument": null,
+    "last_modified": "2026-06-24T21:29:43.834Z",
+    "location": "s3://aind-open-data/behavior_779531_2025-05-20_09-20-14",
+    "metadata_status": "Missing",
+    "name": "behavior_779531_2025-05-20_09-20-14",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "schema_version": "1.2.1",
+        "subject_id": "779531",
+        "subject_procedures": [
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2025-10-27",
+                "experimenter_full_name": "30785",
+                "iacuc_protocol": "2414",
+                "animal_weight_prior": null,
+                "animal_weight_post": null,
+                "weight_unit": "gram",
+                "anaesthesia": null,
+                "workstation_id": null,
+                "procedures": [
+                    {
+                        "procedure_type": "Perfusion",
+                        "output_specimen_ids": [
+                            "779531"
+                        ],
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.8epv51bejl1b/v6"
+                    }
+                ],
+                "notes": null
+            },
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2025-03-11",
+                "experimenter_full_name": "NSB-949",
+                "iacuc_protocol": "2414",
+                "animal_weight_prior": "29.2",
+                "animal_weight_post": "30.2",
+                "weight_unit": "gram",
+                "anaesthesia": {
+                    "type": "isoflurane",
+                    "duration": "90.0",
+                    "duration_unit": "minute",
+                    "level": "1.5"
+                },
+                "workstation_id": "SWS 3",
+                "procedures": [
+                    {
+                        "procedure_type": "Headframe",
+                        "headframe_type": "L-shaped",
+                        "headframe_part_number": null,
+                        "headframe_material": null,
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32066_PHPeB",
+                                    "plasmid_tars_alias": "AiP32066",
+                                    "prep_lot_number": "VT7113G",
+                                    "prep_date": "2024-04-12",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 68700000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "15.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "-0.85",
+                        "injection_coordinate_ap": "-5.4",
+                        "injection_coordinate_depth": [
+                            "2.9"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.9",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Locus ceruleus",
+                            "acronym": "LC",
+                            "id": "147"
+                        },
+                        "injection_hemisphere": "Left",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "300.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32066_PHPeB",
+                                    "plasmid_tars_alias": "AiP32066",
+                                    "prep_lot_number": "VT7113G",
+                                    "prep_date": "2024-04-12",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 68700000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "15.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "0.85",
+                        "injection_coordinate_ap": "-5.4",
+                        "injection_coordinate_depth": [
+                            "2.9"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.9",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Locus ceruleus",
+                            "acronym": "LC",
+                            "id": "147"
+                        },
+                        "injection_hemisphere": "Right",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "300.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "2.5",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_0"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Prelimbic area",
+                                    "acronym": "PL",
+                                    "id": "972"
+                                },
+                                "stereotactic_coordinate_ap": "2.0",
+                                "stereotactic_coordinate_ml": "0.5",
+                                "stereotactic_coordinate_dv": "1.5",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.9",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": null,
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "4.0",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_1"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Anteroventral nucleus of thalamus",
+                                    "acronym": "AV",
+                                    "id": "255"
+                                },
+                                "stereotactic_coordinate_ap": "-1.6",
+                                "stereotactic_coordinate_ml": "-1.6",
+                                "stereotactic_coordinate_dv": "3.2",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.9",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": null,
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": null,
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": "Fiber in burr hole 5 is 12 degree lateral. It should be angeled in the way that the ferrule is farther away from the midline than the bottom tip. Please also refer to the instructions for tapered fiber for this fiber. ",
+                                    "core_diameter_unit": "micrometer",
+                                    "ferrule_material": null,
+                                    "active_length": null,
+                                    "total_length": "5.0",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_2"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Gigantocellular reticular nucleus",
+                                    "acronym": "GRN",
+                                    "id": "1048"
+                                },
+                                "stereotactic_coordinate_ap": "-6.2",
+                                "stereotactic_coordinate_ml": "-1.5",
+                                "stereotactic_coordinate_dv": "4.5",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.9",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "12.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    }
+                ],
+                "notes": null,
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2"
+            },
+            {
+                "procedure_type": "Water restriction",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "baseline_weight": "29.3",
+                "weight_unit": "gram",
+                "start_date": "2025-08-08",
+                "end_date": "2025-09-16"
+            },
+            {
+                "procedure_type": "Water restriction",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "baseline_weight": "29.3",
+                "weight_unit": "gram",
+                "start_date": "2025-03-28",
+                "end_date": "2025-06-12"
+            }
+        ],
+        "specimen_procedures": [
+            {
+                "procedure_type": "Delipidation",
+                "procedure_name": "LifeCanvas Active Whole Mouse Brain Delipidation (UNPUBLISHED)",
+                "specimen_id": "779531",
+                "start_date": "2026-01-30",
+                "end_date": "2026-02-19",
+                "experimenter_full_name": "HollyM",
+                "protocol_id": "https://www.protocols.io/view/whole-mouse-brain-delipidation-lifecanvas-active-cttawnie",
+                "reagents": [
+                    {
+                        "name": "SH-ON",
+                        "source": null,
+                        "rrid": null,
+                        "lot_number": "ON44",
+                        "expiration_date": null
+                    },
+                    {
+                        "name": "DB-500",
+                        "source": null,
+                        "rrid": null,
+                        "lot_number": "A07T103",
+                        "expiration_date": null
+                    },
+                    {
+                        "name": "DB-500",
+                        "source": null,
+                        "rrid": null,
+                        "lot_number": "A07T103",
+                        "expiration_date": null
+                    },
+                    {
+                        "name": "CB-450",
+                        "source": null,
+                        "rrid": null,
+                        "lot_number": "j245108",
+                        "expiration_date": null
+                    }
+                ],
+                "hcr_series": null,
+                "antibodies": null,
+                "sectioning": null,
+                "notes": null
+            },
+            {
+                "procedure_type": "Immunolabeling",
+                "procedure_name": "SmartSPIM Labeling",
+                "specimen_id": "779531",
+                "start_date": null,
+                "end_date": null,
+                "experimenter_full_name": "HollyM",
+                "protocol_id": null,
+                "reagents": [],
+                "hcr_series": null,
+                "antibodies": {
+                    "rrid": null,
+                    "expiration_date": null,
+                    "immunolabel_class": "Primary",
+                    "fluorophore": null,
+                    "mass": null,
+                    "mass_unit": "microgram",
+                    "notes": null
+                },
+                "sectioning": null,
+                "notes": null
+            },
+            {
+                "procedure_type": "Immunolabeling",
+                "procedure_name": "SmartSPIM Labeling",
+                "specimen_id": "779531",
+                "start_date": null,
+                "end_date": null,
+                "experimenter_full_name": "HollyM",
+                "protocol_id": null,
+                "reagents": [],
+                "hcr_series": null,
+                "antibodies": {
+                    "rrid": null,
+                    "expiration_date": null,
+                    "immunolabel_class": "Secondary",
+                    "fluorophore": null,
+                    "mass": null,
+                    "mass_unit": "microgram",
+                    "notes": null
+                },
+                "sectioning": null,
+                "notes": null
+            },
+            {
+                "procedure_type": "Refractive index matching",
+                "procedure_name": "Refractive Index Matching - EasyIndex",
+                "specimen_id": "779531",
+                "start_date": null,
+                "end_date": "2026-02-26",
+                "experimenter_full_name": "HollyM",
+                "protocol_id": "https://dx.doi.org/10.17504/protocols.io.kxygx965kg8j/v1",
+                "reagents": [
+                    {
+                        "name": "EI-500-1.52",
+                        "source": null,
+                        "rrid": null,
+                        "lot_number": "EI81",
+                        "expiration_date": null
+                    }
+                ],
+                "hcr_series": null,
+                "antibodies": null,
+                "sectioning": null,
+                "notes": null
+            }
+        ],
+        "notes": null
+    },
+    "processing": {
+        "analyses": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "notes": null,
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/aind-behavior-video-transformation",
+                    "end_date_time": "2025-10-18T03:25:59Z",
+                    "input_location": "//allen/aind/scratch/dynamic_foraging_rig_transfer/behavior_779531_2025-05-20_09-20-14/behavior-videos",
+                    "name": "Compression",
+                    "notes": "Called compression library with gamma-encoding-fix-colorspace.",
+                    "output_location": "s3://aind-open-data/behavior_779531_2025-05-20_09-20-14/behavior-videos",
+                    "outputs": {},
+                    "parameters": {
+                        "compression_requested": {
+                            "compression_enum": "gamma fix colorspace",
+                            "user_ffmpeg_input_options": null,
+                            "user_ffmpeg_output_options": null
+                        },
+                        "ffmpeg_thread_cnt": 4,
+                        "input_source": "/data",
+                        "output_directory": "/results",
+                        "parallel_compression": true,
+                        "video_specific_compression_requests": null
+                    },
+                    "software_version": "0.2.0",
+                    "start_date_time": "2025-10-17T13:25:59Z"
+                },
+                {
+                    "code_url": "https://github.com/AllenNeuralDynamics/ffmpeg-fix-colorrange-metadata-capsule",
+                    "code_version": "1.0.0",
+                    "end_date_time": "2026-04-06T22:00:43Z",
+                    "input_location": "",
+                    "name": "Fix Color Range",
+                    "notes": "Fixed mp4 color range metadata via ffmpeg.",
+                    "output_location": "",
+                    "parameters": {},
+                    "software_version": "",
+                    "start_date_time": "2026-04-06T21:51:01Z"
+                }
+            ],
+            "note": null,
+            "pipeline_url": null,
+            "pipeline_version": null,
+            "processor_full_name": "AIND Scientific Computing"
+        },
+        "schema_version": "1.1.3"
+    },
+    "quality_control": null,
+    "rig": {
+        "additional_devices": [
+            {
+                "additional_settings": {},
+                "device_type": "Photometry Clock",
+                "manufacturer": null,
+                "model": null,
+                "name": "Photometry Clock",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            }
+        ],
+        "calibrations": [
+            {
+                "calibration_date": "2025-05-13T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.13
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-05-06T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.235
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-29T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.17
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-23T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.27
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-15T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.105
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-08T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.09
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-01T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.205
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-25T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.1
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-18T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.185
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-12T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.1
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-04T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.19
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-25T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.023
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-18T00:00:00-08:00",
+                "description": "Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "device_name": "Lick spout Left",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        1.732,
+                        2.634
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-05-13T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.23
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-05-06T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.16
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-29T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.215
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-23T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.22
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-15T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.145
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-08T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.25
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-04-01T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.18
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-25T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-18T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.145
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-12T00:00:00-07:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.25
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-03-04T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-25T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-18T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.05
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-02-11T00:00:00-08:00",
+                "description": "Spot check of water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delievered in microliters. The valve open time was selected to produce 2ul of water. This measurement was used to check the previous calibration, and was not used to set the calibration.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.0265
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        2.1
+                    ]
+                }
+            },
+            {
+                "calibration_date": "2025-01-06T00:00:00-08:00",
+                "description": "Water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "device_name": "Lick spout Right",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        1.16,
+                        2.45
+                    ]
+                }
+            }
+        ],
+        "cameras": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT714027",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "Right size of face camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "24211019",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face side right",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Fujinon",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "CF16ZA-1S",
+                    "name": "Behavior Video Lens Right Side",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Right Camera assembly",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "W10DT714027",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "bottom of face camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "24210996",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face bottom",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "25",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Other",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "LM25HC",
+                    "name": "Behavior Video Lens Bottom of face",
+                    "notes": "Manufacturer is Kowa",
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Bottom Camera assembly",
+                "position": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "daqs": [
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "DI3",
+                        "channel_type": "Digital Input",
+                        "device_name": "Photometry Clock",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "W10DT714027",
+                "core_version": "1.11",
+                "data_interface": "Ethernet",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Behavior",
+                    "whoami": 1216
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp behavior board",
+                "notes": "Left lick spout and Right lick spout, as well as reward delivery solenoids are connected via ethernet cables",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714027",
+                "core_version": "1.4",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Sound Card",
+                    "whoami": 1280
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp sound card",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714027",
+                "core_version": "",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Clock Synchronizer",
+                    "whoami": 1152
+                },
+                "is_clock_generator": true,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp clock synchronization board",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "W10DT714027",
+                "core_version": "",
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Input Expander",
+                    "whoami": 1106
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp sound amplifier",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "detectors": [
+            {
+                "additional_settings": {},
+                "bin_height": 4,
+                "bin_mode": "Additive",
+                "bin_unit": "pixel",
+                "bin_width": 4,
+                "bit_depth": 16,
+                "chroma": "Monochrome",
+                "computer_name": null,
+                "cooling": "Air",
+                "crop_height": 200,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": 200,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": "2",
+                "immersion": "air",
+                "manufacturer": {
+                    "abbreviation": "FLIR",
+                    "name": "Teledyne FLIR",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "name": "Green CMOS",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "23391007",
+                "size_unit": "pixel"
+            },
+            {
+                "additional_settings": {},
+                "bin_height": 4,
+                "bin_mode": "Additive",
+                "bin_unit": "pixel",
+                "bin_width": 4,
+                "bit_depth": 16,
+                "chroma": "Monochrome",
+                "computer_name": null,
+                "cooling": "Air",
+                "crop_height": 200,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": 200,
+                "data_interface": "USB",
+                "detector_type": "Camera",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": "2",
+                "immersion": "air",
+                "manufacturer": {
+                    "abbreviation": "FLIR",
+                    "name": "Teledyne FLIR",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "name": "Red CMOS",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": "23391006",
+                "size_unit": "pixel"
+            }
+        ],
+        "digital_micromirror_devices": [],
+        "enclosure": {
+            "additional_settings": {},
+            "air_filtration": false,
+            "device_type": "Enclosure",
+            "external_material": "",
+            "grounded": false,
+            "internal_material": "",
+            "laser_interlock": false,
+            "manufacturer": {
+                "abbreviation": "AIND",
+                "name": "Allen Institute for Neural Dynamics",
+                "registry": {
+                    "abbreviation": "ROR",
+                    "name": "Research Organization Registry"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "name": "Behavior enclosure",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "size": {
+                "height": 54,
+                "length": 54,
+                "unit": "centimeter",
+                "width": 54
+            }
+        },
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "filters": [
+            {
+                "additional_settings": {},
+                "center_wavelength": 520,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-520/35-25",
+                "name": "Green emission filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 600,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-600/37-25",
+                "name": "Red emission filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": 562,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Dichroic",
+                "filter_wheel_index": null,
+                "height": "25",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF562-Di03-25x36",
+                "name": "Emission Dichroic",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "36"
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Multiband",
+                "filter_wheel_index": null,
+                "height": "25",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Semrock",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF493/574-Di01-25x36",
+                "name": "beamsplitter",
+                "notes": "493/574 nm BrightLine dual-edge standard epi-fluorescence dichroic beamsplitter",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "36"
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 410,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB410-10",
+                "name": "Excitation filter 410nm",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 470,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB470-10",
+                "name": "Excitation filter 470nm",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": 560,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": "25",
+                "filter_type": "Band pass",
+                "filter_wheel_index": null,
+                "height": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB560-10",
+                "name": "Excitation filter 560nm",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": null
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": 450,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Dichroic",
+                "filter_wheel_index": null,
+                "height": "25.2",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Edmund Optics",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "#69-898",
+                "name": "450 Dichroic Longpass Filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "35.6"
+            },
+            {
+                "additional_settings": {},
+                "center_wavelength": null,
+                "cut_off_wavelength": 500,
+                "cut_on_wavelength": null,
+                "description": null,
+                "device_type": "Filter",
+                "diameter": null,
+                "filter_type": "Dichroic",
+                "filter_wheel_index": null,
+                "height": "23.2",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Edmund Optics",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "#69-899",
+                "name": "500 Dichroic Longpass Filter",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "wavelength_unit": "nanometer",
+                "width": "35.6"
+            }
+        ],
+        "laser_assemblies": [],
+        "lenses": [
+            {
+                "additional_settings": {},
+                "device_type": "Lens",
+                "focal_length": "80",
+                "focal_length_unit": "millimeter",
+                "lens_size_unit": "inch",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "max_aperture": null,
+                "model": "AC254-080-A-ML",
+                "name": "Image focusing lens",
+                "notes": null,
+                "optimized_wavelength_range": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size": 1,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "name": "IR LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M470F3",
+                "name": "470nm LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 470,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M415F3",
+                "name": "415nm LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 415,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M565F3",
+                "name": "565nm LED",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 565,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "fib",
+                "name": "Fiber photometry"
+            }
+        ],
+        "modification_date": "2025-05-13",
+        "mouse_platform": {
+            "additional_settings": {},
+            "date_surface_replaced": null,
+            "device_type": "Tube",
+            "diameter": "3.0",
+            "diameter_unit": "centimeter",
+            "manufacturer": {
+                "abbreviation": null,
+                "name": "Custom",
+                "registry": null,
+                "registry_identifier": null
+            },
+            "model": null,
+            "name": "mouse_tube_foraging",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "surface_material": null
+        },
+        "notes": null,
+        "objectives": [
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "air",
+                "magnification": "10",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Nikon",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "0280y9h11"
+                },
+                "model": "CFI Plan Apochromat Lambda D 10x",
+                "name": "Objective",
+                "notes": null,
+                "numerical_aperture": "0.45",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": "0"
+            }
+        ],
+        "origin": null,
+        "patch_cords": [
+            {
+                "additional_settings": {},
+                "core_diameter": "200",
+                "device_type": "Patch",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Doric",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "059n53q30"
+                },
+                "model": "BBP(4)_200/220/900-0.37_Custom_FCM-4xMF1.25",
+                "name": "Bundle Branching Fiber-optic Patch Cord",
+                "notes": null,
+                "numerical_aperture": "0.37",
+                "path_to_cad": null,
+                "photobleaching_date": null,
+                "port_index": null,
+                "serial_number": null
+            }
+        ],
+        "pockels_cells": [],
+        "polygonal_scanners": [],
+        "rig_axes": null,
+        "rig_id": "447_2D_20250513",
+        "schema_version": "1.0.1",
+        "stick_microscopes": [],
+        "stimulus_devices": [
+            {
+                "device_type": "Reward delivery",
+                "reward_spouts": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Lick Sensor",
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Lick Sensor Left",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Left lick spout",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Left",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "name": "Solenoid Left",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    },
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Lick Sensor",
+                            "manufacturer": {
+                                "abbreviation": "Janelia",
+                                "name": "Janelia Research Campus",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "name": "Lick Sensor Right",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": null,
+                        "model": null,
+                        "name": "Right lick spout",
+                        "notes": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Right",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "name": "Solenoid Right",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    }
+                ],
+                "stage_type": {
+                    "additional_settings": {},
+                    "device_type": "Motorized stage",
+                    "firmware": null,
+                    "manufacturer": {
+                        "abbreviation": "AIND",
+                        "name": "Allen Institute for Neural Dynamics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04szwah67"
+                    },
+                    "model": null,
+                    "name": "AIND lick spout stage",
+                    "notes": "https://allenneuraldynamics.github.io/Bonsai.AllenNeuralDynamics/articles/aind-manipulator.html",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "travel": "30",
+                    "travel_unit": "millimeter"
+                }
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Speaker",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Tymphany",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "XT25SC90-04",
+                "name": "Stimulus Speaker",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "serial_number": null
+            }
+        ]
+    },
+    "schema_version": "1.1.1",
+    "session": {
+        "active_mouse_platform": false,
+        "anaesthesia": null,
+        "animal_weight_post": "24.6",
+        "animal_weight_prior": null,
+        "calibrations": [],
+        "data_streams": [
+            {
+                "camera_names": [
+                    "Face Side Right",
+                    "Face Bottom"
+                ],
+                "daq_names": [
+                    ""
+                ],
+                "detectors": [
+                    {
+                        "exposure_time": "5109.801233",
+                        "exposure_time_unit": "microsecond",
+                        "name": "Green CMOS",
+                        "trigger_type": "External"
+                    },
+                    {
+                        "exposure_time": "5109.801233",
+                        "exposure_time_unit": "microsecond",
+                        "name": "Red CMOS",
+                        "trigger_type": "External"
+                    }
+                ],
+                "ephys_modules": [],
+                "fiber_connections": [
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_green",
+                            "intended_measurement": "calcium",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord A",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_green",
+                            "intended_measurement": "calcium",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord B",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_green",
+                            "intended_measurement": "calcium",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord C",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_isosbestic",
+                            "intended_measurement": null,
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "disconnected",
+                        "patch_cord_name": "Patch Cord D",
+                        "patch_cord_output_power": "0.0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "disconnected",
+                            "intended_measurement": null,
+                            "light_source_name": "None",
+                            "filter_names": [
+                                "None"
+                            ],
+                            "detector_name": "None",
+                            "excitation_wavelength": 300,
+                            "excitation_power": 0,
+                            "emission_wavelength": 300,
+                            "description": "Not connected to any implanted fiber",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    }
+                ],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Light emitting diode",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "IR LED"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "470nm LED"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "415nm LED"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "565nm LED"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": "None;Fib modality: fib mode: Axon This record has been updated to include intended measurements. Fiber connections are repeated for fibers with multiple channels. Disconnected fibers are marked with fiber_name 'disconnected'.",
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [
+                    {
+                        "name": "dynamic-foraging-task",
+                        "parameters": {},
+                        "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                        "version": "behavior branch:main   commit ID:acbae82323a0eb40165bce97e29c5b52efa337d1    version:1.6.42; metadata branch: main   commit ID:acbae82323a0eb40165bce97e29c5b52efa337d1   version:1.6.42"
+                    }
+                ],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-05-20T11:06:35.366619-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "behavior-videos",
+                        "name": "Behavior videos"
+                    },
+                    {
+                        "abbreviation": "fib",
+                        "name": "Fiber photometry"
+                    }
+                ],
+                "stream_start_time": "2025-05-20T09:37:00.269677-07:00"
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "experimenter_full_name": [
+            "Huy Nguyen"
+        ],
+        "headframe_registration": null,
+        "iacuc_protocol": "2109",
+        "maintenance": [],
+        "mouse_platform_name": "mouse_tube_foraging",
+        "notes": "",
+        "protocol_id": [
+            ""
+        ],
+        "reward_consumed_total": "714.0",
+        "reward_consumed_unit": "microliter",
+        "reward_delivery": null,
+        "rig_id": "447_2D_20250513",
+        "schema_version": "1.0.1",
+        "session_end_time": "2025-05-20T11:06:35.366619-07:00",
+        "session_start_time": "2025-05-20T09:37:00.269677-07:00",
+        "session_type": "Uncoupled Without Baiting",
+        "stimulus_epochs": [
+            {
+                "light_source_config": [],
+                "notes": "The duration of go cue is 100 ms. The frequency is 7500 Hz. Amplitude is 76dB. The total reward consumed in the session is 714.0 microliters. The total reward including consumed in the session and supplementary water is 1.047 milliliters.",
+                "output_parameters": {
+                    "meta": {
+                        "box": "447-2-D",
+                        "session_run_time_in_min": 85
+                    },
+                    "performance": {
+                        "foraging_efficiency": 0.7454583420338274,
+                        "foraging_efficiency_with_actual_random_seed": 0.7212121212121212
+                    },
+                    "task_parameters": {
+                        "BlockBeta": "20",
+                        "BlockMax": "35",
+                        "BlockMin": "20",
+                        "DelayBeta": "0.0",
+                        "DelayMax": "1.0",
+                        "DelayMin": "1.0",
+                        "ITIBeta": "3.0",
+                        "ITIMax": "15.0",
+                        "ITIMin": "2.0",
+                        "LeftValue_volume": "2.00",
+                        "RightValue_volume": "2.00",
+                        "Task": "Uncoupled Without Baiting",
+                        "reward_probability": "0.1, 0.5, 0.9",
+                        "curriculum_in_use": "Uncoupled Without Baiting (v2.3.1rwdDelay159@1.0)",
+                        "stage_in_use": "GRADUATED"
+                    },
+                    "water": {
+                        "water_after_session": 0.305,
+                        "water_day_total": 1.047,
+                        "water_in_session_foraging": 0.714,
+                        "water_in_session_manual": 0.028000000000000025,
+                        "water_in_session_total": 0.742
+                    }
+                },
+                "reward_consumed_during_epoch": "714.0",
+                "reward_consumed_unit": "microliter",
+                "script": null,
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "dynamic-foraging-task",
+                        "parameters": {},
+                        "url": "https://github.com/AllenNeuralDynamics/dynamic-foraging-task.git",
+                        "version": "behavior branch:main   commit ID:acbae82323a0eb40165bce97e29c5b52efa337d1    version:1.6.42; metadata branch: main   commit ID:acbae82323a0eb40165bce97e29c5b52efa337d1   version:1.6.42"
+                    }
+                ],
+                "speaker_config": {
+                    "name": "Stimulus Speaker",
+                    "volume": "76",
+                    "volume_unit": "decibels"
+                },
+                "stimulus_device_names": [
+                    "Stimulus Speaker"
+                ],
+                "stimulus_end_time": "2025-05-20T11:02:04.974483-07:00",
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_name": "The behavior auditory go cue",
+                "stimulus_parameters": [
+                    {
+                        "amplitude_modulation_frequency": 7500,
+                        "bandpass_filter_type": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_low_frequency": null,
+                        "bandpass_order": null,
+                        "frequency_unit": "hertz",
+                        "notes": null,
+                        "sample_frequency": "96000",
+                        "stimulus_name": "auditory go cue",
+                        "stimulus_type": "Auditory Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-05-20T09:37:00.293678-07:00",
+                "trials_finished": 574,
+                "trials_rewarded": 357,
+                "trials_total": 597
+            }
+        ],
+        "subject_id": "779531",
+        "weight_unit": "gram"
+    },
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Dbh-Cre-KI(ND)",
+            "maternal_genotype": "Dbh-Cre-KI/wt",
+            "maternal_id": "761437",
+            "paternal_genotype": "wt/wt",
+            "paternal_id": "759896"
+        },
+        "date_of_birth": "2024-11-22",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "Dbh-Cre-KI/wt",
+        "housing": {
+            "cage_id": "8291060",
+            "cohoused_subjects": [],
+            "home_cage_enrichment": [],
+            "light_cycle": null,
+            "room_id": "221"
+        },
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.2",
+        "sex": "Male",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "779531",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where `Version` objects were being passed into invalid Procedures metadata, which was then being constructed with model_construct causing the Version object to fail serialization. The code now uses the str cast of the version which will always serialize correctly.