### PR TITLE
fix: prevent instrument_id from being added as a missing Device

### DIFF
--- a/src/aind_metadata_upgrader/instrument/v1v2.py
+++ b/src/aind_metadata_upgrader/instrument/v1v2.py
@@ -208,7 +208,7 @@ class InstrumentUpgraderV1V2(CoreUpgrader):
 
         return connections
 
-    def _validate_and_fix_connections(self, components: list, connections: list) -> list:
+    def _validate_and_fix_connections(self, components: list, connections: list, instrument_id: str = "") -> list:
         """Validate connections and add missing devices if needed"""
         # Flatten the list of device names from all connections
         connection_names = [name for conn in connections for name in [conn["source_device"], conn["target_device"]]]
@@ -224,6 +224,10 @@ class InstrumentUpgraderV1V2(CoreUpgrader):
                 missing_names.append(name)
 
         for name in set(missing_names):
+            # The instrument_id itself is a valid connection endpoint (representing the
+            # whole instrument), not a missing component — skip it.
+            if instrument_id and name == instrument_id:
+                continue
             # Create an empty Device with the name
             device = Device(
                 name=name,
@@ -282,7 +286,7 @@ class InstrumentUpgraderV1V2(CoreUpgrader):
         connections = self._create_component_connections(saved_connections)
 
         # Validate and fix connections
-        components = self._validate_and_fix_connections(components, connections)
+        components = self._validate_and_fix_connections(components, connections, data.get("instrument_id", ""))
 
         return (components, connections)
 

--- a/src/aind_metadata_upgrader/utils/v1v2_metadata_utils.py
+++ b/src/aind_metadata_upgrader/utils/v1v2_metadata_utils.py
@@ -52,11 +52,20 @@ def repair_missing_active_devices(data: dict) -> dict:
         except Exception as e:
             print(f"Failed to validate procedures to capture procedure device names: {e}")
 
+    # Exclude the instrument_id itself — ImagingConfig.device_name legitimately points to
+    # the whole instrument, so it should never be treated as a missing component device.
+    instrument_id = (
+        data.get("acquisition", {}).get("instrument_id")
+        or data.get("instrument", {}).get("instrument_id")
+    )
+
     # Check if all active devices are in the available devices
     if not all(device in device_names for device in active_devices):
         missing_devices = set(active_devices) - set(device_names)
         # Create missing devices with default names
         for device in missing_devices:
+            if instrument_id and device == instrument_id:
+                continue
             new_device = Device(
                 name=device,
                 notes=(
@@ -113,8 +122,17 @@ def repair_connection_devices(data: dict) -> dict:
             procedures = Procedures.model_construct(**data["procedures"])
         device_names.extend(procedures.get_device_names())
 
+    # Exclude the instrument_id itself — it's a valid connection endpoint representing
+    # the whole instrument, not a missing component device.
+    instrument_id = (
+        data.get("acquisition", {}).get("instrument_id")
+        or data.get("instrument", {}).get("instrument_id")
+    )
+
     # Check if all connection devices are in the available devices
     for device_name in connection_devices:
+        if instrument_id and device_name == instrument_id:
+            continue
         if device_name not in device_names:
             # Create a new device with a note indicating it was missing
             new_device = Device(


### PR DESCRIPTION
PR fixes two code paths that check for missing devices in the connections or in the configs and prevents both of these from creating unnecessary copies of the `instrument_id` field as missing Devices. This is an issue because we allow ImagingConfig, SamplerChamberConfig, and Connection objects to all reference the instrument_id directly.