### PR TITLE
fix: improve craniotomy type inference

### DIFF
--- a/src/aind_metadata_upgrader/procedures/v1v2.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2.py
@@ -408,19 +408,7 @@ class ProceduresUpgraderV1V2(CoreUpgrader):
                     break
 
         for procedure in procedures:
-            try:
-                upgraded = self._upgrade_procedure(procedure)
-            except Exception as e:
-                logging.warning(
-                    f"Failed to upgrade procedure {procedure.get('procedure_type')!r}, "
-                    f"falling back to GenericSurgeryProcedure: {e}"
-                )
-                upgraded = GenericSurgeryProcedure(
-                    description=(
-                        f"(v1v2 upgrader) Could not upgrade procedure "
-                        f"{procedure.get('procedure_type')!r}: {e}"
-                    ),
-                ).model_dump()
+            upgraded = self._upgrade_procedure(procedure)
             if isinstance(upgraded, tuple):
                 upgraded, measured_coordinates = upgraded
                 if measured_coordinates:

--- a/src/aind_metadata_upgrader/procedures/v1v2.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2.py
@@ -345,12 +345,11 @@ class ProceduresUpgraderV1V2(CoreUpgrader):
 
         procedure_type = data.get("procedure_type")
 
-        # For Dynamic Routing data, a null craniotomy_type is a whole hemisphere craniotomy,
-        # but only when the same surgery also has a headframe with "WHC" in its type.
+        # A null craniotomy_type alongside a WHC headframe in the same surgery indicates
+        # a whole hemisphere craniotomy regardless of project.
         if (
             procedure_type == "Craniotomy"
             and not data.get("craniotomy_type")
-            and self.project_name == "Dynamic Routing"
             and self._surgery_has_whc_headframe
         ):
             data["craniotomy_type"] = "Whole hemisphere craniotomy"
@@ -409,7 +408,19 @@ class ProceduresUpgraderV1V2(CoreUpgrader):
                     break
 
         for procedure in procedures:
-            upgraded = self._upgrade_procedure(procedure)
+            try:
+                upgraded = self._upgrade_procedure(procedure)
+            except Exception as e:
+                logging.warning(
+                    f"Failed to upgrade procedure {procedure.get('procedure_type')!r}, "
+                    f"falling back to GenericSurgeryProcedure: {e}"
+                )
+                upgraded = GenericSurgeryProcedure(
+                    description=(
+                        f"(v1v2 upgrader) Could not upgrade procedure "
+                        f"{procedure.get('procedure_type')!r}: {e}"
+                    ),
+                ).model_dump()
             if isinstance(upgraded, tuple):
                 upgraded, measured_coordinates = upgraded
                 if measured_coordinates:

--- a/src/aind_metadata_upgrader/procedures/v1v2_procedures.py
+++ b/src/aind_metadata_upgrader/procedures/v1v2_procedures.py
@@ -266,10 +266,11 @@ def upgrade_craniotomy(data: dict) -> tuple[dict, list]:
             upgraded_data["craniotomy_type"] = CRANIO_TYPES[upgraded_data["craniotomy_type"]]
             upgraded_data["size_unit"] = SizeUnit.MM
         else:
