### PR TITLE
fix: properly pass through FOV Translation and Scale

### DIFF
--- a/src/aind_metadata_upgrader/session/v1v2.py
+++ b/src/aind_metadata_upgrader/session/v1v2.py
@@ -65,6 +65,31 @@ from aind_metadata_upgrader.utils.v1v2_utils import (
     upgrade_experimenter_names,
 )
 
+# Conversion factors from a length unit to millimeter (the BREGMA_ARI axis unit)
+_LENGTH_UNIT_TO_MM = {
+    "nanometer": 1e-6,
+    "nm": 1e-6,
+    "micrometer": 1e-3,
+    "micron": 1e-3,
+    "um": 1e-3,
+    "millimeter": 1.0,
+    "mm": 1.0,
+    "centimeter": 10.0,
+    "cm": 10.0,
+    "meter": 1000.0,
+    "m": 1000.0,
+}
+
+
+def _length_to_mm_factor(unit: Optional[str]) -> float:
+    """Return the multiplier that converts a value in ``unit`` to millimeters.
+
+    Falls back to 1.0 (assume already millimeters) for unknown/None units.
+    """
+    if not unit:
+        return 1.0
+    return _LENGTH_UNIT_TO_MM.get(str(unit).strip().lower(), 1.0)
+
 
 class SessionV1V2(CoreUpgrader):
     """Upgrade session from v1.4 to v2.0 (acquisition)"""
@@ -551,17 +576,68 @@ class SessionV1V2(CoreUpgrader):
         fovs = stream.get("ophys_fovs", [])
         coupled_partner_map = self._build_coupled_fov_partner_map(fovs)
 
+        # Any planar imaging FOV is expressed relative to Bregma (ARI orientation)
+        if fovs:
+            self._acquisition_coordinate_system = CoordinateSystemLibrary.BREGMA_ARI.model_dump()
+
         for fov in fovs:
             fov_index = fov.get("index", 0)
             partner_index = coupled_partner_map.get(fov_index)
             plane = self._upgrade_ophys_fov_to_plane(fov, coupled_partner_index=partner_index)
+            transform, dimensions = self._build_fov_image_transform(fov)
             for channel in channels:
                 image = PlanarImage(
-                    planes=[plane], image_to_acquisition_transform=[], channel_name=channel["channel_name"]
+                    planes=[plane],
+                    image_to_acquisition_transform=transform,
+                    dimensions=dimensions,
+                    dimensions_unit=SizeUnit.PX,
+                    channel_name=channel["channel_name"],
                 ).model_dump()
                 images.append(image)
 
         return channels, images
+
+    def _build_fov_image_transform(self, fov: Dict) -> tuple:
+        """Build the image_to_acquisition_transform and dimensions for an ophys FOV.
+
+        The transform maps image pixel space into the acquisition coordinate system
+        (BREGMA_ARI, millimeters): a Scale (um/pixel -> mm/pixel) followed by a
+        Translation of the AP/ML position (converted to mm). scanfield_z is not
+        represented in v2, so the SI component is left at 0.
+        """
+        # AP/ML position, converted from the recorded unit to millimeters
+        coord_factor = _length_to_mm_factor(fov.get("fov_coordinate_unit"))
+        ap = float(fov.get("fov_coordinate_ap", 0) or 0) * coord_factor
+        ml = float(fov.get("fov_coordinate_ml", 0) or 0) * coord_factor
+        translation = Translation(translation=[ap, ml, 0])
+
+        transform = []
+        # Scale factor (e.g. um/pixel) converted to the coordinate system unit (mm/pixel)
+        scale_factor = fov.get("fov_scale_factor")
+        if scale_factor is not None:
+            scale_unit = fov.get("fov_scale_factor_unit", "")
+            length_part = str(scale_unit).split("/")[0] if scale_unit else None
+            scale_mm = float(scale_factor) * _length_to_mm_factor(length_part)
+            transform.append(Scale(scale=[scale_mm, scale_mm]))
+        transform.append(translation)
+
+        # Image dimensions (width, height) in pixels
+        dimensions = None
+        width = fov.get("fov_width")
+        height = fov.get("fov_height")
+        if width is not None and height is not None:
+            dimensions = Scale(scale=[float(width), float(height)])
+
+        # Preserve fields that have no dedicated home in v2 on the stream notes
+        extras = []
+        if fov.get("magnification") is not None:
+            extras.append(f"magnification={fov.get('magnification')}")
+        if fov.get("scanimage_roi_index") is not None:
+            extras.append(f"scanimage_roi_index={fov.get('scanimage_roi_index')}")
+        if extras:
+            self._fov_notes.append(f"FOV {fov.get('index', 0)}: " + ", ".join(extras))
+
+        return transform, dimensions
 
     def _create_stack_components(self, stream: Dict, light_sources: List, detectors: List) -> tuple:
         """Create channels and PlanarImageStack objects from stack_parameters"""
@@ -747,6 +823,7 @@ class SessionV1V2(CoreUpgrader):
             active_devices.append(stick_microscope.get("assembly_name", "Unknown Stick Microscope"))
 
         # Create configurations and connections
+        self._fov_notes = []
         configurations, connections = self._upgrade_all_device_configurations(stream, rig_id)
 
         # Make sure all configuration devices are in active devices
@@ -756,6 +833,12 @@ class SessionV1V2(CoreUpgrader):
         ]
         active_devices = list(set(active_devices + configuration_device_names + connection_device_names))
 
