### PR TITLE
fix: map transcode to Other

### DIFF
--- a/src/aind_metadata_upgrader/processing/v1v2.py
+++ b/src/aind_metadata_upgrader/processing/v1v2.py
@@ -38,6 +38,8 @@ class ProcessingV1V2(CoreUpgrader):
 
     def _resolve_process_type(self, name: str) -> str:
         """Repair known invalid process_type values and validate against ProcessName enum."""
+        if "transcode" in name.lower():
+            return ProcessName.OTHER.value
         repaired = _PROCESS_TYPE_REPAIR_MAP.get(name, name)
         if repaired not in _VALID_PROCESS_TYPES:
             raise ValueError(f"Invalid process_type '{name}': not a valid ProcessName value")

--- a/tests/records/v1/0fc6a09d-3d21-49b9-a365-f9e8cff7863f.json
+++ b/tests/records/v1/0fc6a09d-3d21-49b9-a365-f9e8cff7863f.json
@@ -1,0 +1,2449 @@
+{
+    "_id": "0fc6a09d-3d21-49b9-a365-f9e8cff7863f",
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "schema_version": "1.2.1",
+    "name": "behavior_809487_2025-11-26_15-58-37",
+    "created": "2026-02-19T09:02:52.979526Z",
+    "last_modified": "2026-07-10T22:42:21.563Z",
+    "location": "s3://aind-open-data/behavior_809487_2025-11-26_15-58-37",
+    "metadata_status": "Invalid",
+    "external_links": {
+        "Code Ocean": [
+            "394522f7-9123-4ba1-add3-0d3dce8b5e82"
+        ]
+    },
+    "subject": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "schema_version": "1.0.3",
+        "subject_id": "809487",
+        "sex": "Male",
+        "date_of_birth": "2025-05-22",
+        "genotype": "Dbh-Cre-KI/wt",
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "name": "National Center for Biotechnology Information",
+                "abbreviation": "NCBI"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Exp-ND-01-001-2414",
+            "maternal_id": "788918",
+            "maternal_genotype": "wt/wt",
+            "paternal_id": "785950",
+            "paternal_genotype": "Dbh-Cre-KI/wt"
+        },
+        "source": {
+            "name": "Allen Institute",
+            "abbreviation": "AI",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "rrid": null,
+        "restrictions": null,
+        "wellness_reports": [],
+        "housing": {
+            "cage_id": "8301900",
+            "room_id": "221",
+            "light_cycle": null,
+            "home_cage_enrichment": [],
+            "cohoused_subjects": []
+        },
+        "notes": null
+    },
+    "data_description": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "schema_version": "1.0.3",
+        "license": "CC-BY-4.0",
+        "platform": {
+            "name": "Behavior platform",
+            "abbreviation": "behavior"
+        },
+        "subject_id": "809487",
+        "creation_time": "2025-11-26T15:58:37-08:00",
+        "label": null,
+        "name": "behavior_809487_2025-11-26_15-58-37",
+        "institution": {
+            "name": "Allen Institute for Neural Dynamics",
+            "abbreviation": "AIND",
+            "registry": {
+                "name": "Research Organization Registry",
+                "abbreviation": "ROR"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "funding_source": [
+            {
+                "funder": {
+                    "name": "Allen Institute",
+                    "abbreviation": "AI",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null,
+                "fundee": "Alex Piet, Jeremiah Cohen, Kanghoon Jung, Polina Kosillo, Sue Su"
+            },
+            {
+                "funder": {
+                    "name": "National Institute of Mental Health",
+                    "abbreviation": "NIMH",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04xeg9z08"
+                },
+                "grant_number": "1R01MH134833",
+                "fundee": "Jeremiah Cohen, Jonathan Ting, Kenta Hagihara, Polina Kosillo, Yoav Ben-Simon"
+            }
+        ],
+        "data_level": "raw",
+        "group": null,
+        "investigators": [
+            {
+                "name": "Alex Piet",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Jonathan Ting",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Kenta Hagihara",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Rachel Lee",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Stefano Recanatesi",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Sue Su",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "name": "Yoav Ben-Simon",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "project_name": "Discovery-Neuromodulator circuit dynamics during foraging - Subproject 3 Fiber Photometry Recordings of NM Release During Behavior",
+        "restrictions": null,
+        "modality": [
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            },
+            {
+                "name": "Fiber photometry",
+                "abbreviation": "fib"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            }
+        ],
+        "related_data": [],
+        "data_summary": null
+    },
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "schema_version": "1.2.1",
+        "subject_id": "809487",
+        "subject_procedures": [
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2026-05-21",
+                "experimenter_full_name": "30361",
+                "iacuc_protocol": "2414",
+                "animal_weight_prior": null,
+                "animal_weight_post": null,
+                "weight_unit": "gram",
+                "anaesthesia": null,
+                "workstation_id": null,
+                "procedures": [
+                    {
+                        "procedure_type": "Perfusion",
+                        "output_specimen_ids": [
+                            "809487"
+                        ],
+                        "protocol_id": "dx.doi.org/10.17504/protocols.io.8epv51bejl1b/v6"
+                    }
+                ],
+                "notes": null
+            },
+            {
+                "procedure_type": "Surgery",
+                "start_date": "2025-07-21",
+                "experimenter_full_name": "NSB-3543",
+                "iacuc_protocol": "2414",
+                "animal_weight_prior": "24.3",
+                "animal_weight_post": "26.5",
+                "weight_unit": "gram",
+                "anaesthesia": {
+                    "type": "isoflurane",
+                    "duration": "180.0",
+                    "duration_unit": "minute",
+                    "level": "1.5"
+                },
+                "workstation_id": "SWS 1",
+                "procedures": [
+                    {
+                        "procedure_type": "Headframe",
+                        "headframe_type": "AI Straight bar",
+                        "headframe_part_number": null,
+                        "headframe_material": null,
+                        "well_part_number": null,
+                        "well_type": "No Well"
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "2.0",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_0"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Prelimbic area",
+                                    "acronym": "PL",
+                                    "id": "972"
+                                },
+                                "stereotactic_coordinate_ap": "2.0",
+                                "stereotactic_coordinate_ml": "-0.8",
+                                "stereotactic_coordinate_dv": "1.6",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.415",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "5.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "2.0",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_1"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Prelimbic area",
+                                    "acronym": "PL",
+                                    "id": "972"
+                                },
+                                "stereotactic_coordinate_ap": "2.0",
+                                "stereotactic_coordinate_ml": "0.8",
+                                "stereotactic_coordinate_dv": "1.6",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.415",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "5.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32017-pND-pAAV-hSyn-Nonflex-SSS-dLight3_8-myc-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32017_PHPeB",
+                                    "plasmid_tars_alias": "AiP32017",
+                                    "prep_lot_number": "VT6549G",
+                                    "prep_date": "2023-12-21",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32017-pND-pAAV-hSyn-Nonflex-SSS-dLight3_8-myc-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            },
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32294-pND-pAAV-hSyn-GRAB-rACh1.7-HA-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32294_PHPeB",
+                                    "plasmid_tars_alias": "AiP32294",
+                                    "prep_lot_number": "VT8558G",
+                                    "prep_date": "2025-02-26",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32294-pND-pAAV-hSyn-GRAB-rACh1.7-HA-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "-2.2",
+                        "injection_coordinate_ap": "1.0",
+                        "injection_coordinate_depth": [
+                            "4.2"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.415",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "10.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Nucleus accumbens",
+                            "acronym": "ACB",
+                            "id": "56"
+                        },
+                        "injection_hemisphere": "Left",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "200.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "4.5",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_2"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Nucleus accumbens",
+                                    "acronym": "ACB",
+                                    "id": "56"
+                                },
+                                "stereotactic_coordinate_ap": "1.0",
+                                "stereotactic_coordinate_ml": "-2.2",
+                                "stereotactic_coordinate_dv": "4.1",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.415",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "10.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32017-pND-pAAV-hSyn-Nonflex-SSS-dLight3_8-myc-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32017_PHPeB",
+                                    "plasmid_tars_alias": "AiP32017",
+                                    "prep_lot_number": "VT6549G",
+                                    "prep_date": "2023-12-21",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32017-pND-pAAV-hSyn-Nonflex-SSS-dLight3_8-myc-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            },
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32294-pND-pAAV-hSyn-GRAB-rACh1.7-HA-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32294_PHPeB",
+                                    "plasmid_tars_alias": "AiP32294",
+                                    "prep_lot_number": "VT8558G",
+                                    "prep_date": "2025-02-26",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32294-pND-pAAV-hSyn-GRAB-rACh1.7-HA-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 2500000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "2.2",
+                        "injection_coordinate_ap": "1.0",
+                        "injection_coordinate_depth": [
+                            "4.2"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.415",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "10.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Nucleus accumbens",
+                            "acronym": "ACB",
+                            "id": "56"
+                        },
+                        "injection_hemisphere": "Right",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "200.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "procedure_type": "Fiber implant",
+                        "probes": [
+                            {
+                                "ophys_probe": {
+                                    "device_type": "Fiber optic probe",
+                                    "serial_number": null,
+                                    "manufacturer": {
+                                        "name": "Neurophotometrics",
+                                        "abbreviation": null,
+                                        "registry": null,
+                                        "registry_identifier": null
+                                    },
+                                    "model": null,
+                                    "path_to_cad": null,
+                                    "port_index": null,
+                                    "additional_settings": {},
+                                    "notes": null,
+                                    "core_diameter": 200,
+                                    "core_diameter_unit": "micrometer",
+                                    "numerical_aperture": 0.37,
+                                    "ferrule_material": "Ceramic",
+                                    "active_length": null,
+                                    "total_length": "4.5",
+                                    "length_unit": "millimeter",
+                                    "name": "Fiber_3"
+                                },
+                                "targeted_structure": {
+                                    "atlas": "CCFv3",
+                                    "name": "Nucleus accumbens",
+                                    "acronym": "ACB",
+                                    "id": "56"
+                                },
+                                "stereotactic_coordinate_ap": "1.0",
+                                "stereotactic_coordinate_ml": "2.2",
+                                "stereotactic_coordinate_dv": "4.1",
+                                "stereotactic_coordinate_unit": "millimeter",
+                                "stereotactic_coordinate_reference": "Bregma",
+                                "bregma_to_lambda_distance": "4.415",
+                                "bregma_to_lambda_unit": "millimeter",
+                                "angle": "10.0",
+                                "angle_unit": "degrees",
+                                "notes": null
+                            }
+                        ]
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32066_PHPeB",
+                                    "plasmid_tars_alias": "AiP32066",
+                                    "prep_lot_number": "VT7113G",
+                                    "prep_date": "2024-04-12",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 10000000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "-0.85",
+                        "injection_coordinate_ap": "-5.4",
+                        "injection_coordinate_depth": [
+                            "3.0"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.415",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": "0.0",
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Locus ceruleus",
+                            "acronym": "LC",
+                            "id": "147"
+                        },
+                        "injection_hemisphere": "Left",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "200.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    },
+                    {
+                        "injection_materials": [
+                            {
+                                "material_type": "Virus",
+                                "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                "tars_identifiers": {
+                                    "virus_tars_id": "VIR32066_PHPeB",
+                                    "plasmid_tars_alias": "AiP32066",
+                                    "prep_lot_number": "VT7113G",
+                                    "prep_date": "2024-04-12",
+                                    "prep_type": "Purified",
+                                    "prep_protocol": "SOP#VC003"
+                                },
+                                "addgene_id": {
+                                    "name": "AiP32066-pAAV-FLEX-AXON-jGCaMP8s-WPRE",
+                                    "abbreviation": null,
+                                    "registry": null,
+                                    "registry_identifier": null
+                                },
+                                "titer": 10000000000000,
+                                "titer_unit": "gc/mL"
+                            }
+                        ],
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute",
+                        "injection_duration": null,
+                        "injection_duration_unit": "minute",
+                        "instrument_id": null,
+                        "injection_coordinate_ml": "0.85",
+                        "injection_coordinate_ap": "-5.4",
+                        "injection_coordinate_depth": [
+                            "3.0"
+                        ],
+                        "injection_coordinate_unit": "millimeter",
+                        "injection_coordinate_reference": "Bregma",
+                        "bregma_to_lambda_distance": "4.415",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "injection_angle": null,
+                        "injection_angle_unit": "degrees",
+                        "targeted_structure": {
+                            "atlas": "CCFv3",
+                            "name": "Locus ceruleus",
+                            "acronym": "LC",
+                            "id": "147"
+                        },
+                        "injection_hemisphere": "Right",
+                        "procedure_type": "Nanoject injection",
+                        "injection_volume": [
+                            "200.0"
+                        ],
+                        "injection_volume_unit": "nanoliter"
+                    }
+                ],
+                "notes": null,
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2"
+            },
+            {
+                "procedure_type": "Water restriction",
+                "target_fraction_weight": 85,
+                "target_fraction_weight_unit": "percent",
+                "minimum_water_per_day": "1.0",
+                "minimum_water_per_day_unit": "milliliter",
+                "baseline_weight": "26.43",
+                "weight_unit": "gram",
+                "start_date": "2025-08-22",
+                "end_date": "2025-12-11"
+            }
+        ],
+        "specimen_procedures": [],
+        "notes": null
+    },
+    "session": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "schema_version": "1.1.2",
+        "protocol_id": [],
+        "experimenter_full_name": [
+            "Bryan MacLennan",
+            "Kenta Hagihara"
+        ],
+        "session_start_time": "2025-11-26T15:58:37-08:00",
+        "session_end_time": "2025-11-26T17:20:29.675123-08:00",
+        "session_type": "Pavlovian_Conditioning + FIB",
+        "iacuc_protocol": "2414",
+        "rig_id": "428_9D_20250509",
+        "calibrations": [],
+        "maintenance": [],
+        "subject_id": "809487",
+        "animal_weight_prior": null,
+        "animal_weight_post": null,
+        "weight_unit": "gram",
+        "anaesthesia": null,
+        "data_streams": [
+            {
+                "stream_start_time": "2025-11-26T15:58:37-08:00",
+                "stream_end_time": "2025-11-26T17:20:29.675123-08:00",
+                "daq_names": [
+                    ""
+                ],
+                "camera_names": [
+                    "BehaviorVideography_Eye",
+                    "BehaviorVideography_Body"
+                ],
+                "light_sources": [
+                    {
+                        "device_type": "Light emitting diode",
+                        "name": "IR LED",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "name": "470nm LED",
+                        "excitation_power": "20",
+                        "excitation_power_unit": "microwatt"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "name": "415nm LED",
+                        "excitation_power": "20",
+                        "excitation_power_unit": "microwatt"
+                    },
+                    {
+                        "device_type": "Light emitting diode",
+                        "name": "565nm LED",
+                        "excitation_power": "20",
+                        "excitation_power_unit": "microwatt"
+                    }
+                ],
+                "ephys_modules": [],
+                "stick_microscopes": [],
+                "manipulator_modules": [],
+                "detectors": [
+                    {
+                        "name": "Green CMOS",
+                        "exposure_time": "15650",
+                        "exposure_time_unit": "microsecond",
+                        "trigger_type": "Internal"
+                    },
+                    {
+                        "name": "Red CMOS",
+                        "exposure_time": "15650",
+                        "exposure_time_unit": "microsecond",
+                        "trigger_type": "Internal"
+                    }
+                ],
+                "fiber_connections": [
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord 0",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord 0",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_green",
+                            "intended_measurement": "calcium",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 0",
+                        "patch_cord_name": "Patch Cord 0",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 0_isosbestic",
+                            "intended_measurement": "control",
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord 1",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_red",
+                            "intended_measurement": null,
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord 1",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_green",
+                            "intended_measurement": "calcium",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 1",
+                        "patch_cord_name": "Patch Cord 1",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 1_isosbestic",
+                            "intended_measurement": "control",
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord 2",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_red",
+                            "intended_measurement": "acetylcholine",
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord 2",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_green",
+                            "intended_measurement": "dopamine",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 2",
+                        "patch_cord_name": "Patch Cord 2",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 2_isosbestic",
+                            "intended_measurement": "control",
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 3",
+                        "patch_cord_name": "Patch Cord 3",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 3_red",
+                            "intended_measurement": "acetylcholine",
+                            "light_source_name": "565nm LED",
+                            "filter_names": [
+                                "Red emission bandpass filter",
+                                "Emission Dichroic",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 560nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Red Channel",
+                            "excitation_wavelength": 565,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 590,
+                            "description": "Red emission (590nm) with yellow excitation (565nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 3",
+                        "patch_cord_name": "Patch Cord 3",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 3_green",
+                            "intended_measurement": "dopamine",
+                            "light_source_name": "470nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 470nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 470,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Green emission (510nm) with blue excitation (470nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    },
+                    {
+                        "fiber_name": "Fiber 3",
+                        "patch_cord_name": "Patch Cord 3",
+                        "patch_cord_output_power": "0",
+                        "output_power_unit": "PowerUnit.UW",
+                        "channel": {
+                            "channel_name": "Fiber 3_isosbestic",
+                            "intended_measurement": "control",
+                            "light_source_name": "415nm LED",
+                            "filter_names": [
+                                "Green emission bandpass filter",
+                                "dual-edge standard epi-fluorescence dichroic beamsplitter",
+                                "Excitation filter 410nm"
+                            ],
+                            "detector_name": "FLIR CMOS for Green Channel",
+                            "excitation_wavelength": 415,
+                            "excitation_power": 20,
+                            "excitation_power_unit": "microwatt",
+                            "emission_wavelength": 510,
+                            "description": "Isosbestic control emission (510nm) with UV excitation (415nm)",
+                            "emission_wavelength_unit": "nanometer"
+                        }
+                    }
+                ],
+                "fiber_modules": [],
+                "ophys_fovs": [],
+                "slap_fovs": [],
+                "stack_parameters": null,
+                "mri_scans": [],
+                "stream_modalities": [
+                    {
+                        "name": "Behavior videos",
+                        "abbreviation": "behavior-videos"
+                    },
+                    {
+                        "name": "Behavior",
+                        "abbreviation": "behavior"
+                    },
+                    {
+                        "name": "Fiber photometry",
+                        "abbreviation": "fib"
+                    }
+                ],
+                "software": [
+                    {
+                        "name": "Bonsai",
+                        "version": "",
+                        "url": "https://github.com/AllenNeuralDynamics/PavlovianCond_Bonsai/tree/dafd7dfe0f347f781e91466b3d16b83cf32f8b6d",
+                        "parameters": {}
+                    }
+                ],
+                "notes": "Behavioral tracking with IR LED This record has been updated to include intended measurements. Fiber connections are repeated for fibers with multiple channels. Disconnected fibers are marked with fiber_name 'disconnected'."
+            }
+        ],
+        "stimulus_epochs": [
+            {
+                "stimulus_start_time": "2025-11-26T15:58:37-08:00",
+                "stimulus_end_time": "2025-11-26T17:20:14.705062-08:00",
+                "stimulus_name": "CS - auditory conditioned stimuli",
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "Bonsai",
+                        "version": "",
+                        "url": "https://github.com/AllenNeuralDynamics/PavlovianCond_Bonsai/tree/dafd7dfe0f347f781e91466b3d16b83cf32f8b6d",
+                        "parameters": {}
+                    }
+                ],
+                "script": null,
+                "stimulus_modalities": [
+                    "Auditory"
+                ],
+                "stimulus_parameters": [
+                    {
+                        "stimulus_type": "Auditory Stimulation",
+                        "stimulus_name": "CS1",
+                        "sample_frequency": "96000",
+                        "amplitude_modulation_frequency": 5000,
+                        "frequency_unit": "hertz",
+                        "bandpass_low_frequency": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_order": null,
+                        "notes": "assigned reward probability is 10%, duration is 1.0 s"
+                    },
+                    {
+                        "stimulus_type": "Auditory Stimulation",
+                        "stimulus_name": "CS2",
+                        "sample_frequency": "96000",
+                        "amplitude_modulation_frequency": 8000,
+                        "frequency_unit": "hertz",
+                        "bandpass_low_frequency": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_order": null,
+                        "notes": "assigned reward probability is 50%, duration is 1.0 s"
+                    },
+                    {
+                        "stimulus_type": "Auditory Stimulation",
+                        "stimulus_name": "CS3",
+                        "sample_frequency": "96000",
+                        "amplitude_modulation_frequency": 13000,
+                        "frequency_unit": "hertz",
+                        "bandpass_low_frequency": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_order": null,
+                        "notes": "assigned reward probability is 90%, duration is 1.0 s"
+                    },
+                    {
+                        "stimulus_type": "Auditory Stimulation",
+                        "stimulus_name": "CS4",
+                        "sample_frequency": "96000",
+                        "amplitude_modulation_frequency": null,
+                        "frequency_unit": "hertz",
+                        "bandpass_low_frequency": null,
+                        "bandpass_high_frequency": null,
+                        "bandpass_filter_type": null,
+                        "bandpass_order": null,
+                        "notes": "White noise, aversive probability is 90%, duration is 1.0 s"
+                    }
+                ],
+                "stimulus_device_names": [
+                    "Stimulus Speaker"
+                ],
+                "speaker_config": {
+                    "name": "Stimulus Speaker",
+                    "volume": "72",
+                    "volume_unit": "decibels"
+                },
+                "light_source_config": [],
+                "objects_in_arena": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": "382.0",
+                "reward_consumed_unit": "microliter",
+                "trials_total": 400,
+                "trials_finished": 400,
+                "trials_rewarded": 191,
+                "notes": null
+            }
+        ],
+        "mouse_platform_name": "mouse_tube_foraging",
+        "active_mouse_platform": false,
+        "headframe_registration": null,
+        "reward_delivery": {
+            "reward_solution": "Water",
+            "reward_spouts": [
+                {
+                    "side": "Left",
+                    "starting_position": {
+                        "device_position_transformations": [
+                            {
+                                "type": "translation",
+                                "translation": [
+                                    "0.0",
+                                    "-1.5",
+                                    "0.0"
+                                ]
+                            }
+                        ],
+                        "device_origin": "lower jaw",
+                        "device_axes": [
+                            {
+                                "name": "X",
+                                "direction": "left/right"
+                            },
+                            {
+                                "name": "Y",
+                                "direction": "rostro-caudal"
+                            },
+                            {
+                                "name": "Z",
+                                "direction": "up/down"
+                            }
+                        ],
+                        "notes": "Left spout in extended position, manually positioned about 1.5 mm from the lower jaw"
+                    },
+                    "variable_position": false
+                },
+                {
+                    "side": "Right",
+                    "starting_position": {
+                        "device_position_transformations": [
+                            {
+                                "type": "translation",
+                                "translation": [
+                                    "5.0",
+                                    "-31.5",
+                                    "0.0"
+                                ]
+                            }
+                        ],
+                        "device_origin": "lower jaw",
+                        "device_axes": [
+                            {
+                                "name": "X",
+                                "direction": "left/right"
+                            },
+                            {
+                                "name": "Y",
+                                "direction": "rostro-caudal"
+                            },
+                            {
+                                "name": "Z",
+                                "direction": "up/down"
+                            }
+                        ],
+                        "notes": "Right spout in retracted position, retraction travel is 30 mm placing it about 31.5 mm from the lower jaw."
+                    },
+                    "variable_position": false
+                }
+            ],
+            "notes": "Water delivered from left lick spout, right spout retracted"
+        },
+        "reward_consumed_total": "382.0",
+        "reward_consumed_unit": "microliter",
+        "notes": "The following information has no corresponding field in the session metadata: Punishment delivery: airpuff with 25 psi for 1 s (DO2)."
+    },
+    "rig": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "schema_version": "1.0.1",
+        "rig_id": "428_9D_20250509",
+        "modification_date": "2025-05-09",
+        "mouse_platform": {
+            "device_type": "Tube",
+            "name": "mouse_tube_foraging",
+            "serial_number": null,
+            "manufacturer": {
+                "name": "Custom",
+                "abbreviation": null,
+                "registry": null,
+                "registry_identifier": null
+            },
+            "model": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "additional_settings": {},
+            "notes": null,
+            "surface_material": null,
+            "date_surface_replaced": null,
+            "diameter": "3.0",
+            "diameter_unit": "centimeter"
+        },
+        "stimulus_devices": [
+            {
+                "device_type": "Reward delivery",
+                "stage_type": {
+                    "device_type": "Motorized stage",
+                    "name": "NewScaleMotor for LickSpouts",
+                    "serial_number": "0",
+                    "manufacturer": {
+                        "name": "New Scale Technologies",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "XYZ Stage with M30LS-3.4-15 linear stages",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "travel": "15.0",
+                    "travel_unit": "millimeter",
+                    "firmware": "https://github.com/AllenNeuralDynamics/python-newscale, branch: axes-on-target, commit #7c17497"
+                },
+                "reward_spouts": [
+                    {
+                        "device_type": "Reward spout",
+                        "name": "Left lick spout",
+                        "serial_number": null,
+                        "manufacturer": null,
+                        "model": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "additional_settings": {},
+                        "notes": null,
+                        "side": "Left",
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null,
+                        "solenoid_valve": {
+                            "device_type": "Solenoid",
+                            "name": "Solenoid Left",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "The Lee Company",
+                                "abbreviation": null,
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor": {
+                            "device_type": "Lick Sensor",
+                            "name": "Lick Sensor Left",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "Janelia Research Campus",
+                                "abbreviation": "Janelia",
+                                "registry": {
+                                    "name": "Research Organization Registry",
+                                    "abbreviation": "ROR"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor_type": "Capacitive"
+                    },
+                    {
+                        "device_type": "Reward spout",
+                        "name": "Right lick spout",
+                        "serial_number": null,
+                        "manufacturer": null,
+                        "model": null,
+                        "path_to_cad": null,
+                        "port_index": null,
+                        "additional_settings": {},
+                        "notes": null,
+                        "side": "Right",
+                        "spout_diameter": "1.2",
+                        "spout_diameter_unit": "millimeter",
+                        "spout_position": null,
+                        "solenoid_valve": {
+                            "device_type": "Solenoid",
+                            "name": "Solenoid Right",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "The Lee Company",
+                                "abbreviation": null,
+                                "registry": null,
+                                "registry_identifier": null
+                            },
+                            "model": "LHDA1233415H",
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor": {
+                            "device_type": "Lick Sensor",
+                            "name": "Lick Sensor Right",
+                            "serial_number": null,
+                            "manufacturer": {
+                                "name": "Janelia Research Campus",
+                                "abbreviation": "Janelia",
+                                "registry": {
+                                    "name": "Research Organization Registry",
+                                    "abbreviation": "ROR"
+                                },
+                                "registry_identifier": "013sk6x84"
+                            },
+                            "model": null,
+                            "path_to_cad": null,
+                            "port_index": null,
+                            "additional_settings": {},
+                            "notes": null
+                        },
+                        "lick_sensor_type": "Capacitive"
+                    }
+                ]
+            },
+            {
+                "device_type": "Speaker",
+                "name": "Stimulus Speaker",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Tymphany",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "XT25SC90-04",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "position": null
+            }
+        ],
+        "cameras": [
+            {
+                "name": "Right Camera assembly",
+                "camera_target": "Face side right",
+                "camera": {
+                    "device_type": "Detector",
+                    "name": "Right size of face camera",
+                    "serial_number": "23350954",
+                    "manufacturer": {
+                        "name": "Teledyne FLIR",
+                        "abbreviation": "FLIR",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "USB",
+                    "cooling": "Air",
+                    "computer_name": "DT300178",
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 720,
+                    "sensor_height": 540,
+                    "size_unit": "pixel",
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "bit_depth": null,
+                    "bin_mode": "None",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": null,
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "device_type": "Lens",
+                    "name": "Behavior Video Lens Right Side",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Fujinon",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "CF16ZA-1S",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "focal_length": "16",
+                    "focal_length_unit": "millimeter",
+                    "size": null,
+                    "lens_size_unit": "inch",
+                    "optimized_wavelength_range": null,
+                    "wavelength_unit": "nanometer",
+                    "max_aperture": null
+                },
+                "filter": null,
+                "position": null
+            },
+            {
+                "name": "Bottom Camera assembly",
+                "camera_target": "Face bottom",
+                "camera": {
+                    "device_type": "Detector",
+                    "name": "bottom of face camera",
+                    "serial_number": "23347797",
+                    "manufacturer": {
+                        "name": "Teledyne FLIR",
+                        "abbreviation": "FLIR",
+                        "registry": {
+                            "name": "Research Organization Registry",
+                            "abbreviation": "ROR"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "model": "Blackfly S BFS-U3-04S2M",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": null,
+                    "detector_type": "Camera",
+                    "data_interface": "USB",
+                    "cooling": "Air",
+                    "computer_name": "DT300178",
+                    "frame_rate": null,
+                    "frame_rate_unit": "hertz",
+                    "immersion": null,
+                    "chroma": "Monochrome",
+                    "sensor_width": 720,
+                    "sensor_height": 540,
+                    "size_unit": "pixel",
+                    "sensor_format": "1/2.9",
+                    "sensor_format_unit": "inch",
+                    "bit_depth": null,
+                    "bin_mode": "None",
+                    "bin_width": null,
+                    "bin_height": null,
+                    "bin_unit": "pixel",
+                    "gain": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_width": null,
+                    "crop_height": null,
+                    "crop_unit": "pixel",
+                    "recording_software": null,
+                    "driver": null,
+                    "driver_version": null
+                },
+                "lens": {
+                    "device_type": "Lens",
+                    "name": "Behavior Video Lens Bottom of face",
+                    "serial_number": null,
+                    "manufacturer": {
+                        "name": "Other",
+                        "abbreviation": null,
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "LM25HC",
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "additional_settings": {},
+                    "notes": "Manufacturer is Kowa",
+                    "focal_length": "25",
+                    "focal_length_unit": "millimeter",
+                    "size": null,
+                    "lens_size_unit": "inch",
+                    "optimized_wavelength_range": null,
+                    "wavelength_unit": "nanometer",
+                    "max_aperture": null
+                },
+                "filter": null,
+                "position": null
+            }
+        ],
+        "enclosure": {
+            "device_type": "Enclosure",
+            "name": "Behavior enclosure",
+            "serial_number": null,
+            "manufacturer": {
+                "name": "Allen Institute for Neural Dynamics",
+                "abbreviation": "AIND",
+                "registry": {
+                    "name": "Research Organization Registry",
+                    "abbreviation": "ROR"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "path_to_cad": null,
+            "port_index": null,
+            "additional_settings": {},
+            "notes": null,
+            "size": {
+                "width": 54,
+                "length": 54,
+                "height": 54,
+                "unit": "centimeter"
+            },
+            "internal_material": "",
+            "external_material": "",
+            "grounded": false,
+            "laser_interlock": false,
+            "air_filtration": false
+        },
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "stick_microscopes": [],
+        "laser_assemblies": [],
+        "patch_cords": [
+            {
+                "device_type": "Patch",
+                "name": "Bundle Branching Fiber-optic Patch Cord",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Doric",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "059n53q30"
+                },
+                "model": "BBP(4)_200/220/900-0.37_Custom_FCM-4xMF1.25",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "core_diameter": "200",
+                "numerical_aperture": "0.37",
+                "photobleaching_date": null
+            }
+        ],
+        "light_sources": [
+            {
+                "device_type": "Light emitting diode",
+                "name": "IR LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M810L5",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 810,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            },
+            {
+                "device_type": "Light emitting diode",
+                "name": "470nm LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M470F3",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 470,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            },
+            {
+                "device_type": "Light emitting diode",
+                "name": "415nm LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M415F3",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 415,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            },
+            {
+                "device_type": "Light emitting diode",
+                "name": "565nm LED",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "M565F3",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "wavelength": 565,
+                "wavelength_unit": "nanometer",
+                "bandwidth": null,
+                "bandwidth_unit": "nanometer"
+            }
+        ],
+        "detectors": [
+            {
+                "device_type": "Detector",
+                "name": "Green CMOS",
+                "serial_number": "21396991",
+                "manufacturer": {
+                    "name": "Teledyne FLIR",
+                    "abbreviation": "FLIR",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "detector_type": "Camera",
+                "data_interface": "USB",
+                "cooling": "Air",
+                "computer_name": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "immersion": "air",
+                "chroma": "Monochrome",
+                "sensor_width": null,
+                "sensor_height": null,
+                "size_unit": "pixel",
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "bit_depth": 16,
+                "bin_mode": "Additive",
+                "bin_width": 4,
+                "bin_height": 4,
+                "bin_unit": "pixel",
+                "gain": "2",
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_width": 200,
+                "crop_height": 200,
+                "crop_unit": "pixel",
+                "recording_software": null,
+                "driver": null,
+                "driver_version": null
+            },
+            {
+                "device_type": "Detector",
+                "name": "Red CMOS",
+                "serial_number": "21396990",
+                "manufacturer": {
+                    "name": "Teledyne FLIR",
+                    "abbreviation": "FLIR",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "BFS-U3-20S40M",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "detector_type": "Camera",
+                "data_interface": "USB",
+                "cooling": "Air",
+                "computer_name": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "immersion": "air",
+                "chroma": "Monochrome",
+                "sensor_width": null,
+                "sensor_height": null,
+                "size_unit": "pixel",
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "bit_depth": 16,
+                "bin_mode": "Additive",
+                "bin_width": 4,
+                "bin_height": 4,
+                "bin_unit": "pixel",
+                "gain": "2",
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_width": 200,
+                "crop_height": 200,
+                "crop_unit": "pixel",
+                "recording_software": null,
+                "driver": null,
+                "driver_version": null
+            }
+        ],
+        "objectives": [
+            {
+                "device_type": "Objective",
+                "name": "Objective",
+                "serial_number": "128022336",
+                "manufacturer": {
+                    "name": "Nikon",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "0280y9h11"
+                },
+                "model": "CFI Plan Apochromat Lambda D 10x",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "numerical_aperture": "0.45",
+                "magnification": "10",
+                "immersion": "air",
+                "objective_type": null
+            }
+        ],
+        "filters": [
+            {
+                "device_type": "Filter",
+                "name": "Green emission filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Semrock",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-520/35-25",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 520,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Red emission filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Semrock",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF01-600/37-25",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 600,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Emission Dichroic",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Semrock",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF562-Di03-25x36",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Dichroic",
+                "diameter": null,
+                "width": "36",
+                "height": "25",
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": 562,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "beamsplitter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Semrock",
+                    "abbreviation": null,
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "FF493/574-Di01-25x36",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": "493/574 nm BrightLine dual-edge standard epi-fluorescence dichroic beamsplitter",
+                "filter_type": "Multiband",
+                "diameter": null,
+                "width": "36",
+                "height": "25",
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Excitation filter 410nm",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB410-10",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 410,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Excitation filter 470nm",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB470-10",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 470,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "Excitation filter 560nm",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "FB560-10",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Band pass",
+                "diameter": "25",
+                "width": null,
+                "height": null,
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": null,
+                "cut_on_wavelength": null,
+                "center_wavelength": 560,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "450 Dichroic Longpass Filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Edmund Optics",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "#69-898",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Dichroic",
+                "diameter": null,
+                "width": "35.6",
+                "height": "25.2",
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": 450,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            },
+            {
+                "device_type": "Filter",
+                "name": "500 Dichroic Longpass Filter",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Edmund Optics",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "01j1gwp17"
+                },
+                "model": "#69-899",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "filter_type": "Dichroic",
+                "diameter": null,
+                "width": "35.6",
+                "height": "23.2",
+                "size_unit": "millimeter",
+                "thickness": null,
+                "thickness_unit": "millimeter",
+                "filter_wheel_index": null,
+                "cut_off_wavelength": 500,
+                "cut_on_wavelength": null,
+                "center_wavelength": null,
+                "wavelength_unit": "nanometer",
+                "description": null
+            }
+        ],
+        "lenses": [
+            {
+                "device_type": "Lens",
+                "name": "Image focusing lens",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Thorlabs",
+                    "abbreviation": null,
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": "AC254-080-A-ML",
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "focal_length": "80",
+                "focal_length_unit": "millimeter",
+                "size": 1,
+                "lens_size_unit": "inch",
+                "optimized_wavelength_range": null,
+                "wavelength_unit": "nanometer",
+                "max_aperture": null
+            }
+        ],
+        "digital_micromirror_devices": [],
+        "polygonal_scanners": [],
+        "pockels_cells": [],
+        "additional_devices": [
+            {
+                "device_type": "Photometry Clock",
+                "name": "Photometry Clock",
+                "serial_number": null,
+                "manufacturer": null,
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null
+            }
+        ],
+        "daqs": [
+            {
+                "device_type": "Harp device",
+                "name": "harp behavior board",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": "Left lick spout and Right lick spout, as well as reward delivery solenoids are connected via ethernet cables",
+                "data_interface": "Ethernet",
+                "computer_name": "DT300178",
+                "channels": [
+                    {
+                        "channel_name": "DI3",
+                        "device_name": "Photometry Clock",
+                        "channel_type": "Digital Input",
+                        "port": null,
+                        "channel_index": null,
+                        "sample_rate": null,
+                        "sample_rate_unit": "hertz",
+                        "event_based_sampling": null
+                    }
+                ],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Behavior",
+                    "whoami": 1216
+                },
+                "core_version": "1.11",
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp sound card",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "DT300178",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Sound Card",
+                    "whoami": 1280
+                },
+                "core_version": "1.4",
+                "tag_version": null,
+                "is_clock_generator": false
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp clock synchronization board",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "DT300178",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Clock Synchronizer",
+                    "whoami": 1152
+                },
+                "core_version": "",
+                "tag_version": null,
+                "is_clock_generator": true
+            },
+            {
+                "device_type": "Harp device",
+                "name": "harp sound amplifier",
+                "serial_number": null,
+                "manufacturer": {
+                    "name": "Champalimaud Foundation",
+                    "abbreviation": "Champalimaud",
+                    "registry": {
+                        "name": "Research Organization Registry",
+                        "abbreviation": "ROR"
+                    },
+                    "registry_identifier": "03g001n57"
+                },
+                "model": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "additional_settings": {},
+                "notes": null,
+                "data_interface": "USB",
+                "computer_name": "DT300178",
+                "channels": [],
+                "firmware_version": null,
+                "hardware_version": null,
+                "harp_device_type": {
+                    "name": "Input Expander",
+                    "whoami": 1106
+                },
+                "core_version": "",
+                "tag_version": null,
+                "is_clock_generator": false
+            }
+        ],
+        "calibrations": [
+            {
+                "calibration_date": "2025-02-18T00:00:00-08:00",
+                "device_name": "Lick spout Left",
+                "description": "Water calibration for Lick spout Left. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        1.882,
+                        2.715
+                    ]
+                },
+                "notes": null
+            },
+            {
+                "calibration_date": "2025-02-18T00:00:00-08:00",
+                "device_name": "Lick spout Right",
+                "description": "Water calibration for Lick spout Right. The input is the valve open time in seconds and the output is the volume of water delivered in microliters.",
+                "input": {
+                    "valve open time (s):": [
+                        0.02,
+                        0.03
+                    ]
+                },
+                "output": {
+                    "water volume (ul):": [
+                        2.012,
+                        2.92
+                    ]
+                },
+                "notes": null
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "origin": null,
+        "rig_axes": null,
+        "modalities": [
+            {
+                "name": "Behavior",
+                "abbreviation": "behavior"
+            },
+            {
+                "name": "Behavior videos",
+                "abbreviation": "behavior-videos"
+            },
+            {
+                "name": "Fiber photometry",
+                "abbreviation": "fib"
+            }
+        ],
+        "notes": null
+    },
+    "processing": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "schema_version": "1.1.3",
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "name": "Other",
+                    "software_version": "",
+                    "start_date_time": "2026-02-19T08:57:03Z",
+                    "end_date_time": "2026-02-19T08:57:03Z",
+                    "input_location": "//allen/aind/scratch/KentaHagihara_InternalTransfer/Pavlovian2upload/behavior_809487_2025-11-26_15-58-37/behavior",
+                    "output_location": "",
+                    "code_url": "",
+                    "code_version": null,
+                    "parameters": {
+                        "input_source": "//allen/aind/scratch/KentaHagihara_InternalTransfer/Pavlovian2upload/behavior_809487_2025-11-26_15-58-37/behavior"
+                    },
+                    "outputs": {},
+                    "notes": "Data was copied",
+                    "resources": null
+                },
+                {
+                    "name": "Other",
+                    "software_version": "",
+                    "start_date_time": "2026-02-19T08:57:03Z",
+                    "end_date_time": "2026-02-19T08:57:03Z",
+                    "input_location": "//allen/aind/scratch/KentaHagihara_InternalTransfer/Pavlovian2upload/behavior_809487_2025-11-26_15-58-37/fib",
+                    "output_location": "",
+                    "code_url": "",
+                    "code_version": null,
+                    "parameters": {
+                        "input_source": "//allen/aind/scratch/KentaHagihara_InternalTransfer/Pavlovian2upload/behavior_809487_2025-11-26_15-58-37/fib"
+                    },
+                    "outputs": {},
+                    "notes": "Data was copied",
+                    "resources": null
+                },
+                {
+                    "name": "Other",
+                    "software_version": "",
+                    "start_date_time": "2026-02-19T08:57:48Z",
+                    "end_date_time": "2026-02-19T08:57:48Z",
+                    "input_location": "//allen/aind/scratch/KentaHagihara_InternalTransfer/Pavlovian2upload/behavior_809487_2025-11-26_15-58-37/behavior-videos",
+                    "output_location": "",
+                    "code_url": "",
+                    "code_version": null,
+                    "parameters": {
+                        "input_source": "//allen/aind/scratch/KentaHagihara_InternalTransfer/Pavlovian2upload/behavior_809487_2025-11-26_15-58-37/behavior-videos"
+                    },
+                    "outputs": {},
+                    "notes": "Data was copied",
+                    "resources": null
+                },
+                {
+                    "name": "transcode/behavior_809487_2025-11-26_15-58-37/bottom_camera2025-11-26T15_58_37",
+                    "software_version": "0.1.0",
+                    "start_date_time": "2026-07-03T16:43:22.268090Z",
+                    "end_date_time": "2026-07-03T16:43:22.268090Z",
+                    "input_location": "s3://aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/bottom_camera2025-11-26T15_58_37.avi",
+                    "output_location": "s3://aind-scratch-data-dev-u5u0i5/encoded/smoke-v2/final/aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/bottom_camera2025-11-26T15_58_37.mp4",
+                    "code_url": "https://github.com/AllenNeuralDynamics/backlog-batch-transcode",
+                    "code_version": "0.1.0",
+                    "parameters": {
+                        "summary": "Re-encode of legacy h264_nvenc gbrp AVI to AIND OFFLINE_8BIT MP4.",
+                        "profile": "OFFLINE_8BIT/v1.0",
+                        "codec": "libx264",
+                        "preset": "slow",
+                        "crf": 18,
+                        "pix_fmt": "yuv420p",
+                        "input_s3": "s3://aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/bottom_camera2025-11-26T15_58_37.avi",
+                        "output_s3": "s3://aind-scratch-data-dev-u5u0i5/encoded/smoke-v2/final/aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/bottom_camera2025-11-26T15_58_37.mp4",
+                        "chunk_count": 6,
+                        "encoder": "ffmpeg version n8.1.2-20260624 Copyright (c) 2000-2026 the FFmpeg developers"
+                    },
+                    "outputs": {},
+                    "notes": "{\"summary\": \"Re-encode of legacy h264_nvenc gbrp AVI to AIND OFFLINE_8BIT MP4.\", \"profile\": \"OFFLINE_8BIT/v1.0\", \"codec\": \"libx264\", \"preset\": \"slow\", \"crf\": 18, \"pix_fmt\": \"yuv420p\", \"input_s3\": \"s3://aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/bottom_camera2025-11-26T15_58_37.avi\", \"output_s3\": \"s3://aind-scratch-data-dev-u5u0i5/encoded/smoke-v2/final/aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/bottom_camera2025-11-26T15_58_37.mp4\", \"chunk_count\": 6, \"encoder\": \"ffmpeg version n8.1.2-20260624 Copyright (c) 2000-2026 the FFmpeg developers\"}",
+                    "resources": null
+                },
+                {
+                    "name": "transcode/behavior_809487_2025-11-26_15-58-37/side_camera_right2025-11-26T15_58_37",
+                    "software_version": "0.1.0",
+                    "start_date_time": "2026-07-03T16:49:51.997050Z",
+                    "end_date_time": "2026-07-03T16:49:51.997050Z",
+                    "input_location": "s3://aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/side_camera_right2025-11-26T15_58_37.avi",
+                    "output_location": "s3://aind-scratch-data-dev-u5u0i5/encoded/smoke-v2/final/aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/side_camera_right2025-11-26T15_58_37.mp4",
+                    "code_url": "https://github.com/AllenNeuralDynamics/backlog-batch-transcode",
+                    "code_version": "0.1.0",
+                    "parameters": {
+                        "summary": "Re-encode of legacy h264_nvenc gbrp AVI to AIND OFFLINE_8BIT MP4.",
+                        "profile": "OFFLINE_8BIT/v1.0",
+                        "codec": "libx264",
+                        "preset": "slow",
+                        "crf": 18,
+                        "pix_fmt": "yuv420p",
+                        "input_s3": "s3://aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/side_camera_right2025-11-26T15_58_37.avi",
+                        "output_s3": "s3://aind-scratch-data-dev-u5u0i5/encoded/smoke-v2/final/aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/side_camera_right2025-11-26T15_58_37.mp4",
+                        "chunk_count": 6,
+                        "encoder": "ffmpeg version n8.1.2-20260624 Copyright (c) 2000-2026 the FFmpeg developers"
+                    },
+                    "outputs": {},
+                    "notes": "{\"summary\": \"Re-encode of legacy h264_nvenc gbrp AVI to AIND OFFLINE_8BIT MP4.\", \"profile\": \"OFFLINE_8BIT/v1.0\", \"codec\": \"libx264\", \"preset\": \"slow\", \"crf\": 18, \"pix_fmt\": \"yuv420p\", \"input_s3\": \"s3://aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/side_camera_right2025-11-26T15_58_37.avi\", \"output_s3\": \"s3://aind-scratch-data-dev-u5u0i5/encoded/smoke-v2/final/aind-open-data/behavior_809487_2025-11-26_15-58-37/behavior-videos/side_camera_right2025-11-26T15_58_37.mp4\", \"chunk_count\": 6, \"encoder\": \"ffmpeg version n8.1.2-20260624 Copyright (c) 2000-2026 the FFmpeg developers\"}",
+                    "resources": null
+                }
+            ],
+            "processor_full_name": "AIND Scientific Computing",
+            "pipeline_version": null,
+            "pipeline_url": null,
+            "note": null
+        },
+        "analyses": [],
+        "notes": null
+    },
+    "acquisition": null,
+    "instrument": null,
+    "quality_control": null
+}


### PR DESCRIPTION
Video re-encoding DataProcess objects are coming in with a ProcessName that doesn't map properly through the upgrader. This adds a new path for these custom processing steps, and adds a test asset.