-            raise ValueError(
-                f"Unsupported craniotomy_type: {upgraded_data['craniotomy_type']}. "
-                f"Expected one of {valid_enum_values}."
+            logging.warning(
+                f"Unsupported craniotomy_type: {upgraded_data['craniotomy_type']!r}. "
+                f"Defaulting to 'Other'."
             )
+            upgraded_data["craniotomy_type"] = CraniotomyType.OTHER.value
 
     # Must be called before retrieve_bl_distance strips the distance field
     visual_cortex_position = _compute_visual_cortex_position(data)

--- a/tests/records/v1/18e3a007-f998-4921-b12d-37157e39446b.json
+++ b/tests/records/v1/18e3a007-f998-4921-b12d-37157e39446b.json
@@ -1,0 +1,1659 @@
+{
+    "_id": "18e3a007-f998-4921-b12d-37157e39446b",
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "schema_version": "1.2.1",
+    "name": "behavior_754559_2024-12-17_17-40-13",
+    "created": "2026-05-13T23:39:32.370779Z",
+    "last_modified": "2026-05-13T23:39:39.342Z",
+    "location": "s3://aind-open-data/behavior_754559_2024-12-17_17-40-13",
+    "metadata_status": "Invalid",
+    "external_links": {
+        "Code Ocean": [
+            "d3978a37-b5db-49e9-9e93-950e8feb067c"
+        ]
+    },
+    "subject": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "schema_version": "1.0.3",
+        "subject_id": "754559",
+        "sex": "Male",
+        "date_of_birth": "2024-05-21",
+        "genotype": "wt/wt",
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "name": "National Center for Biotechnology Information",
+                "abbreviation": "NCBI"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Exp-ND-01-001-2414",
+            "maternal_id": null,
+            "maternal_genotype": null,
+            "paternal_id": null,
+            "paternal_genotype": null
+        },
+        "source": {
+            "name": "Allen Institute",
+            "abbreviation": "AI",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "rrid": null,
+        "restrictions": null,
+        "wellness_reports": [],
+        "housing": null,
+        "notes": null
+    },
+    "data_description": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "1.0.3",
+        "license": "CC-BY-4.0",
+        "platform": {
+            "name": "Behavior platform",
+            "abbreviation": "behavior"
+        },
+        "subject_id": "754559",
+        "creation_time": "2024-12-17T17:40:13-08:00",
+        "label": null,
+        "name": "behavior_754559_2024-12-17_17-40-13",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "funder": {
+                    "name": "Allen Institute",
+                    "abbreviation": "AI",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null,
+                "fundee": "Bruno Cruz, Cindy Poo, Tiffany Ona"
+            },
+            {
+                "funder": {
+                    "name": "Simons Foundation",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01cmst727"
+                },
+                "grant_number": "Simons863738",
+                "fundee": "Cindy Poo, Tiffany Ona"
+            }
+        ],
+        "data_level": "raw",
+        "group": null,
+        "investigators": [
+            {
+                "name": "Bruno Cruz",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Cindy Poo",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Tiffany Ona",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "project_name": "Cognitive flexibility in patch foraging",
+        "restrictions": null,
+        "modality": [
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            }
+        ],
+        "related_data": [],
+        "data_summary": null
+    },
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "schema_version": "1.2.1",
+        "subject_id": "754559",
+        "subject_procedures": [
+            {
+                "procedure_type": "Surgery",
+                "start_date": null,
+                "experimenter_full_name": "NSB",
+                "iacuc_protocol": "2109",
+                "animal_weight_prior": null,
+                "animal_weight_post": null,
+                "weight_unit": "gram",
+                "anaesthesia": {
+                    "type": "isoflurane",
+                    "duration": null,
+                    "duration_unit": "minute",
+                    "level": null
+                },
+                "workstation_id": null,
+                "procedures": [
+                    {
+                        "procedure_type": "Headframe",
+                        "headframe_type": "WHC (Full ring)",
+                        "headframe_part_number": null,
+                        "headframe_material": null,
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    }
+                ],
+                "notes": null,
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2"
+            },
+            {
+                "procedure_type": "Surgery",
+                "start_date": null,
+                "experimenter_full_name": "NSB",
+                "iacuc_protocol": "2109",
+                "animal_weight_prior": null,
+                "animal_weight_post": null,
+                "weight_unit": "gram",
+                "anaesthesia": {
+                    "type": "isoflurane",
+                    "duration": null,
+                    "duration_unit": "minute",
+                    "level": null
+                },
+                "workstation_id": null,
+                "procedures": [
+                    {
+                        "procedure_type": "Headframe",
+                        "headframe_type": "WHC (Full ring)",
+                        "headframe_part_number": null,
+                        "headframe_material": null,
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    },
+                    {
+                        "procedure_type": "Craniotomy",
+                        "craniotomy_type": null,
+                        "craniotomy_hemisphere": null,
+                        "bregma_to_lambda_distance": null,
+                        "bregma_to_lambda_unit": "millimeter",
+                        "implant_part_number": null,
+                        "dura_removed": null,
+                        "protective_material": null,
+                        "recovery_time": null,
+                        "recovery_time_unit": "minute"
+                    },
+                    {
+                        "procedure_type": "Headframe",
+                        "headframe_type": "WHC (Full ring)",
+                        "headframe_part_number": null,
+                        "headframe_material": null,
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    }
+                ],
+                "notes": null,
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2"
+            }
+        ],
+        "specimen_procedures": [],
+        "notes": null
+    },
+    "session": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "schema_version": "1.0.3",
+        "protocol_id": [],
+        "experimenter_full_name": [
+            "Katrina"
+        ],
+        "session_start_time": "2024-12-17T17:40:13.721403Z",
+        "session_end_time": "2024-12-17T18:41:34.542049Z",
+        "session_type": "AindVrForaging",
+        "iacuc_protocol": "2414",
+        "rig_id": "5A",
+        "calibrations": [],
+        "maintenance": [],
+        "subject_id": "754559",
+        "animal_weight_prior": null,
+        "animal_weight_post": "24.5",
+        "weight_unit": "gram",
+        "anaesthesia": null,
+        "data_streams": [
+            {
+                "stream_start_time": "2024-12-17T17:40:13.721403Z",
+                "stream_end_time": "2024-12-17T18:41:34.542049Z",
+                "daq_names": [
+                    "harp_behavior",
+                    "harp_olfactometer",
+                    "harp_lickometer",
+                    "harp_clock_generator",
+                    "harp_treadmill",
+                    "harp_sniff_detector",
+                    "manipulator"
+                ],
+                "camera_names": [
+                    "FaceCamera",
+                    "SideCamera"
+                ],
+                "light_sources": [],
+                "ephys_modules": [],
+                "stick_microscopes": [],
+                "manipulator_modules": [],
+                "detectors": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "stack_parameters": null,
+                "mri_scans": [],
+                "stream_modalities": [
+                    {
+                        "name": "Behavior",
+                        "abbreviation": "behavior"
+                    },
+                    {
+                        "name": "Behavior videos",
+                        "abbreviation": "behavior-videos"
+                    }
+                ],
+                "software": [],
+                "notes": null
+            }
+        ],
+        "stimulus_epochs": [
+            {
+                "stimulus_start_time": "2024-12-17T17:40:13.721403Z",
+                "stimulus_end_time": "2024-12-17T18:41:34.542049Z",
+                "stimulus_name": "AindVrForaging",
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "Bonsai",
+                        "version": "unknown",
+                        "url": "https://github.com/AllenNeuralDynamics/Aind.Behavior.VrForaging",
+                        "parameters": {}
+                    }
+                ],
+                "script": {
+                    "name": "vr-foraging",
+                    "version": "unknown",
+                    "url": "https://github.com/AllenNeuralDynamics/Aind.Behavior.VrForaging/blob/main/src/vr-foraging.bonsai",
+                    "parameters": {}
+                },
+                "stimulus_modalities": [
+                    "Olfactory",
+                    "Auditory",
+                    "Visual",
+                    "Virtual reality",
+                    "Wheel friction"
+                ],
+                "stimulus_parameters": [
+                    {
+                        "stimulus_type": "Auditory Stimulation",
+                        "stimulus_name": "Beep",
+                        "sample_frequency": "0",
+                        "amplitude_modulation_frequency": null,
+                        "frequency_unit": "hertz",
+                        "bandpass_low_frequency": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_order": null,
+                        "notes": null
+                    },
+                    {
+                        "stimulus_type": "Olfactory Stimulation",
+                        "stimulus_name": "Olfactory",
+                        "channels": [
+                            {
+                                "channel_index": 0,
+                                "odorant": "Amyl Acetate",
+                                "odorant_dilution": "1",
+                                "odorant_dilution_unit": "% v/v",
+                                "notes": null
+                            },
+                            {
+                                "channel_index": 1,
+                                "odorant": "Alpha-pinene",
+                                "odorant_dilution": "1",
+                                "odorant_dilution_unit": "% v/v",
+                                "notes": null
+                            },
+                            {
+                                "channel_index": 2,
+                                "odorant": "Methyl Butyrate",
+                                "odorant_dilution": "1",
+                                "odorant_dilution_unit": "% v/v",
+                                "notes": null
+                            }
+                        ],
+                        "notes": null
+                    },
+                    {
+                        "stimulus_type": "Visual Stimulation",
+                        "stimulus_name": "VrScreen",
+                        "stimulus_parameters": {},
+                        "stimulus_template_name": [],
+                        "notes": null
+                    }
+                ],
+                "stimulus_device_names": [
+                    "harp_olfactometer",
+                    "Speaker",
+                    "Screen Left",
+                    "Screen Center",
+                    "Screen Right"
+                ],
+                "speaker_config": {
+                    "name": "Speaker",
+                    "volume": "60",
+                    "volume_unit": "decibels"
+                },
+                "light_source_config": [],
+                "output_parameters": {},
+                "reward_consumed_during_epoch": "0.88",
+                "reward_consumed_unit": "microliter",
+                "trials_total": null,
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "notes": null
+            }
+        ],
+        "mouse_platform_name": "VR Wheel",
+        "active_mouse_platform": true,
+        "headframe_registration": null,
+        "reward_delivery": {
+            "reward_solution": "Water",
+            "reward_spouts": [
+                {
+                    "side": "Center",
+                    "starting_position": {
+                        "device_position_transformations": [
+                            {
+                                "type": "translation",
+                                "translation": [
+                                    "0",
+                                    "0",
+                                    "0"
+                                ]
+                            }
+                        ],
+                        "device_origin": "Manipulator home",
+                        "device_axes": [
+                            {
+                                "name": "X",
+                                "direction": "Left"
+                            },
+                            {
+                                "name": "Y",
+                                "direction": "Front"
+                            },
+                            {
+                                "name": "Z",
+                                "direction": "Top"
+                            }
+                        ],
+                        "notes": null
+                    },
+                    "variable_position": false
+                }
+            ],
+            "notes": null
+        },
+        "reward_consumed_total": "0.88",
+        "reward_consumed_unit": "milliliter",
+        "notes": null
+    },
+    "rig": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "schema_version": "1.0.3",
+        "rig_id": "426_5A_20250128",
+        "modification_date": "2025-01-28",
+        "mouse_platform": {
+            "device_type": "Wheel",
+            "name": "VR Wheel",
+            "serial_number": null,
+            "manufacturer": {
+                "name": "Allen Institute for Neural Dynamics",
+                "abbreviation": "AIND",
+                "registry": {
+                    "name": "Research Organization Registry",
+                    "abbreviation": "ROR"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "path_to_cad": "https://tinyurl.com/AI-RunningWheel",
+            "port_index": null,
+            "additional_settings": {},
+            "notes": null,
+            "surface_material": "Rubber",
+            "date_surface_replaced": null,
+            "radius": "7.5",
+            "width": "3.5",
+            "size_unit": "centimeter",
+            "encoder": {
+                "device_type": "Encoder",
+                "name": "Encoder",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": "AMT102-V",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null
+            },
+            "encoder_output": {
+                "channel_name": "Encoder",
+                "device_name": "harp_treadmill",
+                "channel_type": "Analog Output",
+                "port": null,
+                "channel_index": null,
+                "sample_rate": null,
+                "sample_rate_unit": "hertz",
+                "event_based_sampling": null
+            },
+            "pulse_per_revolution": 8192,
+            "magnetic_brake": {
+                "device_type": "Magnetic brake",
+                "name": "Magnetic brake",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": "B1-2FM",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null
+            },
+            "brake_output": {
+                "channel_name": "Magnetic brake",
+                "device_name": "harp_treadmill",
+                "channel_type": "Analog Output",
+                "port": null,
+                "channel_index": null,
+                "sample_rate": null,
+                "sample_rate_unit": "hertz",
+                "event_based_sampling": null
+            },
+            "torque_sensor": {
+                "device_type": "Torque sensor",
+                "name": "Torque sensor",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Transducer Techniques",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "RTS-10",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null
+            },
+            "torque_output": {
+                "channel_name": "Torque sensor",
+                "device_name": "harp_treadmill",
+                "channel_type": "Analog Output",
+                "port": null,
+                "channel_index": null,
+                "sample_rate": null,
+                "sample_rate_unit": "hertz",
+                "event_based_sampling": null
+            }
+        },
+        "stimulus_devices": [
+            {
+                "device_type": "Reward delivery",
+                "stage_type": {
+                    "device_type": "Motorized stage",
+                    "name": "Motorized stage",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Allen Institute for Neural Dynamics",
+                        "abbreviation": "AIND",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "04szwah67"
+                    },
+                    "model": "328-300-00",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": "Motorized stage for positioning",
+                    "travel": "30",
+                    "travel_unit": "millimeter",
+                    "firmware": null
+                },
+                "reward_spouts": [
+                    {
+                        "device_type": "Reward spout",
+                        "name": "Lick spout",
+                        "serial_number": null,
+                        "manufacturer": {
+                            "name": "Other",
+                            "abbreviation": null,
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "model": "89875K27",
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "additional_settings": {},
+                        "notes": "Lick spout for water delivery, the tube is ordered from McMaster, cut to size and shaped by AIND",
+                        "side": "Center",
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null,
+                        "solenoid_valve": {
+                            "device_type": "Solenoid",
+                            "name": "Solenoid",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "The Lee Company",
+                                "abbreviation": null,
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDB1233518H",
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor": {
+                            "device_type": "Harp device",
+                            "name": "harp_lickometer",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "Allen Institute for Neural Dynamics",
+                                "abbreviation": "AIND",
+                                "registry": {
+                                    "name": "Research Organization Registry",
+                                    "abbreviation": "ROR"
+                                },
+                                "registry_identifier": "04szwah67"
+                            },
+                            "model": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": "Lick sensor with low noise artifacts; https://github.com/AllenNeuralDynamics/harp.device.lickety-split"
+                        },
+                        "lick_sensor_type": "Capacitive"
+                    }
+                ]
+            },
+            {
+                "device_type": "Speaker",
+                "name": "Speaker",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Tymphany",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "XT25SC90-04",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "position": null
+            },
+            {
+                "device_type": "Olfactometer",
+                "name": "Olfactometer",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "SAKTIMUNA",
+                "channels": [
+                    {
+                        "channel_index": 0,
+                        "channel_type": "Odor",
+                        "flow_capacity": 100,
+                        "flow_unit": "mL/min"
+                    },
+                    {
+                        "channel_index": 1,
+                        "channel_type": "Odor",
+                        "flow_capacity": 100,
+                        "flow_unit": "mL/min"
+                    },
+                    {
+                        "channel_index": 2,
+                        "channel_type": "Odor",
+                        "flow_capacity": 100,
+                        "flow_unit": "mL/min"
+                    },
+                    {
+                        "channel_index": 3,
+                        "channel_type": "Carrier",
+                        "flow_capacity": 1000,
+                        "flow_unit": "mL/min"
+                    },
+                    {
+                        "channel_index": 4,
+                        "channel_type": "Carrier",
+                        "flow_capacity": 1000,
+                        "flow_unit": "mL/min"
+                    }
+                ],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "whoami": 1140,
+                    "name": "Olfactometer"
+                },
+                "core_version": null,
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Monitor",
+                "name": "Screen Left",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "LG",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "02b948n83"
+                },
+                "model": "LG LP097QX1",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "refresh_rate": 60,
+                "width": 2048,
+                "height": 1536,
+                "size_unit": "pixel",
+                "viewing_distance": "15.5",
+                "viewing_distance_unit": "centimeter",
+                "position": null,
+                "contrast": null,
+                "brightness": null
+            },
+            {
+                "device_type": "Monitor",
+                "name": "Screen Center",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "LG",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "02b948n83"
+                },
+                "model": "LG LP097QX1",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "refresh_rate": 60,
+                "width": 2048,
+                "height": 1536,
+                "size_unit": "pixel",
+                "viewing_distance": "17.5",
+                "viewing_distance_unit": "centimeter",
+                "position": null,
+                "contrast": null,
+                "brightness": null
+            },
+            {
+                "device_type": "Monitor",
+                "name": "Screen Right",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "LG",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "02b948n83"
+                },
+                "model": "LG LP097QX1",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "refresh_rate": 60,
+                "width": 2048,
+                "height": 1536,
+                "size_unit": "pixel",
+                "viewing_distance": "17.5",
+                "viewing_distance_unit": "centimeter",
+                "position": null,
+                "contrast": null,
+                "brightness": null
+            }
+        ],
+        "cameras": [
+            {
+                "name": "FaceCamera",
+                "camera_target": "Face side right",
+                "camera": {
+                    "device_type": "Detector",
+                    "name": "FaceCamera",
+                    "serial_number": "23113701",
+                    "manufacturer": {
+                        "name": "Teledyne FLIR",
+                        "abbreviation": "FLIR",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "USB",
+                    "cooling": "Air",
+                    "computer_name": "SAKTIMUNA",
+                    "frame_rate": "100",
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 720,
+                    "sensor_height": 540,
+                    "size_unit": "pixel",
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "bit_depth": null,
+                    "bin_mode": "None",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": "12.0",
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": null,
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "device_type": "Lens",
+                    "name": "Behavior Video Lens Face View",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Tamron",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "M112FM16",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "size": null,
+                    "lens_size_unit": "inch",
+                    "optimized_wavelength_range": null,
+                    "wavelength_unit": "nanometer",
+                    "max_aperture": null
+                },
+                "filter": {
+                    "device_type": "Filter",
+                    "name": "LP filter",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Thorlabs",
+                        "abbreviation": null,
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "04gsnvb07"
+                    },
+                    "model": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "filter_type": "Long pass",
+                    "diameter": null,
+                    "width": null,
+                    "height": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "filter_wheel_index": null,
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": null,
+                    "center_wavelength": null,
+                    "wavelength_unit": "nanometer",
+                    "description": "810 nm longpass filter"
+                },
+                "position": null
+            },
+            {
+                "name": "SideCamera",
+                "camera_target": "Side",
+                "camera": {
+                    "device_type": "Detector",
+                    "name": "SideCamera",
+                    "serial_number": "23113701",
+                    "manufacturer": {
+                        "name": "Teledyne FLIR",
+                        "abbreviation": "FLIR",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "USB",
+                    "cooling": "Air",
+                    "computer_name": "SAKTIMUNA",
+                    "frame_rate": "100",
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 720,
+                    "sensor_height": 540,
+                    "size_unit": "pixel",
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "bit_depth": null,
+                    "bin_mode": "None",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": "12.0",
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": null,
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "device_type": "Lens",
+                    "name": "Behavior Video Lens Side View",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Other",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "LM5JCM",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": "Manufacturer is KOWA",
+                    "focal_length": "5",
+                    "focal_length_unit": "millimeter",
+                    "size": null,
+                    "lens_size_unit": "inch",
+                    "optimized_wavelength_range": null,
+                    "wavelength_unit": "nanometer",
+                    "max_aperture": null
+                },
+                "filter": null,
+                "position": null
+            },
+            {
+                "name": "USB_top_view",
+                "camera_target": "Body",
+                "camera": {
+                    "device_type": "Detector",
+                    "name": "Bottom face Camera",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Ailipu Technology Co",
+                        "abbreviation": "Ailipu",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "ELP-USBFHD05MT-KL170IR",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": "The targe is top of the body",
+                    "detector_type": "Camera",
+                    "data_interface": "USB",
+                    "cooling": "Air",
+                    "computer_name": "SAKTIMUNA",
+                    "frame_rate": "30",
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Color",
+                    "sensor_width": 640,
+                    "sensor_height": 480,
+                    "size_unit": "pixel",
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "bit_depth": null,
+                    "bin_mode": "Additive",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": {
+                        "name": "Bonsai",
+                        "version": "2.5",
+                        "url": null,
+                        "parameters": {}
+                    },
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "device_type": "Lens",
+                    "name": "Xenocam 2",
+                    "serial_number": "unknown",
+                    "manufacturer": {
+                        "name": "Other",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "XC0922LENS",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": "Focal Length 9-22mm 1/3\" IR F1.4",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "size": null,
+                    "lens_size_unit": "inch",
+                    "optimized_wavelength_range": null,
+                    "wavelength_unit": "nanometer",
+                    "max_aperture": "f/1.4"
+                },
+                "filter": null,
+                "position": null
+            },
+            {
+                "name": "FrontCamera",
+                "camera_target": "Face side right",
+                "camera": {
+                    "device_type": "Detector",
+                    "name": "FrontCamera",
+                    "serial_number": "23113706",
+                    "manufacturer": {
+                        "name": "Teledyne FLIR",
+                        "abbreviation": "FLIR",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "USB",
+                    "cooling": "Air",
+                    "computer_name": "SAKTIMUNA",
+                    "frame_rate": "100",
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 720,
+                    "sensor_height": 540,
+                    "size_unit": "pixel",
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "bit_depth": null,
+                    "bin_mode": "None",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": "18.0",
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": null,
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "device_type": "Lens",
+                    "name": "Behavior Video Lens Front View",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Other",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "LM25HC",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": "Manufacturer is KOWA",
+                    "focal_length": "25",
+                    "focal_length_unit": "millimeter",
+                    "size": null,
+                    "lens_size_unit": "inch",
+                    "optimized_wavelength_range": null,
+                    "wavelength_unit": "nanometer",
+                    "max_aperture": null
+                },
+                "filter": null,
+                "position": null
+            }
+        ],
+        "enclosure": {
+            "device_type": "Enclosure",
+            "name": "Behavior enclosure",
+            "serial_number": null,
+            "manufacturer": {
+                "name": "Allen Institute for Neural Dynamics",
+                "abbreviation": "AIND",
+                "registry": {
+                    "name": "Research Organization Registry",
+                    "abbreviation": "ROR"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "additional_settings": {},
+            "notes": null,
+            "size": {
+                "width": 568,
+                "length": 540,
+                "height": 506,
+                "unit": "millimeter"
+            },
+            "internal_material": "High density foam",
+            "external_material": "Wood and aluminium frame",
+            "grounded": true,
+            "laser_interlock": false,
+            "air_filtration": false
+        },
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "stick_microscopes": [],
+        "laser_assemblies": [],
+        "patch_cords": [],
+        "light_sources": [
+            {
+                "device_type": "Light emitting diode",
+                "name": "IR LED - Face",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            },
+            {
+                "device_type": "Light emitting diode",
+                "name": "IR LED - Side",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            }
+        ],
+        "detectors": [],
+        "objectives": [],
+        "filters": [
+            {
+                "device_type": "Filter",
+                "name": "Hot Mirror Filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Other",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "HM-VS-1150",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Dichroic",
+                "diameter": null,
+                "width": "8",
+                "height": "6",
+                "size_unit": "inch",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": 750,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            }
+        ],
+        "lenses": [
+            {
+                "device_type": "Lens",
+                "name": "IR LED - Face lens",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "LA1255-B",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "focal_length": "50",
+                "focal_length_unit": "millimeter",
+                "size": null,
+                "lens_size_unit": "inch",
+                "optimized_wavelength_range": null,
+                "wavelength_unit": "nanometer",
+                "max_aperture": null
+            },
+            {
+                "device_type": "Lens",
+                "name": "IR LED - Side lens",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "LA1805-B",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "focal_length": "30",
+                "focal_length_unit": "millimeter",
+                "size": null,
+                "lens_size_unit": "inch",
+                "optimized_wavelength_range": null,
+                "wavelength_unit": "nanometer",
+                "max_aperture": null
+            }
+        ],
+        "digital_micromirror_devices": [],
+        "polygonal_scanners": [],
+        "pockels_cells": [],
+        "additional_devices": [],
+        "daqs": [
+            {
+                "device_type": "Harp device",
+                "name": "harp_behavior",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Open Ephys Production Site",
+                    "abbreviation": "OEPS",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "SAKTIMUNA",
+                "channels": [
+                    {
+                        "channel_name": "DO0",
+                        "device_name": "FaceCamera",
+                        "channel_type": "Digital Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    },
+                    {
+                        "channel_name": "DO0",
+                        "device_name": "SideCamera",
+                        "channel_type": "Digital Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    },
+                    {
+                        "channel_name": "DO0",
+                        "device_name": "FrontCamera",
+                        "channel_type": "Digital Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    },
+                    {
+                        "channel_name": "DO1",
+                        "device_name": "Speaker",
+                        "channel_type": "Digital Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    },
+                    {
+                        "channel_name": "DO1",
+                        "device_name": "Solenoid",
+                        "channel_type": "Digital Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    }
+                ],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "whoami": 1216,
+                    "name": "Behavior"
+                },
+                "core_version": null,
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp_clock_generator",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Open Ephys Production Site",
+                    "abbreviation": "OEPS",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "SAKTIMUNA",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "whoami": 1152,
+                    "name": "Clock Synchronizer"
+                },
+                "core_version": null,
+                "tag_version": null,
+                "is_clock_generator": true
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp_clock_repeaters",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Open Ephys Production Site",
+                    "abbreviation": "OEPS",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "SAKTIMUNA",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "whoami": 1152,
+                    "name": "Clock Synchronizer"
+                },
+                "core_version": null,
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp_treadmill",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Allen Institute for Neural Dynamics",
+                    "abbreviation": "AIND",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04szwah67"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": "https://github.com/AllenNeuralDynamics/harp.device.treadmill-driver",
+                "data_interface": "USB",
+                "computer_name": "SAKTIMUNA",
+                "channels": [
+                    {
+                        "channel_name": "Torque sensor",
+                        "device_name": "harp_treadmill",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    },
+                    {
+                        "channel_name": "Encoder",
+                        "device_name": "harp_treadmill",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    },
+                    {
+                        "channel_name": "Magnetic brake",
+                        "device_name": "harp_treadmill",
+                        "channel_type": "Analog Output",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    }
+                ],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "whoami": 1402,
+                    "name": "Treadmill"
+                },
+                "core_version": null,
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp_lickometer",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Allen Institute for Neural Dynamics",
+                    "abbreviation": "AIND",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04szwah67"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": "Lick sensor with low noise artifacts; https://github.com/AllenNeuralDynamics/harp.device.lickety-split",
+                "data_interface": "USB",
+                "computer_name": "SAKTIMUNA",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "whoami": 1400,
+                    "name": "Lickety Split"
+                },
+                "core_version": null,
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "Stepper driver",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Allen Institute for Neural Dynamics",
+                    "abbreviation": "AIND",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04szwah67"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": "Stepper driver for positioning the lick spout and the odor tubes; https://allenneuraldynamics.github.io/Bonsai.AllenNeuralDynamics/articles/aind-manipulator.html",
+                "data_interface": "USB",
+                "computer_name": "SAKTIMUNA",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "whoami": 1130,
+                    "name": "Stepper Driver"
+                },
+                "core_version": null,
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp_olfactometer",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "SAKTIMUNA",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "whoami": 1140,
+                    "name": "Olfactometer"
+                },
+                "core_version": null,
+                "tag_version": null,
+                "is_clock_generator": false
+            }
+        ],
+        "calibrations": [
+            {
+                "calibration_date": "2024-10-24T00:00:00-07:00",
+                "device_name": "WaterValve",
+                "description": "Water calibration for Lick spout. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "input": {
+                    "valve open time (s):": [
+                        0.03,
+                        0.04,
+                        0.05,
+                        0.08,
+                        0.1,
+                        0.2,
+                        0.3
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        0.36,
+                        0.42,
+                        0.5,
+                        0.79,
+                        1.02,
+                        2.22,
+                        3.29
+                    ]
+                },
+                "notes": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "origin": null,
+        "rig_axes": null,
+        "modalities": [
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            }
+        ],
+        "notes": null
+    },
+    "processing": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "schema_version": "1.1.3",
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "name": "Other",
+                    "software_version": "",
+                    "start_date_time": "2026-05-13T23:37:01Z",
+                    "end_date_time": "2026-05-13T23:37:01Z",
+                    "input_location": "/allen/aind/scratch/vr-foraging/data/754559/754559_20241217T094013/behavior",
+                    "output_location": "",
+                    "code_url": "",
+                    "code_version": null,
+                    "parameters": {
+                        "input_source": "/allen/aind/scratch/vr-foraging/data/754559/754559_20241217T094013/behavior"
+                    },
+                    "outputs": {},
+                    "notes": "Data was copied",
+                    "resources": null
+                }
+            ],
+            "processor_full_name": "AIND Scientific Computing",
+            "pipeline_version": null,
+            "pipeline_url": null,
+            "note": null
+        },
+        "analyses": [],
+        "notes": null
+    },
+    "acquisition": null,
+    "instrument": null,
+    "quality_control": null
+}