+        # Merge any FOV fields that have no dedicated v2 home into the stream notes
+        notes = stream.get("notes")
+        if self._fov_notes:
+            fov_note = "(v1v2 upgrade) " + "; ".join(self._fov_notes)
+            notes = f"{notes} {fov_note}" if notes else fov_note
+
         # Create the data stream
         return DataStream(
             stream_start_time=ensure_timezone(stream.get("stream_start_time"), fallback_tz),
@@ -764,7 +847,7 @@ class SessionV1V2(CoreUpgrader):
             active_devices=active_devices,
             configurations=configurations,
             connections=connections,
-            notes=stream.get("notes"),
+            notes=notes,
         ).model_dump()
 
     def _create_performance_metrics(self, epoch: Dict) -> Optional[Dict]:
@@ -1017,6 +1100,9 @@ class SessionV1V2(CoreUpgrader):
         # Store rig filters and light sources for lookup during stream upgrade
         self._rig_filters = []
         self._rig_light_sources = []
+        # Set to BREGMA_ARI when planar imaging FOVs are encountered during stream upgrade
+        self._acquisition_coordinate_system = None
+        self._fov_notes = []
         if metadata and isinstance(metadata, dict):
             rig = metadata.get("rig", {})
             if isinstance(rig, dict):
@@ -1106,6 +1192,7 @@ class SessionV1V2(CoreUpgrader):
             instrument_id=rig_id,
             acquisition_type=acquisition_type,
             notes=notes,
+            coordinate_system=self._acquisition_coordinate_system,
             calibrations=upgraded_calibrations,
             maintenance=upgraded_maintenance,
             data_streams=upgraded_data_streams,

