### PR TITLE
fix: handle a regression

### DIFF
--- a/src/aind_metadata_upgrader/data_description/v1v2.py
+++ b/src/aind_metadata_upgrader/data_description/v1v2.py
@@ -24,6 +24,14 @@ client = MetadataDbClient(
 class DataDescriptionV1V2(CoreUpgrader):
     """Upgrade data description from v1.4 to v2.0"""
 
+    def _coerce_person(self, value) -> Person:
+        """Coerce a value (string or V2-style Person dict) into a Person"""
+        if isinstance(value, Person):
+            return value
+        if isinstance(value, dict):
+            return Person(name=value["name"])
+        return Person(name=value)
+
     def _process_comma_separated_funders(self, funder: str, fundee, grant_number) -> list:
         """Process comma-separated funders into separate funding sources"""
         result = []
@@ -37,7 +45,7 @@ class DataDescriptionV1V2(CoreUpgrader):
             result.append(
                 Funding(
                     funder=Organization.from_name(funder_name.strip()),
-                    fundee=[Person(name=f) for f in fundee_list],
+                    fundee=[self._coerce_person(f) for f in fundee_list],
                     grant_number=grant_number,
                 ).model_dump()
             )
@@ -98,7 +106,7 @@ class DataDescriptionV1V2(CoreUpgrader):
                     else:
                         fundee_list = [Person(name="unknown")]
                 elif isinstance(fundee, list):
-                    fundee_list = [Person(name=f) for f in fundee]
+                    fundee_list = [self._coerce_person(f) for f in fundee]
                 else:
                     fundee_list = [Person(name="unknown")]
 

--- a/tests/records/v1/57f17293-e21a-4c8e-9ef8-4a7a38fe047c.json
+++ b/tests/records/v1/57f17293-e21a-4c8e-9ef8-4a7a38fe047c.json
@@ -1,0 +1,1524 @@
+{
+    "_id": "57f17293-e21a-4c8e-9ef8-4a7a38fe047c",
+    "acquisition": null,
+    "created": "2025-01-06T04:47:33.198369",
+    "data_description": {
+        "creation_time": "2024-07-26T16:14:22",
+        "data_level": "raw",
+        "data_summary": null,
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "funding_source": [
+            {
+                "object_type": "Funding",
+                "funder": {
+                    "name": "Allen Institute",
+                    "abbreviation": "AI",
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null,
+                "fundee": [
+                    {
+                        "object_type": "Person",
+                        "name": "Bruno Cruz",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": null
+                    },
+                    {
+                        "object_type": "Person",
+                        "name": "Cindy Poo",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": null
+                    },
+                    {
+                        "object_type": "Person",
+                        "name": "Tiffany Ona",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": null
+                    }
+                ]
+            },
+            {
+                "object_type": "Funding",
+                "funder": {
+                    "name": "Simons Foundation",
+                    "abbreviation": null,
+                    "registry": "Research Organization Registry (ROR)",
+                    "registry_identifier": "01cmst727"
+                },
+                "grant_number": "Simons863738",
+                "fundee": [
+                    {
+                        "object_type": "Person",
+                        "name": "Cindy Poo",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": null
+                    },
+                    {
+                        "object_type": "Person",
+                        "name": "Tiffany Ona",
+                        "registry": "Open Researcher and Contributor ID (ORCID)",
+                        "registry_identifier": null
+                    }
+                ]
+            }
+        ],
+        "group": null,
+        "institution": {
+            "abbreviation": "AIND",
+            "name": "Allen Institute for Neural Dynamics",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "investigators": [
+            {
+                "object_type": "Person",
+                "name": "Bruno Cruz",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": null
+            },
+            {
+                "object_type": "Person",
+                "name": "Cindy Poo",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": null
+            },
+            {
+                "object_type": "Person",
+                "name": "Tiffany Ona",
+                "registry": "Open Researcher and Contributor ID (ORCID)",
+                "registry_identifier": null
+            }
+        ],
+        "label": null,
+        "license": "CC-BY-4.0",
+        "modality": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            }
+        ],
+        "name": "behavior_745300_2024-07-26_16-14-22",
+        "platform": {
+            "abbreviation": "behavior",
+            "name": "Behavior platform"
+        },
+        "project_name": "Cognitive flexibility in patch foraging",
+        "related_data": [],
+        "restrictions": null,
+        "schema_version": "1.0.3",
+        "subject_id": "745300"
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "81cfe50d-6fa1-40df-b331-eef2b7283ab5"
+        ]
+    },
+    "instrument": null,
+    "last_modified": "2026-07-07T21:55:01.980Z",
+    "location": "s3://aind-private-data-prod-o5171v/behavior_745300_2024-07-26_16-14-22",
+    "metadata_status": "Missing",
+    "name": "behavior_745300_2024-07-26_16-14-22",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.1.3",
+        "specimen_procedures": [],
+        "subject_id": "745300",
+        "subject_procedures": [
+            {
+                "anaesthesia": {
+                    "duration": "75.00",
+                    "duration_unit": "minute",
+                    "level": "1.75",
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": "26.5",
+                "animal_weight_prior": "24.6",
+                "experimenter_full_name": "NSB-6421",
+                "iacuc_protocol": "2109",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "headframe_material": null,
+                        "headframe_part_number": null,
+                        "headframe_type": "AI Straight bar",
+                        "procedure_type": "Headframe",
+                        "protocol_id": null,
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    }
+                ],
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2",
+                "start_date": "2024-07-03",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 6"
+            }
+        ]
+    },
+    "processing": {
+        "analyses": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "notes": null,
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "code_url": "oras://ghcr.io/allenneuraldynamics/aind-behavior-video-transformation:0.1.6",
+                    "code_version": null,
+                    "end_date_time": "2025-01-06T04:46:21.268557Z",
+                    "input_location": "/allen/aind/scratch/vr-foraging/data/745300/745300_20240726T161422/behavior-videos",
+                    "name": "Compression",
+                    "notes": null,
+                    "output_location": "/allen/aind/stage/svc_aind_airflow/prod/behavior_745300_job_1736137908_9fb94/behavior-videos",
+                    "outputs": {},
+                    "parameters": {},
+                    "resources": null,
+                    "software_version": "0.1.6",
+                    "start_date_time": "2025-01-06T04:44:20.036939Z"
+                }
+            ],
+            "note": null,
+            "pipeline_url": null,
+            "pipeline_version": null,
+            "processor_full_name": "AIND Scientific Computing"
+        },
+        "schema_version": "1.1.3"
+    },
+    "quality_control": null,
+    "rig": {
+        "additional_devices": [],
+        "calibrations": [
+            {
+                "calibration_date": "2024-05-24T00:00:00-07:00",
+                "description": "Water calibration for Lick spout. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "device_name": "WaterValve",
+                "input": {
+                    "valve open time (s):": [
+                        0.03,
+                        0.04,
+                        0.05,
+                        0.08,
+                        0.1,
+                        0.2
+                    ]
+                },
+                "notes": null,
+                "output": {
+                    "water volume (ul):": [
+                        0.34,
+                        0.44,
+                        0.49,
+                        0.73,
+                        0.87,
+                        1.61
+                    ]
+                }
+            }
+        ],
+        "cameras": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "ABAIA",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": "120",
+                    "frame_rate_unit": "hertz",
+                    "gain": "0.0",
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "FaceCamera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "23029765",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Face side right",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": null,
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": null,
+                    "description": "810 nm longpass filter",
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Long pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Thorlabs",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04gsnvb07"
+                    },
+                    "model": null,
+                    "name": "LP filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Tamron",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "M112FM16",
+                    "name": "Behavior Video Lens Face View",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "FaceCamera",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Monochrome",
+                    "computer_name": "ABAIA",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": "120",
+                    "frame_rate_unit": "hertz",
+                    "gain": "0.0",
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "FLIR",
+                        "name": "Teledyne FLIR",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "name": "SideCamera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": null,
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 540,
+                    "sensor_width": 720,
+                    "serial_number": "23029765",
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Side",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "5",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Other",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "LM5JCM",
+                    "name": "Behavior Video Lens Side View",
+                    "notes": "Manufacturer is KOWA",
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "SideCamera",
+                "position": null
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "Additive",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": null,
+                    "chroma": "Color",
+                    "computer_name": "ABAIA",
+                    "cooling": "Air",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "USB",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": null,
+                    "driver_version": null,
+                    "frame_rate": "30",
+                    "frame_rate_unit": "hertz",
+                    "gain": null,
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": "Ailipu",
+                        "name": "Ailipu Technology Co",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "ELP-USBFHD05MT-KL170IR",
+                    "name": "Bottom face Camera",
+                    "notes": "The targe is top of the body",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": {
+                        "name": "Bonsai",
+                        "parameters": {},
+                        "url": null,
+                        "version": "2.5"
+                    },
+                    "sensor_format": null,
+                    "sensor_format_unit": null,
+                    "sensor_height": 480,
+                    "sensor_width": 640,
+                    "serial_number": null,
+                    "size_unit": "pixel"
+                },
+                "camera_target": "Body",
+                "filter": null,
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Other",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": "f/1.4",
+                    "model": "XC0922LENS",
+                    "name": "Xenocam 2",
+                    "notes": "Focal Length 9-22mm 1/3\" IR F1.4",
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": "unknown",
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "USB_top_view",
+                "position": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "daqs": [
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "DO0",
+                        "channel_type": "Digital Output",
+                        "device_name": "FaceCamera",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    },
+                    {
+                        "channel_index": null,
+                        "channel_name": "DO0",
+                        "channel_type": "Digital Output",
+                        "device_name": "SideCamera",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    },
+                    {
+                        "channel_index": null,
+                        "channel_name": "DO1",
+                        "channel_type": "Digital Output",
+                        "device_name": "Speaker",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    },
+                    {
+                        "channel_index": null,
+                        "channel_name": "DO1",
+                        "channel_type": "Digital Output",
+                        "device_name": "Solenoid",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "ABAIA",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Behavior",
+                    "whoami": 1216
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "harp_behavior",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "ABAIA",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Clock Synchronizer",
+                    "whoami": 1152
+                },
+                "is_clock_generator": true,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "harp_clock_generator",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "ABAIA",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Clock Synchronizer",
+                    "whoami": 1152
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "OEPS",
+                    "name": "Open Ephys Production Site",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "007rkz355"
+                },
+                "model": null,
+                "name": "harp_clock_repeaters",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": null,
+                        "channel_name": "Torque sensor",
+                        "channel_type": "Analog Output",
+                        "device_name": "harp_treadmill",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    },
+                    {
+                        "channel_index": null,
+                        "channel_name": "Encoder",
+                        "channel_type": "Analog Output",
+                        "device_name": "harp_treadmill",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    },
+                    {
+                        "channel_index": null,
+                        "channel_name": "Magnetic brake",
+                        "channel_type": "Analog Output",
+                        "device_name": "harp_treadmill",
+                        "event_based_sampling": null,
+                        "port": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz"
+                    }
+                ],
+                "computer_name": "ABAIA",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Treadmill",
+                    "whoami": 1402
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "AIND",
+                    "name": "Allen Institute for Neural Dynamics",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04szwah67"
+                },
+                "model": null,
+                "name": "harp_treadmill",
+                "notes": "https://github.com/AllenNeuralDynamics/harp.device.treadmill-driver",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "ABAIA",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Lickety Split",
+                    "whoami": 1400
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "AIND",
+                    "name": "Allen Institute for Neural Dynamics",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04szwah67"
+                },
+                "model": null,
+                "name": "harp_lickometer",
+                "notes": "Lick sensor with low noise artifacts; https://github.com/AllenNeuralDynamics/harp.device.lickety-split",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "ABAIA",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Stepper Driver",
+                    "whoami": 1130
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "AIND",
+                    "name": "Allen Institute for Neural Dynamics",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04szwah67"
+                },
+                "model": null,
+                "name": "Stepper driver",
+                "notes": "Stepper driver for positioning the lick spout and the odor tubes; https://allenneuraldynamics.github.io/Bonsai.AllenNeuralDynamics/articles/aind-manipulator.html",
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "ABAIA",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Harp device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Olfactometer",
+                    "whoami": 1140
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "harp_olfactometer",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "detectors": [],
+        "digital_micromirror_devices": [],
+        "enclosure": {
+            "additional_settings": {},
+            "air_filtration": false,
+            "device_type": "Enclosure",
+            "external_material": "Wood and aluminium frame",
+            "grounded": true,
+            "internal_material": "High density foam",
+            "laser_interlock": false,
+            "manufacturer": {
+                "abbreviation": "AIND",
+                "name": "Allen Institute for Neural Dynamics",
+                "registry": {
+                    "abbreviation": "ROR",
+                    "name": "Research Organization Registry"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "name": "Behavior enclosure",
+            "notes": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "serial_number": null,
+            "size": {
+                "height": 506,
+                "length": 540,
+                "unit": "millimeter",
+                "width": 568
+            }
+        },
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "filters": [],
+        "laser_assemblies": [],
+        "lenses": [
+            {
+                "additional_settings": {},
+                "device_type": "Lens",
+                "focal_length": "50",
+                "focal_length_unit": "millimeter",
+                "lens_size_unit": "inch",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "max_aperture": null,
+                "model": "LA1255-B",
+                "name": "IR LED - Face lens",
+                "notes": null,
+                "optimized_wavelength_range": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size": null,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Lens",
+                "focal_length": "30",
+                "focal_length_unit": "millimeter",
+                "lens_size_unit": "inch",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "max_aperture": null,
+                "model": "LA1805-B",
+                "name": "IR LED - Side lens",
+                "notes": null,
+                "optimized_wavelength_range": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "size": null,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "name": "IR LED - Face",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer"
+            },
+            {
+                "additional_settings": {},
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer",
+                "device_type": "Light emitting diode",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "name": "IR LED - Side",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "modalities": [
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            }
+        ],
+        "modification_date": "2024-11-25",
+        "mouse_platform": {
+            "additional_settings": {},
+            "brake_output": {
+                "channel_index": null,
+                "channel_name": "Magnetic brake",
+                "channel_type": "Analog Output",
+                "device_name": "harp_treadmill",
+                "event_based_sampling": null,
+                "port": null,
+                "sample_rate": null,
+                "sample_rate_unit": "hertz"
+            },
+            "date_surface_replaced": null,
+            "device_type": "Wheel",
+            "encoder": {
+                "additional_settings": {},
+                "device_type": "Encoder",
+                "manufacturer": null,
+                "model": "AMT102-V",
+                "name": "Encoder",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "encoder_output": {
+                "channel_index": null,
+                "channel_name": "Encoder",
+                "channel_type": "Analog Output",
+                "device_name": "harp_treadmill",
+                "event_based_sampling": null,
+                "port": null,
+                "sample_rate": null,
+                "sample_rate_unit": "hertz"
+            },
+            "magnetic_brake": {
+                "additional_settings": {},
+                "device_type": "Magnetic brake",
+                "manufacturer": null,
+                "model": "B1-2FM",
+                "name": "Magnetic brake",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "manufacturer": {
+                "abbreviation": "AIND",
+                "name": "Allen Institute for Neural Dynamics",
+                "registry": {
+                    "abbreviation": "ROR",
+                    "name": "Research Organization Registry"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "name": "VR Wheel",
+            "notes": null,
+            "path_to_cad": "https://tinyurl.com/AI-RunningWheel",
+            "port_index": null,
+            "pulse_per_revolution": 8192,
+            "radius": "7.5",
+            "serial_number": null,
+            "size_unit": "centimeter",
+            "surface_material": "Rubber",
+            "torque_output": {
+                "channel_index": null,
+                "channel_name": "Torque sensor",
+                "channel_type": "Analog Output",
+                "device_name": "harp_treadmill",
+                "event_based_sampling": null,
+                "port": null,
+                "sample_rate": null,
+                "sample_rate_unit": "hertz"
+            },
+            "torque_sensor": {
+                "additional_settings": {},
+                "device_type": "Torque sensor",
+                "manufacturer": null,
+                "model": "RTS-10",
+                "name": "Torque sensor",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            "width": "3.5"
+        },
+        "notes": null,
+        "objectives": [],
+        "origin": null,
+        "patch_cords": [],
+        "pockels_cells": [],
+        "polygonal_scanners": [],
+        "rig_axes": null,
+        "rig_id": "426_4D_20241125",
+        "schema_version": "1.0.3",
+        "stick_microscopes": [],
+        "stimulus_devices": [
+            {
+                "device_type": "Reward delivery",
+                "reward_spouts": [
+                    {
+                        "additional_settings": {},
+                        "device_type": "Reward spout",
+                        "lick_sensor": {
+                            "additional_settings": {},
+                            "device_type": "Harp device",
+                            "manufacturer": {
+                                "abbreviation": "AIND",
+                                "name": "Allen Institute for Neural Dynamics",
+                                "registry": {
+                                    "abbreviation": "ROR",
+                                    "name": "Research Organization Registry"
+                                },
+                                "registry_identifier": "04szwah67"
+                            },
+                            "model": null,
+                            "name": "harp_lickometer",
+                            "notes": "Lick sensor with low noise artifacts; https://github.com/AllenNeuralDynamics/harp.device.lickety-split",
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "lick_sensor_type": "Capacitive",
+                        "manufacturer": {
+                            "abbreviation": null,
+                            "name": "Other",
+                            "registry": null,
+                            "registry_identifier": null
+                        },
+                        "model": "89875K27",
+                        "name": "Lick spout",
+                        "notes": "Lick spout for water delivery, the tube is ordered from McMaster, cut to size and shaped by AIND",
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "serial_number": null,
+                        "side": "Center",
+                        "solenoid_valve": {
+                            "additional_settings": {},
+                            "device_type": "Solenoid",
+                            "manufacturer": {
+                                "abbreviation": null,
+                                "name": "The Lee Company",
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDB1233518H",
+                            "name": "Solenoid",
+                            "notes": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "serial_number": null
+                        },
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null
+                    }
+                ],
+                "stage_type": {
+                    "additional_settings": {},
+                    "device_type": "Motorized stage",
+                    "firmware": null,
+                    "manufacturer": {
+                        "abbreviation": "AIND",
+                        "name": "Allen Institute for Neural Dynamics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04szwah67"
+                    },
+                    "model": "328-300-00",
+                    "name": "Motorized stage",
+                    "notes": "Motorized stage for positioning",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "travel": "30",
+                    "travel_unit": "millimeter"
+                }
+            },
+            {
+                "additional_settings": {},
+                "device_type": "Speaker",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Tymphany",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "XT25SC90-04",
+                "name": "Speaker",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "serial_number": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [
+                    {
+                        "channel_index": 0,
+                        "channel_type": "Odor",
+                        "flow_capacity": 100,
+                        "flow_unit": "mL/min"
+                    },
+                    {
+                        "channel_index": 1,
+                        "channel_type": "Odor",
+                        "flow_capacity": 100,
+                        "flow_unit": "mL/min"
+                    },
+                    {
+                        "channel_index": 2,
+                        "channel_type": "Odor",
+                        "flow_capacity": 100,
+                        "flow_unit": "mL/min"
+                    },
+                    {
+                        "channel_index": 3,
+                        "channel_type": "Carrier",
+                        "flow_capacity": 1000,
+                        "flow_unit": "mL/min"
+                    },
+                    {
+                        "channel_index": 4,
+                        "channel_type": "Carrier",
+                        "flow_capacity": 1000,
+                        "flow_unit": "mL/min"
+                    }
+                ],
+                "computer_name": "ABAIA",
+                "core_version": null,
+                "data_interface": "USB",
+                "device_type": "Olfactometer",
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Olfactometer",
+                    "whoami": 1140
+                },
+                "is_clock_generator": false,
+                "manufacturer": {
+                    "abbreviation": "Champalimaud",
+                    "name": "Champalimaud Foundation",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "name": "Olfactometer",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null,
+                "tag_version": null
+            },
+            {
+                "additional_settings": {},
+                "brightness": null,
+                "contrast": null,
+                "device_type": "Monitor",
+                "height": 1536,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "LG",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "02b948n83"
+                },
+                "model": "LG LP097QX1",
+                "name": "Screen Left",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "refresh_rate": 60,
+                "serial_number": null,
+                "size_unit": "pixel",
+                "viewing_distance": "15.5",
+                "viewing_distance_unit": "centimeter",
+                "width": 2048
+            },
+            {
+                "additional_settings": {},
+                "brightness": null,
+                "contrast": null,
+                "device_type": "Monitor",
+                "height": 1536,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "LG",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "02b948n83"
+                },
+                "model": "LG LP097QX1",
+                "name": "Screen Center",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "refresh_rate": 60,
+                "serial_number": null,
+                "size_unit": "pixel",
+                "viewing_distance": "17.5",
+                "viewing_distance_unit": "centimeter",
+                "width": 2048
+            },
+            {
+                "additional_settings": {},
+                "brightness": null,
+                "contrast": null,
+                "device_type": "Monitor",
+                "height": 1536,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "LG",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "02b948n83"
+                },
+                "model": "LG LP097QX1",
+                "name": "Screen Right",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "position": null,
+                "refresh_rate": 60,
+                "serial_number": null,
+                "size_unit": "pixel",
+                "viewing_distance": "17.5",
+                "viewing_distance_unit": "centimeter",
+                "width": 2048
+            }
+        ]
+    },
+    "schema_version": "1.1.1",
+    "session": {
+        "active_mouse_platform": true,
+        "anaesthesia": null,
+        "animal_weight_post": null,
+        "animal_weight_prior": null,
+        "calibrations": [],
+        "data_streams": [
+            {
+                "camera_names": [
+                    "FaceCamera",
+                    "SideCamera"
+                ],
+                "daq_names": [
+                    "harp_behavior",
+                    "harp_olfactometer",
+                    "harp_lickometer",
+                    "harp_clock_generator",
+                    "harp_treadmill",
+                    "harp_sniff_detector",
+                    "manipulator"
+                ],
+                "detectors": [],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2024-07-26T23:52:12.005703Z",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "behavior",
+                        "name": "Behavior"
+                    },
+                    {
+                        "abbreviation": "behavior-videos",
+                        "name": "Behavior videos"
+                    }
+                ],
+                "stream_start_time": "2024-07-26T23:13:48.863885Z"
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "experimenter_full_name": [
+            "Olivia"
+        ],
+        "headframe_registration": null,
+        "iacuc_protocol": "2109",
+        "maintenance": [],
+        "mouse_platform_name": "VR Wheel",
+        "notes": null,
+        "protocol_id": [],
+        "reward_consumed_total": null,
+        "reward_consumed_unit": "milliliter",
+        "reward_delivery": {
+            "notes": null,
+            "reward_solution": "Water",
+            "reward_spouts": [
+                {
+                    "side": "Center",
+                    "starting_position": {
+                        "device_axes": [
+                            {
+                                "direction": "Left",
+                                "name": "X"
+                            },
+                            {
+                                "direction": "Front",
+                                "name": "Y"
+                            },
+                            {
+                                "direction": "Top",
+                                "name": "Z"
+                            }
+                        ],
+                        "device_origin": "Manipulator home",
+                        "device_position_transformations": [
+                            {
+                                "translation": [
+                                    "0",
+                                    "0",
+                                    "0"
+                                ],
+                                "type": "translation"
+                            }
+                        ],
+                        "notes": null
+                    },
+                    "variable_position": false
+                }
+            ]
+        },
+        "rig_id": "4D",
+        "schema_version": "1.0.3",
+        "session_end_time": "2024-07-26T23:52:12.005703Z",
+        "session_start_time": "2024-07-26T23:13:48.863885Z",
+        "session_type": "NoveltyExplorationOdorTask",
+        "stimulus_epochs": [
+            {
+                "light_source_config": [],
+                "notes": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "vr-foraging",
+                    "parameters": {},
+                    "url": "https://github.com/AllenNeuralDynamics/Aind.Behavior.VrForaging/blob/main/src/vr-foraging.bonsai",
+                    "version": "unknown"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "Bonsai",
+                        "parameters": {},
+                        "url": "https://github.com/AllenNeuralDynamics/Aind.Behavior.VrForaging",
+                        "version": "unknown"
+                    }
+                ],
+                "speaker_config": {
+                    "name": "Speaker",
+                    "volume": "60",
+                    "volume_unit": "decibels"
+                },
+                "stimulus_device_names": [
+                    "harp_olfactometer",
+                    "Speaker",
+                    "Screen Left",
+                    "Screen Center",
+                    "Screen Right"
+                ],
+                "stimulus_end_time": "2024-07-26T23:52:12.005703Z",
+                "stimulus_modalities": [
+                    "Olfactory",
+                    "Auditory",
+                    "Visual",
+                    "Virtual reality",
+                    "Wheel friction"
+                ],
+                "stimulus_name": "AindVrForaging",
+                "stimulus_parameters": [
+                    {
+                        "amplitude_modulation_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_low_frequency": null,
+                        "bandpass_order": null,
+                        "frequency_unit": "hertz",
+                        "notes": null,
+                        "sample_frequency": "0",
+                        "stimulus_name": "Beep",
+                        "stimulus_type": "Auditory Stimulation"
+                    },
+                    {
+                        "channels": [
+                            {
+                                "channel_index": 0,
+                                "notes": null,
+                                "odorant": "NULL",
+                                "odorant_dilution": "0",
+                                "odorant_dilution_unit": "% v/v"
+                            },
+                            {
+                                "channel_index": 1,
+                                "notes": null,
+                                "odorant": "ODOR_A",
+                                "odorant_dilution": "1",
+                                "odorant_dilution_unit": "% v/v"
+                            },
+                            {
+                                "channel_index": 2,
+                                "notes": null,
+                                "odorant": "ODOR_B",
+                                "odorant_dilution": "1",
+                                "odorant_dilution_unit": "% v/v"
+                            },
+                            {
+                                "channel_index": 3,
+                                "notes": null,
+                                "odorant": "ODOR_C",
+                                "odorant_dilution": "1",
+                                "odorant_dilution_unit": "% v/v"
+                            }
+                        ],
+                        "notes": null,
+                        "stimulus_name": "Olfactory",
+                        "stimulus_type": "Olfactory Stimulation"
+                    },
+                    {
+                        "notes": null,
+                        "stimulus_name": "VrScreen",
+                        "stimulus_parameters": {},
+                        "stimulus_template_name": [],
+                        "stimulus_type": "Visual Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2024-07-26T23:13:48.863885Z",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            }
+        ],
+        "subject_id": "745300",
+        "weight_unit": "gram"
+    },
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": null,
+        "date_of_birth": "2024-04-16",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "wt/wt",
+        "housing": {
+            "cage_id": "8268163",
+            "cohoused_subjects": [],
+            "home_cage_enrichment": [],
+            "light_cycle": null,
+            "room_id": "221"
+        },
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.2",
+        "sex": "Male",
+        "source": {
+            "abbreviation": null,
+            "name": "Other",
+            "registry": null,
+            "registry_identifier": null
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "745300",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
I recently realized that the V1 metadata-service returns funding/investigators in "V2-style" even though the full data_description gets constructed in V1 format. This means some assets are not upgrading, but only because the upgrader rejects Person objects in the funding/investigators lists. This PR fixes that and adds a corresponding test asset.