--- a/tests/test_procedures_v1v2_procedures.py
+++ b/tests/test_procedures_v1v2_procedures.py
@@ -648,37 +648,77 @@ class TestDynamicRoutingCraniotomy(unittest.TestCase):
         self.assertIsNotNone(craniotomy)
         self.assertEqual(craniotomy["craniotomy_type"], "Whole hemisphere craniotomy")
 
-    def test_null_craniotomy_without_whc_headframe_raises(self):
-        """Null craniotomy_type with no WHC headframe should raise, even in Dynamic Routing."""
+    def test_null_craniotomy_without_whc_headframe_defaults_to_other(self):
+        """Null craniotomy_type with no WHC headframe defaults to 'Other'."""
         upgrader = ProceduresUpgraderV1V2()
         non_whc_headframe = {**self._WHC_HEADFRAME, "headframe_type": "Standard"}
         data = self._make_data([dict(self._CRANIOTOMY), non_whc_headframe])
         metadata = {"data_description": {"project_name": "Dynamic Routing"}}
-        with self.assertRaises(ValueError):
-            upgrader.upgrade(data, schema_version="2.0.0", metadata=metadata)
+        upgraded = upgrader.upgrade(data, schema_version="2.0.0", metadata=metadata)
+        craniotomy = next(
+            (
+                p
+                for sp in upgraded["subject_procedures"]
+                for p in sp["procedures"]
+                if p.get("object_type") == "Craniotomy"
+            ),
+            None,
+        )
+        self.assertIsNotNone(craniotomy)
+        self.assertEqual(craniotomy["craniotomy_type"], "Other")
 