--- a/tests/records/v1/055c3cb7-ca37-4c6c-9ef5-d79e00cf72d1.json
+++ b/tests/records/v1/055c3cb7-ca37-4c6c-9ef5-d79e00cf72d1.json
@@ -1,0 +1,1626 @@
+{
+    "_id": "055c3cb7-ca37-4c6c-9ef5-d79e00cf72d1",
+    "acquisition": null,
+    "created": "2025-09-19T12:28:15.946325",
+    "data_description": {
+        "creation_time": "2025-09-18T11:59:49.412938-07:00",
+        "data_level": "raw",
+        "data_summary": "LearningmFISHTask1A",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/data_description.py",
+        "funding_source": [
+            {
+                "fundee": null,
+                "funder": {
+                    "abbreviation": "AI",
+                    "name": "Allen Institute",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03cpe7c52"
+                },
+                "grant_number": null
+            }
+        ],
+        "group": null,
+        "institution": {
+            "abbreviation": "AIND",
+            "name": "Allen Institute for Neural Dynamics",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "04szwah67"
+        },
+        "investigators": [
+            {
+                "abbreviation": null,
+                "name": "Marina Garrett",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Peter Groblewski",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Anton Arkhipov",
+                "registry": null,
+                "registry_identifier": null
+            },
+            {
+                "abbreviation": null,
+                "name": "Omid Zobeiri",
+                "registry": null,
+                "registry_identifier": null
+            }
+        ],
+        "label": null,
+        "license": "CC-BY-4.0",
+        "modality": [
+            {
+                "abbreviation": "pophys",
+                "name": "Planar optical physiology"
+            },
+            {
+                "abbreviation": "behavior-videos",
+                "name": "Behavior videos"
+            },
+            {
+                "abbreviation": "behavior",
+                "name": "Behavior"
+            }
+        ],
+        "name": "multiplane-ophys_800995_2025-09-18_11-59-49",
+        "platform": {
+            "abbreviation": "multiplane-ophys",
+            "name": "Multiplane optical physiology platform"
+        },
+        "project_name": "Learning mFISH-V1omFISH",
+        "related_data": [],
+        "restrictions": null,
+        "schema_version": "1.0.3",
+        "subject_id": "800995"
+    },
+    "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/metadata.py",
+    "external_links": {
+        "Code Ocean": [
+            "4b07da8c-2e4b-4f6e-a1e1-bb6658d985de"
+        ]
+    },
+    "instrument": null,
+    "last_modified": "2025-09-19T12:40:20.770Z",
+    "location": "s3://aind-open-data/multiplane-ophys_800995_2025-09-18_11-59-49",
+    "metadata_status": "Missing",
+    "name": "multiplane-ophys_800995_2025-09-18_11-59-49",
+    "procedures": {
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/procedures.py",
+        "notes": null,
+        "schema_version": "1.2.1",
+        "specimen_procedures": [],
+        "subject_id": "800995",
+        "subject_procedures": [
+            {
+                "anaesthesia": {
+                    "duration": "180.0",
+                    "duration_unit": "minute",
+                    "level": "1.5",
+                    "type": "isoflurane"
+                },
+                "animal_weight_post": "21.9",
+                "animal_weight_prior": "19.0",
+                "experimenter_full_name": "NSB-3302",
+                "iacuc_protocol": "2427",
+                "notes": null,
+                "procedure_type": "Surgery",
+                "procedures": [
+                    {
+                        "bregma_to_lambda_distance": "4.1",
+                        "bregma_to_lambda_unit": "millimeter",
+                        "craniotomy_hemisphere": null,
+                        "craniotomy_type": "5 mm",
+                        "dura_removed": null,
+                        "implant_part_number": "5mm stacked coverslip",
+                        "procedure_type": "Craniotomy",
+                        "protective_material": null,
+                        "recovery_time": "10.0",
+                        "recovery_time_unit": "minute"
+                    },
+                    {
+                        "headframe_material": null,
+                        "headframe_part_number": "0160-100-10",
+                        "headframe_type": "Visual Ctx",
+                        "procedure_type": "Headframe",
+                        "well_part_number": "0160-200-20",
+                        "well_type": "Mesoscope"
+                    }
+                ],
+                "protocol_id": "dx.doi.org/10.17504/protocols.io.kqdg392o7g25/v2",
+                "start_date": "2025-06-09",
+                "weight_unit": "gram",
+                "workstation_id": "SWS 3"
+            }
+        ]
+    },
+    "processing": {
+        "analyses": [],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/processing.py",
+        "notes": null,
+        "processing_pipeline": {
+            "data_processes": [
+                {
+                    "code_url": "",
+                    "code_version": null,
+                    "end_date_time": "2025-09-19T12:27:39.268174Z",
+                    "input_location": "//allen/aind/stage/2p-working-group/data-uploads/multiplane-ophys_800995_2025-09-18_11-59-49/pophys",
+                    "name": "Other",
+                    "notes": "Data was copied",
+                    "output_location": "",
+                    "outputs": {},
+                    "parameters": {
+                        "input_source": "//allen/aind/stage/2p-working-group/data-uploads/multiplane-ophys_800995_2025-09-18_11-59-49/pophys"
+                    },
+                    "resources": null,
+                    "software_version": "",
+                    "start_date_time": "2025-09-19T12:25:38.043752Z"
+                },
+                {
+                    "code_url": "",
+                    "code_version": null,
+                    "end_date_time": "2025-09-19T12:27:39.302546Z",
+                    "input_location": "//allen/aind/stage/2p-working-group/data-uploads/multiplane-ophys_800995_2025-09-18_11-59-49/behavior",
+                    "name": "Other",
+                    "notes": "Data was copied",
+                    "output_location": "",
+                    "outputs": {},
+                    "parameters": {
+                        "input_source": "//allen/aind/stage/2p-working-group/data-uploads/multiplane-ophys_800995_2025-09-18_11-59-49/behavior"
+                    },
+                    "resources": null,
+                    "software_version": "",
+                    "start_date_time": "2025-09-19T12:25:38.073183Z"
+                },
+                {
+                    "code_url": "",
+                    "code_version": null,
+                    "end_date_time": "2025-09-19T12:27:39.968509Z",
+                    "input_location": "//allen/aind/stage/2p-working-group/data-uploads/multiplane-ophys_800995_2025-09-18_11-59-49/behavior-videos",
+                    "name": "Other",
+                    "notes": "Data was copied",
+                    "output_location": "",
+                    "outputs": {},
+                    "parameters": {
+                        "input_source": "//allen/aind/stage/2p-working-group/data-uploads/multiplane-ophys_800995_2025-09-18_11-59-49/behavior-videos"
+                    },
+                    "resources": null,
+                    "software_version": "",
+                    "start_date_time": "2025-09-19T12:25:38.775587Z"
+                }
+            ],
+            "note": null,
+            "pipeline_url": null,
+            "pipeline_version": null,
+            "processor_full_name": "AIND Scientific Computing"
+        },
+        "schema_version": "1.1.3"
+    },
+    "quality_control": null,
+    "rig": {
+        "additional_devices": [],
+        "calibrations": [],
+        "cameras": [
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": 8,
+                    "chroma": "Monochrome",
+                    "computer_name": "Video Monitor",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "Ethernet",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": "Vimba",
+                    "driver_version": "Vimba GigE Transport Layer 1.6.0",
+                    "frame_rate": "60",
+                    "frame_rate_unit": "hertz",
+                    "gain": "4",
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Allied",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "Mako G-32B",
+                    "name": "Behavior Camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": {
+                        "name": "MultiVideoRecorder",
+                        "parameters": {},
+                        "url": null,
+                        "version": "1.1.7"
+                    },
+                    "sensor_format": "1/3",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 492,
+                    "sensor_width": 658,
+                    "serial_number": null,
+                    "size_unit": "inch"
+                },
+                "camera_target": "Body",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": 747,
+                    "cut_off_wavelength": 780,
+                    "cut_on_wavelength": 714,
+                    "description": null,
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Band pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Semrock",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "FF01-747/33-25",
+                    "name": "Behavior Camera Filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "6",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Thorlabs",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "04gsnvb07"
+                    },
+                    "max_aperture": "f/1.4",
+                    "model": "MVL6WA",
+                    "name": "Behavior Camera Lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Behavior Camera",
+                "position": {
+                    "device_axes": [
+                        {
+                            "direction": "moving away from the sensor towards the object",
+                            "name": "Z"
+                        },
+                        {
+                            "direction": "pointing to the bottom edge of the sensor",
+                            "name": "Y"
+                        },
+                        {
+                            "direction": "parallel to the bottom edge of the sensor",
+                            "name": "X"
+                        }
+                    ],
+                    "device_origin": "Located on face of the lens mounting surface in its center",
+                    "device_position_transformations": [
+                        {
+                            "rotation": [
+                                "-1",
+                                "0",
+                                "0",
+                                "0",
+                                "0",
+                                "-1",
+                                "0",
+                                "-3",
+                                "0"
+                            ],
+                            "type": "rotation"
+                        },
+                        {
+                            "translation": [
+                                "-0.03617",
+                                "0.23887",
+                                "-0.02535"
+                            ],
+                            "type": "translation"
+                        }
+                    ],
+                    "notes": null
+                }
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": 8,
+                    "chroma": "Monochrome",
+                    "computer_name": "Video Monitor",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "Ethernet",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": "Vimba",
+                    "driver_version": "Vimba GigE Transport Layer 1.6.0",
+                    "frame_rate": "60",
+                    "frame_rate_unit": "hertz",
+                    "gain": "4",
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Allied",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "Mako G-32B",
+                    "name": "Eye Camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": {
+                        "name": "MultiVideoRecorder",
+                        "parameters": {},
+                        "url": null,
+                        "version": "1.1.7"
+                    },
+                    "sensor_format": "1/3",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 492,
+                    "sensor_width": 658,
+                    "serial_number": null,
+                    "size_unit": "inch"
+                },
+                "camera_target": "Eye",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": 850,
+                    "cut_off_wavelength": 860,
+                    "cut_on_wavelength": 840,
+                    "description": null,
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Band pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Semrock",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "FF01-850/10-25",
+                    "name": "Eye Camera Filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": null,
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Infinity Photo-Optical",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "max_aperture": null,
+                    "model": "213073",
+                    "name": "Eye Camera Lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Eye Camera",
+                "position": {
+                    "device_axes": [
+                        {
+                            "direction": "moving away from the sensor towards the object",
+                            "name": "Z"
+                        },
+                        {
+                            "direction": "pointing to the bottom edge of the sensor",
+                            "name": "Y"
+                        },
+                        {
+                            "direction": "parallel to the bottom edge of the sensor",
+                            "name": "X"
+                        }
+                    ],
+                    "device_origin": "Located on face of the lens mounting surface in its center",
+                    "device_position_transformations": [
+                        {
+                            "rotation": [
+                                "-0.5",
+                                "-0.86603",
+                                "0",
+                                "-0.366",
+                                "0.21131",
+                                "-0.90631",
+                                "0.78489",
+                                "-0.45315",
+                                "-0.42262"
+                            ],
+                            "type": "rotation"
+                        },
+                        {
+                            "translation": [
+                                "-0.14259",
+                                "0.06209",
+                                "-0.09576"
+                            ],
+                            "type": "translation"
+                        }
+                    ],
+                    "notes": null
+                }
+            },
+            {
+                "camera": {
+                    "additional_settings": {},
+                    "bin_height": null,
+                    "bin_mode": "None",
+                    "bin_unit": "pixel",
+                    "bin_width": null,
+                    "bit_depth": 8,
+                    "chroma": "Monochrome",
+                    "computer_name": "Video Monitor",
+                    "cooling": "None",
+                    "crop_height": null,
+                    "crop_offset_x": null,
+                    "crop_offset_y": null,
+                    "crop_unit": "pixel",
+                    "crop_width": null,
+                    "data_interface": "Ethernet",
+                    "detector_type": "Camera",
+                    "device_type": "Detector",
+                    "driver": "Vimba",
+                    "driver_version": "Vimba GigE Transport Layer 1.6.0",
+                    "frame_rate": "60",
+                    "frame_rate_unit": "hertz",
+                    "gain": "4",
+                    "immersion": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Allied",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "Mako G-32B",
+                    "name": "Face Camera",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "recording_software": {
+                        "name": "MultiVideoRecorder",
+                        "parameters": {},
+                        "url": null,
+                        "version": "1.1.7"
+                    },
+                    "sensor_format": "1/3",
+                    "sensor_format_unit": "inch",
+                    "sensor_height": 492,
+                    "sensor_width": 658,
+                    "serial_number": null,
+                    "size_unit": "inch"
+                },
+                "camera_target": "Face forward",
+                "filter": {
+                    "additional_settings": {},
+                    "center_wavelength": null,
+                    "cut_off_wavelength": null,
+                    "cut_on_wavelength": 715,
+                    "description": null,
+                    "device_type": "Filter",
+                    "diameter": null,
+                    "filter_type": "Long pass",
+                    "filter_wheel_index": null,
+                    "height": null,
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Semrock",
+                        "registry": null,
+                        "registry_identifier": null
+                    },
+                    "model": "FF01-715/LP-25",
+                    "name": "Face Camera Filter",
+                    "notes": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size_unit": "millimeter",
+                    "thickness": null,
+                    "thickness_unit": "millimeter",
+                    "wavelength_unit": "nanometer",
+                    "width": null
+                },
+                "lens": {
+                    "additional_settings": {},
+                    "device_type": "Lens",
+                    "focal_length": "8.5",
+                    "focal_length_unit": "millimeter",
+                    "lens_size_unit": "inch",
+                    "manufacturer": {
+                        "abbreviation": null,
+                        "name": "Edmund Optics",
+                        "registry": {
+                            "abbreviation": "ROR",
+                            "name": "Research Organization Registry"
+                        },
+                        "registry_identifier": "01j1gwp17"
+                    },
+                    "max_aperture": "f/8",
+                    "model": "86-604",
+                    "name": "Face Camera Lens",
+                    "notes": null,
+                    "optimized_wavelength_range": null,
+                    "path_to_cad": null,
+                    "port_index": null,
+                    "serial_number": null,
+                    "size": null,
+                    "wavelength_unit": "nanometer"
+                },
+                "name": "Face Camera",
+                "position": {
+                    "device_axes": [
+                        {
+                            "direction": "moving away from the sensor towards the object",
+                            "name": "Z"
+                        },
+                        {
+                            "direction": "pointing to the bottom edge of the sensor",
+                            "name": "Y"
+                        },
+                        {
+                            "direction": "parallel to the bottom edge of the sensor",
+                            "name": "X"
+                        }
+                    ],
+                    "device_origin": "Located on face of the lens mounting surface in its center",
+                    "device_position_transformations": [
+                        {
+                            "rotation": [
+                                "-0.17365",
+                                "0.98481",
+                                "0",
+                                "0.44709",
+                                "0.07883",
+                                "-0.89101",
+                                "-0.87747",
+                                "-0.15472",
+                                "-0.45399"
+                            ],
+                            "type": "rotation"
+                        },
+                        {
+                            "translation": [
+                                "0.154",
+                                "0.03078",
+                                "0.06346"
+                            ],
+                            "type": "translation"
+                        }
+                    ],
+                    "notes": null
+                }
+            }
+        ],
+        "ccf_coordinate_transform": null,
+        "daqs": [
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "STIM",
+                "data_interface": "USB",
+                "device_type": "DAQ Device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "National Instruments",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "USB-6001",
+                "name": "VBEB DAQ",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "SYNC",
+                "data_interface": "PCIe",
+                "device_type": "DAQ Device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "National Instruments",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "PCIe-6612",
+                "name": "SYNC DAQ",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "STIM",
+                "data_interface": "PCIe",
+                "device_type": "DAQ Device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "National Instruments",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "PCIe-6321",
+                "name": "STIM DAQ",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            },
+            {
+                "additional_settings": {},
+                "channels": [],
+                "computer_name": "ACQ",
+                "data_interface": "PCIe",
+                "device_type": "DAQ Device",
+                "firmware_version": null,
+                "hardware_version": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "National Instruments",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "026exqw73"
+                },
+                "model": "vDAQ",
+                "name": "vDAQ0",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/rig.py",
+        "detectors": [
+            {
+                "additional_settings": {},
+                "bin_height": null,
+                "bin_mode": "None",
+                "bin_unit": "pixel",
+                "bin_width": null,
+                "bit_depth": null,
+                "chroma": null,
+                "computer_name": null,
+                "cooling": "None",
+                "crop_height": null,
+                "crop_offset_x": null,
+                "crop_offset_y": null,
+                "crop_unit": "pixel",
+                "crop_width": null,
+                "data_interface": "PCIe",
+                "detector_type": "Photomultiplier Tube",
+                "device_type": "Detector",
+                "driver": null,
+                "driver_version": null,
+                "frame_rate": null,
+                "frame_rate_unit": "hertz",
+                "gain": null,
+                "immersion": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Hamamatsu",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "03natb733"
+                },
+                "model": null,
+                "name": "H11706-40",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "recording_software": null,
+                "sensor_format": null,
+                "sensor_format_unit": null,
+                "sensor_height": null,
+                "sensor_width": null,
+                "serial_number": null,
+                "size_unit": "pixel"
+            }
+        ],
+        "digital_micromirror_devices": [],
+        "enclosure": null,
+        "ephys_assemblies": [],
+        "fiber_assemblies": [],
+        "filters": [],
+        "laser_assemblies": [],
+        "lenses": [],
+        "light_sources": [
+            {
+                "additional_settings": {},
+                "coupling": null,
+                "coupling_efficiency": null,
+                "coupling_efficiency_unit": "percent",
+                "device_type": "Laser",
+                "item_number": null,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Coherent Scientific",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "031tysd23"
+                },
+                "maximum_power": null,
+                "model": null,
+                "name": "Axon 920-2 TPC",
+                "notes": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "power_unit": "milliwatt",
+                "serial_number": null,
+                "wavelength": 920,
+                "wavelength_unit": "nanometer"
+            }
+        ],
+        "modalities": [
+            {
+                "abbreviation": "pophys",
+                "name": "Planar optical physiology"
+            }
+        ],
+        "modification_date": "2024-10-28",
+        "mouse_platform": {
+            "additional_settings": {},
+            "date_surface_replaced": null,
+            "decoder": "LS7366R",
+            "device_type": "Disc",
+            "encoder": "CUI Devices AMT102-V 0000 Dip Switch 2048 ppr",
+            "encoder_firmware": {
+                "name": "ls7366r_quadrature_counter",
+                "parameters": {},
+                "url": "https://eng-gitlab/hardware/ls7366r_quadrature_counter",
+                "version": "0.1.6"
+            },
+            "manufacturer": {
+                "abbreviation": "AIND",
+                "name": "Allen Institute for Neural Dynamics",
+                "registry": {
+                    "abbreviation": "ROR",
+                    "name": "Research Organization Registry"
+                },
+                "registry_identifier": "04szwah67"
+            },
+            "model": null,
+            "name": "MindScope Running Disk",
+            "notes": null,
+            "output": "Digital Output",
+            "path_to_cad": null,
+            "port_index": null,
+            "radius": "8.255",
+            "radius_unit": "centimeter",
+            "serial_number": null,
+            "surface_material": "Kittrich Magic Cover Solid Grip Liner"
+        },
+        "notes": null,
+        "objectives": [
+            {
+                "additional_settings": {},
+                "device_type": "Objective",
+                "immersion": "water",
+                "magnification": "3.6",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Thorlabs",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "04gsnvb07"
+                },
+                "model": null,
+                "name": "Mesoscope JenOptik Objective",
+                "notes": "Part from JenOptik: 14163000",
+                "numerical_aperture": "0.8",
+                "objective_type": null,
+                "path_to_cad": null,
+                "port_index": null,
+                "serial_number": null
+            }
+        ],
+        "origin": "Bregma",
+        "patch_cords": [],
+        "pockels_cells": [
+            {
+                "additional_settings": {},
+                "beam_modulation": null,
+                "beam_modulation_unit": "Volts",
+                "device_type": "Pockels cell",
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "Conoptics",
+                    "registry": null,
+                    "registry_identifier": null
+                },
+                "model": "350-80",
+                "name": "Pockels Cell 1",
+                "notes": null,
+                "off_time": null,
+                "on_time": null,
+                "path_to_cad": null,
+                "polygonal_scanner": null,
+                "port_index": null,
+                "serial_number": null,
+                "time_setting_unit": "fraction of cycle"
+            }
+        ],
+        "polygonal_scanners": [],
+        "rig_axes": [
+            {
+                "direction": "lays on the Mouse Sagittal Plane, Positive direction is towards the nose of the mouse",
+                "name": "X"
+            },
+            {
+                "direction": "positive pointing UP opposite the direction from the force of gravity",
+                "name": "Z"
+            },
+            {
+                "direction": "defined by the right hand rule and the other two axis",
+                "name": "Y"
+            }
+        ],
+        "rig_id": "422_MESO2_20241017",
+        "schema_version": "1.0.1",
+        "stick_microscopes": [],
+        "stimulus_devices": [
+            {
+                "additional_settings": {},
+                "brightness": null,
+                "contrast": null,
+                "device_type": "Monitor",
+                "height": 1200,
+                "manufacturer": {
+                    "abbreviation": null,
+                    "name": "ASUS",
+                    "registry": {
+                        "abbreviation": "ROR",
+                        "name": "Research Organization Registry"
+                    },
+                    "registry_identifier": "00bxkz165"
+                },
+                "model": "PA248Q",
+                "name": "Stimulus Screen",
+                "notes": "viewing distance is from screen normal to bregma",
+                "path_to_cad": null,
+                "port_index": null,
+                "position": {
+                    "device_axes": [
+                        {
+                            "direction": "Away from screen",
+                            "name": "Z"
+                        },
+                        {
+                            "direction": "Pointing to the top of the screen",
+                            "name": "Y"
+                        },
+                        {
+                            "direction": "Oriented parallel to the long edge of the screen",
+                            "name": "X"
+                        }
+                    ],
+                    "device_origin": "Center of Screen on Face",
+                    "device_position_transformations": [
+                        {
+                            "rotation": [
+                                "-0.80914",
+                                "-0.58761",
+                                "0",
+                                "-0.12391",
+                                "0.17063",
+                                "0.97751",
+                                "-0.5744",
+                                "0.79095",
+                                "-0.21087"
+                            ],
+                            "type": "rotation"
+                        },
+                        {
+                            "translation": [
+                                "0.08751",
+                                "-0.12079",
+                                "0.02298"
+                            ],
+                            "type": "translation"
+                        }
+                    ],
+                    "notes": null
+                },
+                "refresh_rate": 60,
+                "serial_number": null,
+                "size_unit": "pixel",
+                "viewing_distance": "15.5",
+                "viewing_distance_unit": "centimeter",
+                "width": 1920
+            }
+        ]
+    },
+    "schema_version": "1.1.1",
+    "session": {
+        "active_mouse_platform": true,
+        "anaesthesia": null,
+        "animal_weight_post": null,
+        "animal_weight_prior": null,
+        "calibrations": [],
+        "data_streams": [
+            {
+                "camera_names": [
+                    "Mesoscope",
+                    "Behavior",
+                    "Eye",
+                    "Face"
+                ],
+                "daq_names": [],
+                "detectors": [],
+                "ephys_modules": [],
+                "fiber_connections": [],
+                "fiber_modules": [],
+                "light_sources": [
+                    {
+                        "device_type": "Laser",
+                        "excitation_power": null,
+                        "excitation_power_unit": "milliwatt",
+                        "name": "Laser",
+                        "wavelength": 920,
+                        "wavelength_unit": "nanometer"
+                    }
+                ],
+                "manipulator_modules": [],
+                "mri_scans": [],
+                "notes": null,
+                "ophys_fovs": [
+                    {
+                        "coupled_fov_index": 0,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 512,
+                        "fov_reference": "Bregma",
+                        "fov_scale_factor": "0.78",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "10.63",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 188,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 0,
+                        "magnification": "16x",
+                        "notes": null,
+                        "power": "23.0",
+                        "power_ratio": "35.0",
+                        "power_unit": "percent",
+                        "scanfield_z": -147,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": 0,
+                        "targeted_structure": "VISp"
+                    },
+                    {
+                        "coupled_fov_index": 0,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 512,
+                        "fov_reference": "Bregma",
+                        "fov_scale_factor": "0.78",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "10.63",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 232,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 1,
+                        "magnification": "16x",
+                        "notes": null,
+                        "power": "23.0",
+                        "power_ratio": "35.0",
+                        "power_unit": "percent",
+                        "scanfield_z": -93,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": 0,
+                        "targeted_structure": "VISp"
+                    },
+                    {
+                        "coupled_fov_index": 1,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 512,
+                        "fov_reference": "Bregma",
+                        "fov_scale_factor": "0.78",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "10.63",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 139,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 2,
+                        "magnification": "16x",
+                        "notes": null,
+                        "power": "25.0",
+                        "power_ratio": "29.0",
+                        "power_unit": "percent",
+                        "scanfield_z": -196,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": 0,
+                        "targeted_structure": "VISp"
+                    },
+                    {
+                        "coupled_fov_index": 1,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 512,
+                        "fov_reference": "Bregma",
+                        "fov_scale_factor": "0.78",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "10.63",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 257,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 3,
+                        "magnification": "16x",
+                        "notes": null,
+                        "power": "25.0",
+                        "power_ratio": "29.0",
+                        "power_unit": "percent",
+                        "scanfield_z": -68,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": 0,
+                        "targeted_structure": "VISp"
+                    },
+                    {
+                        "coupled_fov_index": 2,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 512,
+                        "fov_reference": "Bregma",
+                        "fov_scale_factor": "0.78",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "10.63",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 104,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 4,
+                        "magnification": "16x",
+                        "notes": null,
+                        "power": "38.0",
+                        "power_ratio": "17.0",
+                        "power_unit": "percent",
+                        "scanfield_z": -231,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": 0,
+                        "targeted_structure": "VISp"
+                    },
+                    {
+                        "coupled_fov_index": 2,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 512,
+                        "fov_reference": "Bregma",
+                        "fov_scale_factor": "0.78",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "10.63",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 302,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 5,
+                        "magnification": "16x",
+                        "notes": null,
+                        "power": "38.0",
+                        "power_ratio": "17.0",
+                        "power_unit": "percent",
+                        "scanfield_z": -23,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": 0,
+                        "targeted_structure": "VISp"
+                    },
+                    {
+                        "coupled_fov_index": 3,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 512,
+                        "fov_reference": "Bregma",
+                        "fov_scale_factor": "0.78",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "10.63",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 41,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 6,
+                        "magnification": "16x",
+                        "notes": null,
+                        "power": "50.0",
+                        "power_ratio": "13.0",
+                        "power_unit": "percent",
+                        "scanfield_z": -294,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": 0,
+                        "targeted_structure": "VISp"
+                    },
+                    {
+                        "coupled_fov_index": 3,
+                        "fov_coordinate_ap": "1.5",
+                        "fov_coordinate_ml": "1.5",
+                        "fov_coordinate_unit": "micrometer",
+                        "fov_height": 512,
+                        "fov_reference": "Bregma",
+                        "fov_scale_factor": "0.78",
+                        "fov_scale_factor_unit": "um/pixel",
+                        "fov_size_unit": "pixel",
+                        "fov_width": 512,
+                        "frame_rate": "10.63",
+                        "frame_rate_unit": "hertz",
+                        "imaging_depth": 354,
+                        "imaging_depth_unit": "micrometer",
+                        "index": 7,
+                        "magnification": "16x",
+                        "notes": null,
+                        "power": "50.0",
+                        "power_ratio": "13.0",
+                        "power_unit": "percent",
+                        "scanfield_z": 29,
+                        "scanfield_z_unit": "micrometer",
+                        "scanimage_roi_index": 0,
+                        "targeted_structure": "VISp"
+                    }
+                ],
+                "slap_fovs": [],
+                "software": [],
+                "stack_parameters": null,
+                "stick_microscopes": [],
+                "stream_end_time": "2025-09-18T13:02:25.597228-07:00",
+                "stream_modalities": [
+                    {
+                        "abbreviation": "pophys",
+                        "name": "Planar optical physiology"
+                    }
+                ],
+                "stream_start_time": "2025-09-18T11:59:49.412938-07:00"
+            }
+        ],
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/session.py",
+        "experimenter_full_name": [
+            "Sam Seid"
+        ],
+        "headframe_registration": null,
+        "iacuc_protocol": "2115",
+        "maintenance": [],
+        "mouse_platform_name": "disc",
+        "notes": null,
+        "protocol_id": [],
+        "reward_consumed_total": null,
+        "reward_consumed_unit": "milliliter",
+        "reward_delivery": null,
+        "rig_id": "MESO.2",
+        "schema_version": "1.0.3",
+        "session_end_time": "2025-09-18T13:02:25.597228-07:00",
+        "session_start_time": "2025-09-18T11:59:49.412938-07:00",
+        "session_type": "STAGE_1",
+        "stimulus_epochs": [
+            {
+                "light_source_config": [],
+                "notes": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "STAGE_1",
+                    "parameters": {},
+                    "url": null,
+                    "version": "1.0"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "camstim",
+                        "parameters": {},
+                        "url": "https://eng-gitlab.corp.alleninstitute.org/braintv/camstim",
+                        "version": "1.0"
+                    }
+                ],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-09-18T12:14:15.732282-07:00",
+                "stimulus_modalities": [
+                    "Visual"
+                ],
+                "stimulus_name": "drifting_gratings_contrast",
+                "stimulus_parameters": [
+                    {
+                        "notes": null,
+                        "stimulus_name": "drifting_gratings_contrast",
+                        "stimulus_parameters": {
+                            "contrast": [
+                                0.8,
+                                0.4,
+                                0.1,
+                                0.2,
+                                0.05
+                            ],
+                            "orientation": [
+                                0,
+                                225,
+                                135,
+                                45,
+                                270,
+                                180,
+                                90,
+                                315
+                            ],
+                            "spatial_frequency": [
+                                0.04
+                            ],
+                            "stim_index": [
+                                0
+                            ],
+                            "temporal_frequency": [
+                                1
+                            ]
+                        },
+                        "stimulus_template_name": [],
+                        "stimulus_type": "Visual Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-09-18T12:00:15.968562-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "STAGE_1",
+                    "parameters": {},
+                    "url": null,
+                    "version": "1.0"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "camstim",
+                        "parameters": {},
+                        "url": "https://eng-gitlab.corp.alleninstitute.org/braintv/camstim",
+                        "version": "1.0"
+                    }
+                ],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-09-18T12:28:16.429942-07:00",
+                "stimulus_modalities": [
+                    "Visual"
+                ],
+                "stimulus_name": "drifting_gratings_TF",
+                "stimulus_parameters": [
+                    {
+                        "notes": null,
+                        "stimulus_name": "drifting_gratings_TF",
+                        "stimulus_parameters": {
+                            "contrast": [
+                                0.8
+                            ],
+                            "orientation": [
+                                0,
+                                225,
+                                135,
+                                45,
+                                270,
+                                180,
+                                90,
+                                315
+                            ],
+                            "spatial_frequency": [
+                                0.04
+                            ],
+                            "stim_index": [
+                                1
+                            ],
+                            "temporal_frequency": [
+                                1,
+                                2,
+                                4,
+                                8,
+                                15
+                            ]
+                        },
+                        "stimulus_template_name": [],
+                        "stimulus_type": "Visual Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-09-18T12:14:16.733112-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "STAGE_1",
+                    "parameters": {},
+                    "url": null,
+                    "version": "1.0"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "camstim",
+                        "parameters": {},
+                        "url": "https://eng-gitlab.corp.alleninstitute.org/braintv/camstim",
+                        "version": "1.0"
+                    }
+                ],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-09-18T12:48:17.426952-07:00",
+                "stimulus_modalities": [
+                    "Visual"
+                ],
+                "stimulus_name": "drifting_gratings_contrast",
+                "stimulus_parameters": [
+                    {
+                        "notes": null,
+                        "stimulus_name": "drifting_gratings_contrast",
+                        "stimulus_parameters": {
+                            "contrast": [
+                                0.05,
+                                0.8,
+                                0.1,
+                                0.2,
+                                0.4
+                            ],
+                            "orientation": [
+                                0,
+                                225,
+                                135,
+                                45,
+                                270,
+                                180,
+                                90,
+                                315
+                            ],
+                            "spatial_frequency": [
+                                0.04
+                            ],
+                            "stim_index": [
+                                0
+                            ],
+                            "temporal_frequency": [
+                                1
+                            ]
+                        },
+                        "stimulus_template_name": [],
+                        "stimulus_type": "Visual Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-09-18T12:34:17.729822-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            },
+            {
+                "light_source_config": [],
+                "notes": null,
+                "output_parameters": {},
+                "reward_consumed_during_epoch": null,
+                "reward_consumed_unit": "microliter",
+                "script": {
+                    "name": "STAGE_1",
+                    "parameters": {},
+                    "url": null,
+                    "version": "1.0"
+                },
+                "session_number": null,
+                "software": [
+                    {
+                        "name": "camstim",
+                        "parameters": {},
+                        "url": "https://eng-gitlab.corp.alleninstitute.org/braintv/camstim",
+                        "version": "1.0"
+                    }
+                ],
+                "speaker_config": null,
+                "stimulus_device_names": [],
+                "stimulus_end_time": "2025-09-18T13:02:18.124982-07:00",
+                "stimulus_modalities": [
+                    "Visual"
+                ],
+                "stimulus_name": "drifting_gratings_TF",
+                "stimulus_parameters": [
+                    {
+                        "notes": null,
+                        "stimulus_name": "drifting_gratings_TF",
+                        "stimulus_parameters": {
+                            "contrast": [
+                                0.8
+                            ],
+                            "orientation": [
+                                0,
+                                225,
+                                135,
+                                45,
+                                270,
+                                180,
+                                90,
+                                315
+                            ],
+                            "spatial_frequency": [
+                                0.04
+                            ],
+                            "stim_index": [
+                                1
+                            ],
+                            "temporal_frequency": [
+                                1,
+                                2,
+                                4,
+                                8,
+                                15
+                            ]
+                        },
+                        "stimulus_template_name": [],
+                        "stimulus_type": "Visual Stimulation"
+                    }
+                ],
+                "stimulus_start_time": "2025-09-18T12:48:18.427762-07:00",
+                "trials_finished": null,
+                "trials_rewarded": null,
+                "trials_total": null
+            }
+        ],
+        "subject_id": "800995",
+        "weight_unit": "gram"
+    },
+    "subject": {
+        "alleles": [],
+        "background_strain": null,
+        "breeding_info": {
+            "breeding_group": "Exp-ND-01-013-2402",
+            "maternal_genotype": "Slc32a1-IRES-Cre/wt",
+            "maternal_id": "768680",
+            "paternal_genotype": "Oi1(TIT2L-jGCaMP8s-WPRE-ICL-IRES-tTA2)/wt",
+            "paternal_id": "771341"
+        },
+        "date_of_birth": "2025-04-07",
+        "describedBy": "https://raw.githubusercontent.com/AllenNeuralDynamics/aind-data-schema/main/src/aind_data_schema/core/subject.py",
+        "genotype": "Slc32a1-IRES-Cre/wt;Oi1(TIT2L-jGCaMP8s-WPRE-ICL-IRES-tTA2)/wt",
+        "housing": {
+            "cage_id": "8301405",
+            "cohoused_subjects": [],
+            "home_cage_enrichment": [],
+            "light_cycle": null,
+            "room_id": "221"
+        },
+        "notes": null,
+        "restrictions": null,
+        "rrid": null,
+        "schema_version": "1.0.3",
+        "sex": "Female",
+        "source": {
+            "abbreviation": "AI",
+            "name": "Allen Institute",
+            "registry": {
+                "abbreviation": "ROR",
+                "name": "Research Organization Registry"
+            },
+            "registry_identifier": "03cpe7c52"
+        },
+        "species": {
+            "name": "Mus musculus",
+            "registry": {
+                "abbreviation": "NCBI",
+                "name": "National Center for Biotechnology Information"
+            },
+            "registry_identifier": "NCBI:txid10090"
+        },
+        "subject_id": "800995",
+        "wellness_reports": []
+    }
+}


### PR DESCRIPTION
While reviewing assets Marina wanted to use for SWDB I noticed that the pophys FOVs weren't passing through AP/ML information, Scale, and a few other things were being dropped. These are now properly handled.

Includes a test asset.