-    def test_null_craniotomy_no_headframe_raises(self):
-        """Null craniotomy_type with no headframe at all should raise."""
+    def test_null_craniotomy_no_headframe_defaults_to_other(self):
+        """Null craniotomy_type with no headframe at all defaults to 'Other'."""
         upgrader = ProceduresUpgraderV1V2()
         data = self._make_data([dict(self._CRANIOTOMY)])
         metadata = {"data_description": {"project_name": "Dynamic Routing"}}
-        with self.assertRaises(ValueError):
-            upgrader.upgrade(data, schema_version="2.0.0", metadata=metadata)
+        upgraded = upgrader.upgrade(data, schema_version="2.0.0", metadata=metadata)
+        craniotomy = next(
+            (
+                p
+                for sp in upgraded["subject_procedures"]
+                for p in sp["procedures"]
+                if p.get("object_type") == "Craniotomy"
+            ),
+            None,
+        )
+        self.assertIsNotNone(craniotomy)
+        self.assertEqual(craniotomy["craniotomy_type"], "Other")
 
-    def test_null_craniotomy_type_non_dynamic_routing_raises(self):
-        """Null craniotomy_type in a non-Dynamic Routing record should raise even with WHC headframe."""
+    def test_null_craniotomy_type_non_dynamic_routing_whc_becomes_whole_hemisphere(self):
+        """Null craniotomy_type with WHC headframe becomes whole hemisphere regardless of project."""
         upgrader = ProceduresUpgraderV1V2()
         data = self._make_data([dict(self._CRANIOTOMY), dict(self._WHC_HEADFRAME)])
         metadata = {"data_description": {"project_name": "Some Other Project"}}
-        with self.assertRaises(ValueError):
-            upgrader.upgrade(data, schema_version="2.0.0", metadata=metadata)
+        upgraded = upgrader.upgrade(data, schema_version="2.0.0", metadata=metadata)
+        craniotomy = next(
+            (
+                p
+                for sp in upgraded["subject_procedures"]
+                for p in sp["procedures"]
+                if p.get("object_type") == "Craniotomy"
+            ),
+            None,
+        )
+        self.assertIsNotNone(craniotomy)
+        self.assertEqual(craniotomy["craniotomy_type"], "Whole hemisphere craniotomy")
 
-    def test_null_craniotomy_type_no_metadata_raises(self):
-        """Null craniotomy_type with no metadata should raise."""
+    def test_null_craniotomy_type_no_metadata_whc_becomes_whole_hemisphere(self):
+        """Null craniotomy_type with WHC headframe becomes whole hemisphere even with no metadata."""
         upgrader = ProceduresUpgraderV1V2()
         data = self._make_data([dict(self._CRANIOTOMY), dict(self._WHC_HEADFRAME)])
-        with self.assertRaises(ValueError):
-            upgrader.upgrade(data, schema_version="2.0.0", metadata=None)
+        upgraded = upgrader.upgrade(data, schema_version="2.0.0", metadata=None)
+        craniotomy = next(
+            (
+                p
+                for sp in upgraded["subject_procedures"]
+                for p in sp["procedures"]
+                if p.get("object_type") == "Craniotomy"
+            ),
+            None,
+        )
+        self.assertIsNotNone(craniotomy)
+        self.assertEqual(craniotomy["craniotomy_type"], "Whole hemisphere craniotomy")
 
 
 class TestVisualCortexCraniotomy(unittest.TestCase):


### PR DESCRIPTION
This change allows any craniotomy performed alongside a WHC headframe to show up as a proper whole-hemisphere craniotomy even if it was uploaded with no type. Also adds a fallback so that totally unknown craniotomies still upgrade.